### PR TITLE
docs(root):  ADD project structure

### DIFF
--- a/documentation/ProjectStructure.mdx
+++ b/documentation/ProjectStructure.mdx
@@ -1,0 +1,20 @@
+import { Meta } from '@storybook/blocks'
+
+<Meta title="Project Structure" />
+
+# Project structure
+
+The spark project has the following structure:
+
+- `.storybook/`: The storybook configuration directory for launching the tool.
+- `bin/`: All the needed scripts for the project will be included in it.
+- `documentation/`: MDX files tracked by storybook for documenting the Design System.
+  - `assets/`: All the necessary assets needed for the documentation directory _MUST_ be placed inside.
+  - `foundations/`: Theming guidelines: Colors, Spacings, Typographies, ...
+  - `patterns/`: Standards on how to solve common design problems.
+  - `principles/`: Guidelines on how to design & implement software.
+  - `practices/`: Useful tactics for being an effective developer.
+- `packages/`: This directory is tracked by lerna. All the pills inside of it will be published as packages and _MUST_ follow the [following structure](# /** TODO: when Package structure is defined **/)
+  - `components/`: All ui-library-components container folder.
+  - `hooks/`: All ui-library custom hooks containing folder.
+- `src/`: Untracked by lerna. Source code of the project.

--- a/documentation/ProjectStructure.mdx
+++ b/documentation/ProjectStructure.mdx
@@ -6,15 +6,16 @@ import { Meta } from '@storybook/blocks'
 
 The spark project has the following structure:
 
+- `.github/`: All files related to the CI/CD workflow.
 - `.storybook/`: The storybook configuration directory for launching the tool.
 - `bin/`: All the needed scripts for the project will be included in it.
 - `documentation/`: MDX files tracked by storybook for documenting the Design System.
-  - `assets/`: All the necessary assets needed for the documentation directory _MUST_ be placed inside.
+  - `assets/`: All the necessary assets needed for the documentation directory **_MUST_** be placed inside.
   - `foundations/`: Theming guidelines: Colors, Spacings, Typographies, ...
   - `patterns/`: Standards on how to solve common design problems.
   - `principles/`: Guidelines on how to design & implement software.
   - `practices/`: Useful tactics for being an effective developer.
-- `packages/`: This directory is tracked by lerna. All the pills inside of it will be published as packages and _MUST_ follow the [following structure](# /** TODO: when Package structure is defined **/)
+- `packages/`: This directory is tracked by lerna. All the pills inside of it will be published as packages and **_MUST_** follow the [following structure](# /** TODO: when Package structure is defined **/)
   - `components/`: All ui-library-components container folder.
   - `hooks/`: All ui-library custom hooks containing folder.
 - `src/`: Untracked by lerna. Source code of the project.


### PR DESCRIPTION
# Project structure

The spark project has the following structure:

- `.storybook/`: The storybook configuration directory for launching the tool.
- `bin/`: All the needed scripts for the project will be included in it.
- `documentation/`: MDX files tracked by storybook for documenting the Design System.
  - `assets/`: All the necessary assets needed for the documentation directory _MUST_ be placed inside.
  - `foundations/`: Theming guidelines: Colors, Spacings, Typographies, ...
  - `patterns/`: Standards on how to solve common design problems.
  - `principles/`: Guidelines on how to design & implement software.
  - `practices/`: Useful tactics for being an effective developer.
- `packages/`: This directory is tracked by lerna. All the pills inside of it will be published as packages and _MUST_ follow the [following structure](# /** TODO: when Package structure is defined **/)
  - `components/`: All ui-library-components container folder.
  - `hooks/`: All ui-library custom hooks containing folder.
- `src/`: Untracked by lerna. Source code of the project.