### PR TITLE
docs: fix install command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd spark
 - Setup all the dependencies and packages. This command will install dependencies.
 
 ```sh
-npm run install
+npm install
 ```
 
 > If you run into any problem during this step, feel free to open an issue
@@ -36,7 +36,7 @@ This project follows a monorepo structure. Each folder inside `packages` is an i
 
 Some of the most important commands are listed below.
 
-- **`npm run install`** install all dependencies
+- **`npm install`** install all dependencies
 
 - **`npm run build`** run build for all packages
 


### PR DESCRIPTION
## docs: fix install command in CONTRIBUTING.md


### Description, Motivation and Context

Change `npm run install` to `npm install` in [CONTRIBUTING.md](https://github.com/adevinta/spark/blob/main/CONTRIBUTING.md)

### Types of changes

- [X] 🧾 Documentation


