### PR TITLE
docs: fix typos

### DIFF
--- a/documentation/build/Build.mdx
+++ b/documentation/build/Build.mdx
@@ -12,15 +12,15 @@ import ArgstableImg from '@docs/assets/argstable.png'
 
 <StoryHeading label="How it works" />
 
-The build task of each package is managed by Vite. Among other things, Vite offers "A build command that bundles your code with Rollup, pre-configured to output highly optimized static assets for production."
+Vite manages the build task of each package. Among other things, Vite offers "a build command that bundles your code with Rollup, pre-configured to output highly optimized static assets for production."
 
 When it is time to deploy your app for production, simply run the `vite build` command.
 
 <StoryHeading label="Configuration" />
 
-Each package must include a `vite.config.ts` that will allow certain configuration about the final result of the artifact. The list of posible configutation can be found in the [Vite documentation website](https://vitejs.dev/config/build-options.html#build-target)
+Each package must include a `vite.config.ts` that will allow custom configurations about the final result of the artifact. You can find the list of possible settings on the [Vite documentation website](https://vitejs.dev/config/build-options.html#build-target).
 
-Spark has a base configuration located in the `/config` directory with certain defaults that should be shared between all the packages. Including:
+Spark has a base configuration located in the `/config` directory with some default settings shared between all the packages. Including:
 
 <StoryHeading label="build.target" heading="h3" />
 
@@ -47,7 +47,7 @@ Definition: Build as a library.
 - `entry` is required since the library cannot use HTML as entry.
 - `name` is the exposed global variable and is required when formats includes 'umd' or 'iife'.
 - `formats`: Default formats are ['es', 'umd'], or ['es', 'cjs'], if multiple entries are used.
-- `fileName` is the name of the package file output, default fileName is the name option of package.json, it can also be defined as function taking the format and entryAlias as arguments.
+- `fileName` is the name of the package file output, default fileName is the name option of package.json. It can also be defined as a function taking the format and entryAlias as arguments.
 
 [Documentation](https://vitejs.dev/config/build-options.html#build-lib)
 

--- a/documentation/contributing/CommitStrategy.mdx
+++ b/documentation/contributing/CommitStrategy.mdx
@@ -26,7 +26,7 @@ import ArgstableImg from '@docs/assets/argstable.png'
 
 <StoryHeading label="Commit Convention" />
 
-Spark ✨ is adhered to a commit convention called [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
+Spark ✨ adheres to a commit convention called [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
 
 Anyone who has upgraded to a new patch version of a dependency, only to watch their application start throwing a steady stream of 500 errors, knows how important a readable commit history (and [ideally a well maintained CHANGELOG](https://keepachangelog.com/en/0.3.0/)) is to the ensuing forensic process.
 The Conventional Commits specification proposes introducing a standardized lightweight convention on top of commit messages. This convention dovetails with [SemVer](https://semver.org/), asking software developers to describe in commit messages, features, fixes, and breaking changes that they make.
@@ -42,7 +42,7 @@ The commit message should be structured as follows:
 [optional footer]
 ```
 
-In general the pattern mostly looks like this:
+In general, the pattern mostly looks like this:
 `type(scope?): subject  #scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")`
 
 Checkout [specification docs](https://www.conventionalcommits.org/en/v1.0.0/#specification) for deeper information.

--- a/documentation/contributing/TestingStrategy.mdx
+++ b/documentation/contributing/TestingStrategy.mdx
@@ -115,7 +115,7 @@ it('should trigger click event', async () => {
 import userEvent from '@testing-library/user-event'
 ```
 
-Then triggering events from that object:
+Then you can trigger events from that object:
 
 ```tsx
 await user.click(screen.getByText('bar'))

--- a/documentation/contributing/WritingStories.mdx
+++ b/documentation/contributing/WritingStories.mdx
@@ -7,9 +7,9 @@ import ArgstableImg from '@docs/assets/argstable.png'
 
 # Writing stories
 
-Write your stories using [MDX format](https://storybook.js.org/docs/react/api/mdx). It allows for more flexibility, and automatically generates a Docs pages for your component.
+Write your stories using the [MDX format](https://storybook.js.org/docs/react/api/mdx). It allows for more flexibility and automatically generates a Docs page for your component.
 
-Each component's documentation should follow this structure:
+Each component documentation should follow this structure:
 
 1. [Meta](#meta)
 2. [Description](#description)
@@ -19,7 +19,7 @@ Each component's documentation should follow this structure:
 
 <StoryHeading label="Meta" />
 
-A component's doc should be placed under the `Components` section of the documentation.
+The component documentation should be placed under the `Components` section of the documentation.
 
 They must belong to one of the following categories:
 
@@ -56,9 +56,9 @@ todo
 <StoryHeading label="ArgsTable" />
 
 Simply use Storybook's `ArgsTable` component in your MDX to generate the props documentation.
-It will parse the typescript files of your component to generate a full table.
+It will parse the TypeScript files of your component to generate a full table.
 
-It uses the JSDoc comments above each prop of your component to show it as a description, and also retrieves default values for each prop.
+It uses the JSDoc comments above each prop of your component to show it as a description. It also retrieves default values for each property.
 
 ```
 import { ArgsTable } from "@storybook/addon-docs";
@@ -74,8 +74,8 @@ import { ArgsTable } from "@storybook/addon-docs";
 
 <StoryHeading label="Variants and examples" />
 
-Display and describe as many use-case as you want to showcase the features offered by your component.
-We [suggest you split JSX examples from the markdown](https://github.com/storybookjs/storybook/blob/next/code/addons/docs/docs/recipes.md#csf-stories-with-mdx-docs) for a better developer experience, because Typescript does not support MDX typechecking as of today.
+Display and describe as many use cases as you want to showcase the features offered by your component.
+We [suggest you split JSX examples from the markdown](https://github.com/storybookjs/storybook/blob/next/code/addons/docs/docs/recipes.md#csf-stories-with-mdx-docs) for a better developer experience because TypeScript does not support MDX type-checking as of today.
 
 ###
 

--- a/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
+++ b/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
@@ -9,6 +9,6 @@ There are many correct ways to do things and solve problems. Many times we have 
 - If you are at risk of getting stuck due to the ambiguity or difference of opinions, make decisions that will help us moving forward
 - Make short-term decisions based on long-term goals
 - Evaluate tools and integrations by the risk they present, not just the solution they offer. If the risk is high pay special attention.
-- Prioritize solutions for people who use spark-ui and how it serves the customers who use products built with spark-ui
+- Prioritize solutions for people who use Spark and how it serves the customers who use products built with Spark
 - Seek feedback on code review often, and more often when a solution takes you down a new path
 - Take time to provide good code review, encompassing the above values when providing feedback.

--- a/documentation/definitions/PackageStructure.mdx
+++ b/documentation/definitions/PackageStructure.mdx
@@ -12,28 +12,33 @@ Every single published package will be included inside `packages` directory.
 
 Every single published package will follow that structure:
 
-> For a React Component called `@spark-ui/dummy`
-- `package.json`<sup>*</sup>: json manifest of the package.
-- `README.md`<sup>*</sup>: markdown file explaining the basics of the package
-- `CHANGELOG.md`<sup>*</sup>: markdown which includes all the historical different changes made.
-- `.gitignore`<sup>*</sup>: includes the untracked git rules in the package.
-- `.npmignore`<sup>*</sup>: includes the untracked npm rules of the package
-- `tsconfig.json`<sup>*</sup>: includes the specific ts configs of a package
-- `vite.config.ts`<sup>*</sup>: include teh specific vite configs of a package.
+**For a React Component called `@spark-ui/dummy`**
+
+- `package.json`<sup>\*</sup>: json manifest of the package.
+- `README.md`<sup>\*</sup>: markdown file explaining the basics of the package
+- `CHANGELOG.md`<sup>\*</sup>: markdown that includes all the changes made over time.
+- `.gitignore`<sup>\*</sup>: includes the untracked git rules in the package.
+- `.npmignore`<sup>\*</sup>: includes the untracked npm rules of the package
+- `tsconfig.json`<sup>\*</sup>: includes the specific ts configs of a package
+- `vite.config.ts`<sup>\*</sup>: include teh specific vite configs of a package.
 - `dist/`: directory created with the bundle of a package. It will be ignored by `.gitignore`.
 - `src/<sup>*</sup>`: directory containing the source code of the package.
-  - `index.tsx`<sup>*</sup> a file that only contains import-export all its inner-exposed resources
-  - > if there is a React component `Dummy` entity it will have:
-  - `[Dummy].tsx` (1 file per component, = named as is)
-  - `[Dummy].test.js`: contains the unit tests of that entity
-  - `[Dummy].stories.mdx` contains the basic stories of that entity
-  - `[Dummy].stories.tsx` contains variants and complex stories of that entity
-  - `[Dummy].variants.tsx`: contains the setup of the different default and variation styles related to that entity.
-  - > if the component also includes many other entities (ex: `Element`) they follow the same structure as the Dummy entity.
-  - `[DummyElement].tsx`
-  - `[DummyElement].test.js`
-  - `[DummyElement].stories.mdx`
-  - `[DummyElement].stories.tsx`
-  - `[DummyElement].variants.tsx`:
+- `index.tsx`<sup>\*</sup> a file that only contains import-export all its inner-exposed resources
+
+**If there is a React component `Dummy` entity it will have:**
+
+- `[Dummy].tsx` (1 file per component, = named as is)
+- `[Dummy].test.js`: contains the unit tests of that entity
+- `[Dummy].stories.mdx` contains the basic stories of that entity
+- `[Dummy].stories.tsx` contains variants and complex stories of that entity
+- `[Dummy].variants.tsx`: contains the setup of the different default and variation styles related to that entity.
+
+**If the component also includes many other entities (ex: `Element`) they follow the same structure as the Dummy entity:**
+
+- `[DummyElement].tsx`
+- `[DummyElement].test.js`
+- `[DummyElement].stories.mdx`
+- `[DummyElement].stories.tsx`
+- `[DummyElement].variants.tsx`
 
 <sup>*</sup> *means required*

--- a/documentation/definitions/ProjectStructure.mdx
+++ b/documentation/definitions/ProjectStructure.mdx
@@ -4,12 +4,12 @@ import { Meta } from '@storybook/blocks'
 
 # Project structure
 
-The spark project has the following structure:
+The Spark project has the following structure:
 
 - `.github/`: All files related to the CI/CD workflow.
 - `.storybook/`: The storybook configuration directory for launching the tool.
 - `bin/`: All the needed scripts for the project will be included in it.
-- `documentation/`: MDX files tracked by storybook for documenting the Design System.
+- `documentation/`: MDX files tracked by Storybook for documenting the Design System.
   - `assets/`: All the necessary assets needed for the documentation directory **_MUST_** be placed inside.
   - `contributing/`: An special section for helping contributors how to collaborate to Spark project.
   - `foundations/`: Theming guidelines: Colors, Spacings, Typographies, ...

--- a/documentation/practices/Naming.mdx
+++ b/documentation/practices/Naming.mdx
@@ -5,7 +5,7 @@ import { StoryHeading } from '@docs/helpers/StoryHeading'
 
 <StoryHeading label="Naming" heading="h1" /> Write for reading
 
-**Naming** increases speed to comprehend code and reduces bugs through confusion.
+**Naming** increases the speed to comprehend code and reduces bugs through confusion.
 
 - ✅ [Leverage names to reveal intent](#-leverage-names-to-reveal-intent)
 - ✅ [Empathize with others](#-empathize-with-others)
@@ -269,7 +269,7 @@ Use a infinitive **verb**
 const handleThat = () => {}
 ```
 
-It's async? Use gerund (-ing)
+Is it async? Use gerund (-ing)
 
 ```js
 const handlingThat = async () => {}

--- a/packages/hooks/use-mounted-state/src/useMountedState.stories.mdx
+++ b/packages/hooks/use-mounted-state/src/useMountedState.stories.mdx
@@ -5,11 +5,11 @@ import { StoryHeading } from '@docs/helpers/StoryHeading'
 
 # useMountedState
 
-> **NOTE!:** despite having `State` in its name **_this hook does not cause component re-render_**.
-> This component designed to be used to avoid state updates on unmounted components.
+> **NOTE:** despite having `State` in its name, **_this hook does not cause the component to re-render_**.
+> This component prevents state updates on unmounted components.
 
 Lifecycle hook provides the ability to check the component's mount state.
-Returns a function that will return `true` if component mounted and `false` otherwise.
+Returns a function that will return `true` if the component is mounted and `false` otherwise.
 
 <StoryHeading label="Install" />
 

--- a/packages/utils/theme/src/index.stories.mdx
+++ b/packages/utils/theme/src/index.stories.mdx
@@ -47,7 +47,7 @@ import { createCSSTokensFile, createTailwindThemeConfigFile } from '@spark-ui/th
 
 This function expects one argument:
 
-- A partial theme object which holds the theme values that need to be customized or overridden
+- A partial theme object that holds the theme values that need to be customized or overridden
 
 **Usage:**
 
@@ -64,7 +64,7 @@ const newTheme = createTheme(someTheme) // Theme
 
 <StoryHeading label="createCSSTokensFile" as="h4" />
 
-- A function, that will generate a `css` file containing all of the theme tokens, represented as CSS custom properties.
+- A function, that will generate a `css` file containing all the theme tokens, represented as CSS custom properties.
 
 This function expects two arguments:
 


### PR DESCRIPTION
## docs: fix typos

### Description, Motivation and Context
Some proofreading on the documentation written so far:
- [x] naming
- [x] theme
- [x] hooks
- [x] project structure
- [x] package structure
- [x] writing stories
- [x] code of conduct
- [x] build
- [x] testing
- [x] commit

### Types of changes
- [x] 🧾 Documentation