### PR TITLE
445 components add link option for button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31131,6 +31131,7 @@
       "name": "@spark-ui/button",
       "version": "1.2.1",
       "dependencies": {
+        "@spark-ui/slot": "1",
         "class-variance-authority": "0.4.0"
       }
     },
@@ -38294,6 +38295,7 @@
     "@spark-ui/button": {
       "version": "file:packages/components/button",
       "requires": {
+        "@spark-ui/slot": "1",
         "class-variance-authority": "0.4.0"
       }
     },

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -12,6 +12,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@spark-ui/slot": "1",
     "class-variance-authority": "0.4.0"
   }
 }

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -72,3 +72,11 @@ Use `intent` prop to set the color intent of a button.
 <Canvas>
   <Story of={ButtonStories.Intent} />
 </Canvas>
+
+<StoryHeading label="Link" />
+
+Use `intent` prop to set the color intent of a button.
+
+<Canvas>
+  <Story of={ButtonStories.Link} />
+</Canvas>

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -65,7 +65,9 @@ export const Intent: StoryFn = _args => (
   </div>
 )
 export const Link: StoryFn = _args => (
-  <Button asChild>
-    <a href="/">button</a>
-  </Button>
+  <div className="flex flex-row gap-md">
+    <Button asChild>
+      <a href="/">button</a>
+    </Button>
+  </div>
 )

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -64,3 +64,8 @@ export const Intent: StoryFn = _args => (
     ))}
   </div>
 )
+export const Link: StoryFn = _args => (
+  <Button asChild>
+    <a href="/">button</a>
+  </Button>
+)

--- a/packages/components/button/src/Button.test.tsx
+++ b/packages/components/button/src/Button.test.tsx
@@ -17,6 +17,18 @@ describe('Button', () => {
     expect(element).toBeInTheDocument()
   })
 
+  it('should render as link', async () => {
+    // Given
+    const props = { asChild: true, children: <a href="/">Link</a> }
+
+    // When
+    render(<Button {...props} />)
+    const element = screen.getByRole('link', { name: 'Link' })
+
+    // Then
+    expect(element).toHaveAttribute('href', '/')
+  })
+
   it('should trigger click event', async () => {
     // Given
     const user = userEvent.setup()
@@ -35,7 +47,7 @@ describe('Button', () => {
     expect(clickEvent).toHaveBeenCalledTimes(1)
   })
 
-  it('should not trigger events', async () => {
+  it('should not trigger events when disabled', async () => {
     // Given
     const user = userEvent.setup()
     const clickEvent = vi.fn()

--- a/packages/components/button/src/Button.tsx
+++ b/packages/components/button/src/Button.tsx
@@ -1,13 +1,18 @@
+import { Slot } from '@spark-ui/slot'
 import React, { PropsWithChildren } from 'react'
 
 import { buttonStyles, type ButtonStylesProps } from './Button.styles'
 
-/** Review: Prop VS ButtonProps */
 export interface ButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'disabled'>,
-    ButtonStylesProps {}
+  extends PropsWithChildren<Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'>>,
+    ButtonStylesProps {
+  /**
+   * Change the component to the HTML tag or custom component of the only child.
+   */
+  asChild?: boolean
+}
 
-export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       design = 'filled',
@@ -15,12 +20,15 @@ export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<Butt
       intent = 'primary',
       shape = 'rounded',
       size = 'md',
-      ...otherProps
+      asChild,
+      ...others
     },
     ref
   ) => {
+    const Component = asChild ? Slot : 'button'
+
     return (
-      <button
+      <Component
         ref={ref}
         className={buttonStyles({
           design,
@@ -30,7 +38,7 @@ export const Button = React.forwardRef<HTMLButtonElement, PropsWithChildren<Butt
           size,
         })}
         disabled={!!disabled}
-        {...otherProps}
+        {...others}
       />
     )
   }

--- a/packages/components/radio/src/Radio.test.tsx
+++ b/packages/components/radio/src/Radio.test.tsx
@@ -6,8 +6,12 @@ import { Radio, RadioGroup } from '.'
 
 describe('Radio', () => {
   it('should render correctly', () => {
+    // Given
+    const props = { defaultValue: '1' }
+
+    // When
     render(
-      <RadioGroup defaultValue="1">
+      <RadioGroup {...props}>
         <label>
           1
           <Radio value="1" />
@@ -22,18 +26,22 @@ describe('Radio', () => {
         </label>
       </RadioGroup>
     )
+    const element = screen.getByRole('radiogroup')
 
-    const radiogroupEl = screen.getByRole('radiogroup')
-
-    expect(radiogroupEl).toBeInTheDocument()
-    expect(within(radiogroupEl).getByRole('radio', { name: '1' })).toBeChecked()
-    expect(within(radiogroupEl).getByRole('radio', { name: '2' })).not.toBeChecked()
-    expect(within(radiogroupEl).getByRole('radio', { name: '3' })).not.toBeChecked()
+    // Then
+    expect(element).toBeInTheDocument()
+    expect(within(element).getByRole('radio', { name: '1' })).toBeChecked()
+    expect(within(element).getByRole('radio', { name: '2' })).not.toBeChecked()
+    expect(within(element).getByRole('radio', { name: '3' })).not.toBeChecked()
   })
 
   it('should check and uncheck when a radio is clicked while in uncontrolled mode', async () => {
+    // Given
+    const props = { defaultValue: '1' }
+
+    // When
     render(
-      <RadioGroup defaultValue="1">
+      <RadioGroup {...props}>
         <label>
           1
           <Radio value="1" />
@@ -48,24 +56,24 @@ describe('Radio', () => {
         </label>
       </RadioGroup>
     )
+    const element = screen.getByRole('radiogroup')
 
-    const radiogroupEl = screen.getByRole('radiogroup')
+    // Then
+    expect(element).toBeInTheDocument()
+    expect(within(element).getByRole('radio', { name: '1' })).toBeChecked()
 
-    expect(radiogroupEl).toBeInTheDocument()
-    expect(within(radiogroupEl).getByRole('radio', { name: '1' })).toBeChecked()
+    userEvent.click(within(element).getByRole('radio', { name: '2' }))
 
-    userEvent.click(within(radiogroupEl).getByRole('radio', { name: '2' }))
-
-    await waitFor(() =>
-      expect(within(radiogroupEl).getByRole('radio', { name: '1' })).toBeChecked()
-    )
+    await waitFor(() => expect(within(element).getByRole('radio', { name: '1' })).toBeChecked())
   })
 
   it('should check and uncheck when a radio is clicked while in controlled mode', async () => {
-    const onValueChange = vitest.fn()
+    // Given
+    const props = { value: '1', onValueChange: vitest.fn() }
 
+    // When
     render(
-      <RadioGroup value="1" onValueChange={onValueChange}>
+      <RadioGroup {...props}>
         <label>
           1
           <Radio value="1" />
@@ -80,14 +88,14 @@ describe('Radio', () => {
         </label>
       </RadioGroup>
     )
+    const element = screen.getByRole('radiogroup')
 
-    const radiogroupEl = screen.getByRole('radiogroup')
+    // Then
+    expect(element).toBeInTheDocument()
+    expect(within(element).getByRole('radio', { name: '1' })).toBeChecked()
 
-    expect(radiogroupEl).toBeInTheDocument()
-    expect(within(radiogroupEl).getByRole('radio', { name: '1' })).toBeChecked()
+    userEvent.click(within(element).getByRole('radio', { name: '2' }))
 
-    userEvent.click(within(radiogroupEl).getByRole('radio', { name: '2' }))
-
-    await waitFor(() => expect(onValueChange).toBeCalledWith('2'))
+    await waitFor(() => expect(props.onValueChange).toBeCalledWith('2'))
   })
 })

--- a/packages/components/slot/src/Slot.stories.tsx
+++ b/packages/components/slot/src/Slot.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Slot> = {
 export default meta
 
 export const Default: StoryFn = _args => (
-  <Slot href="/">
-    <a>Link</a>
+  <Slot>
+    <a href="/">Link</a>
   </Slot>
 )

--- a/packages/components/slot/src/Slot.test.tsx
+++ b/packages/components/slot/src/Slot.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vitest } from 'vitest'
 
 import { Slot } from './Slot'
 
@@ -14,13 +14,17 @@ describe('Slot', () => {
     expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument()
   })
 
-  it('should pass props to child component', () => {
+  it('should pass props to child component', async () => {
+    const onClick = vitest.fn()
+
     render(
-      <Slot href="/home">
-        <a>Link</a>
+      <Slot onClick={onClick}>
+        <button>Button</button>
       </Slot>
     )
 
-    expect(screen.getByRole('link', { name: 'Link' })).toHaveAttribute('href', '/home')
+    fireEvent.click(screen.getByRole('button', { name: 'Button' }))
+
+    await waitFor(() => expect(onClick).toBeCalled())
   })
 })

--- a/packages/components/slot/src/Slot.test.tsx
+++ b/packages/components/slot/src/Slot.test.tsx
@@ -5,26 +5,33 @@ import { Slot } from './Slot'
 
 describe('Slot', () => {
   it('should render wrapped component', () => {
+    // Given
+    const props = {}
+
+    // When
     render(
-      <Slot>
-        <button>Link</button>
-      </Slot>
-    )
-
-    expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument()
-  })
-
-  it('should pass props to child component', async () => {
-    const onClick = vitest.fn()
-
-    render(
-      <Slot onClick={onClick}>
+      <Slot {...props}>
         <button>Button</button>
       </Slot>
     )
 
+    // Then
+    expect(screen.getByRole('button', { name: 'Button' })).toBeInTheDocument()
+  })
+
+  it('should pass props to child component', async () => {
+    // Given
+    const props = { onClick: vitest.fn() }
+
+    // When
+    render(
+      <Slot {...props}>
+        <button>Button</button>
+      </Slot>
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Button' }))
 
-    await waitFor(() => expect(onClick).toBeCalled())
+    // Then
+    await waitFor(() => expect(props.onClick).toBeCalled())
   })
 })

--- a/packages/components/slot/src/Slot.tsx
+++ b/packages/components/slot/src/Slot.tsx
@@ -1,8 +1,8 @@
 import { Slot as SlotPrimitive } from '@radix-ui/react-slot'
-import { PropsWithChildren } from 'react'
+import { forwardRef, PropsWithChildren } from 'react'
 
-export type SlotProps = PropsWithChildren<Omit<React.HTMLProps<HTMLDivElement>, 'ref'>>
+export type SlotProps = PropsWithChildren<React.HTMLAttributes<HTMLElement>>
 
-export function Slot(props: SlotProps) {
-  return <SlotPrimitive {...props} />
-}
+export const Slot = forwardRef<HTMLElement, SlotProps>((props, ref) => {
+  return <SlotPrimitive ref={ref} {...props} />
+})

--- a/packages/components/slot/src/index.ts
+++ b/packages/components/slot/src/index.ts
@@ -1,1 +1,1 @@
-export { Slot } from './Slot'
+export * from './Slot'


### PR DESCRIPTION
## Button as link ✨

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #445 

### Description, Motivation and Context
This PR:
- Add the possibility of using the button as a link
- Update some tests to follow the guidelines
- Update `Slot` props definition to match the radix ones
- Add `Slot` missing `forwardRef`. Thanks @Powerplex for spotting this out

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [x] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations

![Screen Shot 2023-03-24 at 11 40 53](https://user-images.githubusercontent.com/6877967/227500001-11ef76c9-952d-4fde-8e02-3ea8b07e653b.png)

