### PR TITLE
ci: add Chromatic deployment step

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,7 +48,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          buildScriptName: 'storybook:build'
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install
         uses: ./.github/composite-actions/install

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,6 +34,21 @@ jobs:
         uses: ./.github/composite-actions/install
 
       - run: npm run test
+  visual-testing:
+    runs-on: ubuntu-latest
+    name: visual testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
   deploy:
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Enable designers and QA analyst to check quickly in every PR the visual changes made on any component.

## ci: add Chromatic deployment step

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #128 

### Description, Motivation and Context
Add Chromatic deployment step to have visual testing in quality.yml

### Types of changes
- [x ] 🛠️ Tool

### Screenshots - Animations
<img width="1440" src="https://user-images.githubusercontent.com/51904909/218496035-effb5ed6-ebff-4b4a-9b0d-8c55f484f05c.png">
