### PR TITLE
docs: story status component for draft and deprecated docs

### DIFF
--- a/documentation/contributing/TestingStrategy.mdx
+++ b/documentation/contributing/TestingStrategy.mdx
@@ -1,7 +1,11 @@
 import { Meta } from '@storybook/blocks'
 import { StoryHeading } from '@docs/helpers/StoryHeading'
+import { StoryStatus } from '@docs/helpers/StoryStatus'
 
 <Meta title="Contributing/Testing" />
+
+<StoryStatus status="draft" />
+<StoryStatus status="deprecated" />
 
 # Testing strategy
 

--- a/documentation/helpers/StoryStatus/index.tsx
+++ b/documentation/helpers/StoryStatus/index.tsx
@@ -1,0 +1,38 @@
+import { ReactElement } from 'react'
+import { cva } from 'class-variance-authority'
+
+const wrapperStyles = cva(
+  ['sb-unstyled', 'shadow-normal', 'my-l', 'rounded-s', 'p-m', 'shadow-normal'],
+  {
+    variants: {
+      status: {
+        draft: ['bg-error-container', 'text-on-error-container'],
+        deprecated: ['bg-neutral-container', 'text-on-neutral-container'],
+      },
+    },
+    defaultVariants: {
+      status: 'draft',
+    },
+  }
+)
+
+interface Props {
+  status: 'draft' | 'final' | 'deprecated'
+}
+
+export const StoryStatus = ({ status }: Props): ReactElement | null => {
+  if (status === 'final') return null
+
+  const title = status === 'draft' ? 'Draft' : 'Deprecated'
+  const description =
+    status === 'draft'
+      ? 'This documentation is a work in progress. It means it is subject to changes.'
+      : 'This documentation describes a feature that no longer exists.'
+
+  return (
+    <div className={wrapperStyles({ status })}>
+      <p className={'mb-s text-l font-bold'}>{title}</p>
+      <p className="text-m">{description}</p>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@vitest/ui": "^0.28.4",
         "autoprefixer": "10.4.13",
         "babel-loader": "^8.3.0",
+        "class-variance-authority": "^0.4.0",
         "commitizen": "^4.3.0",
         "copy-to-clipboard": "^3.3.3",
         "deepmerge": "^4.3.0",
@@ -10384,6 +10385,23 @@
       ],
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.4.0.tgz",
+      "integrity": "sha512-74enNN8O9ZNieycac/y8FxqgyzZhZbxmCitAtAeUrLPlxjSd5zA7LfpprmxEcOmQBnaGs5hYhiSGnJ0mqrtBLQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://joebell.co.uk"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.5.5 < 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/clean-stack": {
@@ -33969,6 +33987,12 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true
+    },
+    "class-variance-authority": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.4.0.tgz",
+      "integrity": "sha512-74enNN8O9ZNieycac/y8FxqgyzZhZbxmCitAtAeUrLPlxjSd5zA7LfpprmxEcOmQBnaGs5hYhiSGnJ0mqrtBLQ==",
       "dev": true
     },
     "clean-stack": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@vitest/ui": "^0.28.4",
     "autoprefixer": "10.4.13",
     "babel-loader": "^8.3.0",
+    "class-variance-authority": "^0.4.0",
     "commitizen": "^4.3.0",
     "copy-to-clipboard": "^3.3.3",
     "deepmerge": "^4.3.0",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -3,10 +3,6 @@ const themeConf = require('./tailwind.theme.cjs')
 /** @type {import('tailwindcss').Config} */
 
 module.exports = {
-  theme: {
-    ...themeConf,
-  },
-  content: [
-    './packages/**/*.{js,ts,jsx,tsx}',
-  ],
+  theme: themeConf,
+  content: ['./packages/**/*.{js,ts,jsx,tsx}', './documentation/**/*.{js,ts,jsx,tsx}'],
 }


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #269 

### Description, Motivation and Context
Because we use ship/show/ask, some documentation might be merged into the `main` branch without validation. I suggest we flag those as "draft" documentation until we validate it together at some point.

(It was also a way to test our new color tokens)

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation

### Screenshots - Animations
![Capture d’écran 2023-02-21 à 12 42 00](https://user-images.githubusercontent.com/2033710/220335756-e56e7893-4477-468e-919d-ca4532c43524.png)



