### PR TITLE
feat(cli-utils): component package template updated to match agreements

### DIFF
--- a/packages/utils/cli/src/generate/templates/component/src/[Component.doc.mdx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.doc.mdx].js
@@ -3,15 +3,14 @@ import { pascalCase } from 'pascal-case'
 export default ({ name, description }) => {
   const componentName = pascalCase(name)
 
-  return `import { ArgsTable, Meta, Story } from '@storybook/addon-docs'
-import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+  return `import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
 import { StoryHeading } from '@docs/helpers/StoryHeading'
 
 import { ${componentName} } from '.'
 
 import * as stories from './${componentName}.stories'
 
-<Meta title="Components/Misc/${componentName}" component={${componentName}} />
+<Meta of={stories} />
 
 # ${componentName}
 
@@ -35,6 +34,8 @@ import { ${componentName} } from "@spark-ui/${name}"
 
 <StoryHeading label="Variants" />
 
-<Story name="default" story={stories.Default} />
+<Canvas>
+  <Story of={stories.Default} />
+</Canvas>
 `
 }

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
@@ -3,14 +3,19 @@ import { pascalCase } from 'pascal-case'
 export default ({ name, description }) => {
   const componentName = pascalCase(name)
 
-  return `import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+  return `import { Meta, StoryFn } from '@storybook/react'
 
 import { ${componentName} } from '.'
 
-export const Default = () => (
-  <ReactLiveBlock scope={{ ${componentName} }}>
-    <${componentName}>Hello World!</${componentName}>
-  </ReactLiveBlock>
+const meta: Meta<typeof Portal> = {
+  title: 'Components/${componentName}',
+  component: ${componentName},
+}
+
+export default meta
+
+export const Default: StoryFn = _args => (
+  <${componentName}>Hello World!</${componentName}>
 )
 `
 }

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.tsx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.tsx].js
@@ -3,12 +3,12 @@ import { pascalCase } from 'pascal-case'
 export default ({ name }) => {
   const componentName = pascalCase(name)
 
-  return `import { ComponentPropsWithoutRef, PropsWithChildren } from 'react'
+  return `import { forwardRef, ComponentPropsWithoutRef, PropsWithChildren } from 'react'
 
 export type ${componentName}Props = ComponentPropsWithoutRef<'div'>
 
-export function ${componentName}(props: PropsWithChildren<${componentName}Props>) {
-  return <div {...props} />
-}
+export const ${componentName} = forwardRef<HTMLDivElement, PropsWithChildren<${componentName}Props>>((props, ref) => {
+  return <div ref={ref} {...props} />
+})
 `
 }

--- a/packages/utils/cli/test/spark-generate.test.ts
+++ b/packages/utils/cli/test/spark-generate.test.ts
@@ -33,7 +33,7 @@ describe('CLI `spark generate` (component package)', () => {
       '/src/Bar.variants.tsx',
       '/src/Bar.tsx',
       '/vite.config.ts',
-      '/src/Bar.stories.mdx',
+      '/src/Bar.doc.mdx',
       '/src/Bar.test.tsx',
       '/src/Bar.stories.tsx',
       '/tsconfig.json',


### PR DESCRIPTION
Following storybook agreements and forwardRef, I updated the default template to match the agreements

fix #465

### Types of changes
- [x] 🛠️ Tool
- [x] 🧠 Refactor
