### PR TITLE
DOCS: add definition of ready documentation

### DIFF
--- a/documentation/practices/ComponentDoD.mdx
+++ b/documentation/practices/ComponentDoD.mdx
@@ -7,10 +7,10 @@ import AtomicDesignPNG from '@docs/assets/atomic-design.png'
 # Component - Definition of Done
 
 <Alert kind="warning">
-  Work in progress. This page has must be submitted to Spark's team approval.
+  Work in progress. This page must be submitted to the Spark team to get the approval.
 </Alert>
 
-**This document provides a list of criterias that each Spark component must fullfill.**
+**This document provides a list of criterias that each Spark component must fulfill.**
 
 ## 1. Must provide stateful implementation
 

--- a/documentation/practices/ComponentDoR.mdx
+++ b/documentation/practices/ComponentDoR.mdx
@@ -11,7 +11,7 @@ import { Alert } from '@docs/helpers/Alert'
 
 **This document provides a set of agreements that each Spark component user story must fulfill.**
 
-A definition of ready deals with the user story, wherein the user story is ready to be taken into a sprint. It doesn't need to be "100% defined" covering all the acceptance criteria. However, it should be "ready enough" only when the team is confident that they can successfully deliver the user story.
+A definition of ready deals with the user story, wherein the user story is ready to be taken into a sprint. It doesn't need to be "100% defined" covering all the possible use cases. However, it should be "ready enough", only when the team is confident that they can successfully deliver the user story.
 
 It will help in saving time if each user story meets the definition of ready before the sprint planning meeting. But it is also fine and acceptable to work on the user story during the sprint planning meeting and bring it to the "Ready" status.
 
@@ -54,9 +54,9 @@ There's no single right or wrong way to write acceptance criteria for a user sto
 
 Read more info about acceptance criteria: [https://www.productplan.com/glossary/acceptance-criteria/](https://www.productplan.com/glossary/acceptance-criteria/)
 
-## 4. All the information needed to start the story is available
+## 4. All the main information needed to start the story is available
 
-All the needed information we need, like UX/design definitions, mockups, prototypes, etc... must be **shared in the same place the user story is written.**
+All the main information we need (UX/design definitions, mockups, prototypes, etc...) to fulfill the acceptance criteria must be **shared in the same place the user story is written.**
 
 ## 5. The story is sized by the team
 
@@ -68,13 +68,12 @@ Now that we have our baseline, we can create an estimation chart to grade other 
 
 Read more info about user story sizing: [https://www.7pace.com/blog/user-story-sizing](https://www.7pace.com/blog/user-story-sizing)
 
-## 6. The person who will accept the user story is identified
+## 6. The team is able to "demo" and test the user story
 
-### ???
+The user story definition and its acceptance criteria should help us to write:
 
-## 7. The team is able to "demo" the user story
-
-### ???
+- **the proper stories documenting visually the defined scenarios**,
+- and **the needed tests covering the main functionality**.
 
 ## Documentation:
 

--- a/documentation/practices/ComponentDoR.mdx
+++ b/documentation/practices/ComponentDoR.mdx
@@ -1,0 +1,81 @@
+import { Meta } from '@storybook/blocks'
+import { Alert } from '@docs/helpers/Alert'
+
+<Meta title="Practices/Component - Definition of Ready" />
+
+# Component - Definition of Ready
+
+<Alert kind="warning">
+  Work in progress. This page must be submitted to the Spark team to get the approval.
+</Alert>
+
+**This document provides a set of agreements that each Spark component user story must fulfill.**
+
+A definition of ready deals with the user story, wherein the user story is ready to be taken into a sprint. It doesn't need to be "100% defined" covering all the acceptance criteria. However, it should be "ready enough" only when the team is confident that they can successfully deliver the user story.
+
+It will help in saving time if each user story meets the definition of ready before the sprint planning meeting. But it is also fine and acceptable to work on the user story during the sprint planning meeting and bring it to the "Ready" status.
+
+## 1. The user story must follow the INVEST checklist
+
+- **`I` Independent**: It should be self-contained.
+- **`N` Negotiable**: It's not an explicit contract and it should leave space for discussion.
+- **`V` Valuable**: It must deliver value to the stakeholders.
+- **`E` Estimable**: You must always be able to estimate its size.
+- **`S` Small or Sized Appropriately**: It should not be so big as to become impossible to plan/task/prioritize within a level of accuracy.
+- **`T` Testable**: Its description must provide the necessary information to make test development possible.
+
+Read more info about **INVEST**: [https://agileforall.com/new-to-agile-invest-in-good-user-stories/](https://agileforall.com/new-to-agile-invest-in-good-user-stories/)
+
+## 2. The story must be written exactly in the "user story" format.
+
+The user story should be written in a simple sentence, structured as follows:
+
+**"As a [persona], I [want to], [so that]."**
+
+Breaking this down:
+
+- **"As a [persona]"**: Who are we building this for? We're not just after a job title, we're after the persona of the person. Mia. Our team should have a shared understanding of who Mia is. We understand how that person works, how they think and what they feel. We have empathy for Mia.
+- **"Wants to"**: Here we're describing their intent — not the features they use. What is it they're actually trying to achieve? This statement should be implementation free — if you're describing any part of the UI and not what the user goal is you're missing the point.
+- **"So that"**: How does their immediate desire to do something this fit into their bigger picture? What's the overall benefit they're trying to achieve? What is the big problem that needs solving?
+
+For example, a possible user story might look like:
+
+**As Mia, I want to invite my friends, so we can enjoy this service together.**
+
+Read more info about how to write goog user stories: [https://www.atlassian.com/agile/project-management/user-stories](https://www.atlassian.com/agile/project-management/user-stories)
+
+## 3. The story acceptance criteria is defined
+
+Acceptance criteria refer to a set of predefined requirements that must be met to mark a user story complete. Acceptance criteria are also sometimes called the “definition of done” because they determine the scope and requirements that must be executed by developers to consider the user story finished.
+
+There's no single right or wrong way to write acceptance criteria for a user story. But we recommend to use the **Given/When/Then** style:
+
+**"Scenario: [explain scenario]. Given [how things begin], when [action taken], then [outcome of taking action]."**
+
+Read more info about acceptance criteria: [https://www.productplan.com/glossary/acceptance-criteria/](https://www.productplan.com/glossary/acceptance-criteria/)
+
+## 4. All the information needed to start the story is available
+
+All the needed information we need, like UX/design definitions, mockups, prototypes, etc... must be **shared in the same place the user story is written.**
+
+## 5. The story is sized by the team
+
+Story sizing is the systematic process of estimating the time and effort required to complete each user story. It often involves using strategies like the [**Fibonacci Sequence**](https://en.wikipedia.org/wiki/Fibonacci_sequence) to make rough estimates about the effort needed to develop a feature or fix a bug.
+
+Start by identifying a base story. Ideally, that'll be a simple story that the team has already completed and feels very confident about. It'll serve as the foundation for the estimation process as other stories will be graded based on how they compare to it.
+
+Now that we have our baseline, we can create an estimation chart to grade other stories in relation to it. The base story is graded as 1, indicating that it's the one that took the least amount of time and effort to finish.
+
+Read more info about user story sizing: [https://www.7pace.com/blog/user-story-sizing](https://www.7pace.com/blog/user-story-sizing)
+
+## 6. The person who will accept the user story is identified
+
+### ???
+
+## 7. The team is able to "demo" the user story
+
+### ???
+
+## Documentation:
+
+- [https://www.knowledgehut.com/tutorials/scrum-tutorial/definition-of-ready](https://www.knowledgehut.com/tutorials/scrum-tutorial/definition-of-ready)


### PR DESCRIPTION
## DOCS: add definition of ready documentation

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #409 

### Description, Motivation and Context
Add documentation for how our tasks (user stories) will be defined before we start to work on them.

### Types of changes
- [x] 🧾 Documentation
