### PR TITLE
chore: to automatically have Git hooks enabled after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
+    "prepare": "husky install",
     "clean": "lerna clean --yes && lerna exec -- rm -rf dist",
     "build": "lerna run build",
     "build:watch": "lerna run build && lerna watch -- lerna run build --since",


### PR DESCRIPTION
## chore: to automatically have Git hooks enabled after install


### Description, Motivation and Context

Make sure git hooks enabled after install as husky suggests in step 3 in manual installation
https://typicode.github.io/husky/#/?id=automatic-recommended

Thanks @acd02 for the heads up


