### PR TITLE
feat: enabled dark theme preview for components

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -13,6 +13,7 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
+    '@storybook/addon-styling',
   ],
   staticDirs: ['../public'],
   framework: {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,4 +2,11 @@
   window.global = window
 </script>
 
+<style>
+  /* Enabled dark mode preview in story views */
+  html {
+    @apply !bg-background;
+  }
+</style>
+
 <link href="/normalize.css" rel="stylesheet" />

--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -1,4 +1,7 @@
 import '../src/tailwind.css'
+import './sb-theming.css'
+
+import { withThemeByDataAttribute } from '@storybook/addon-styling'
 
 export const parameters = {
   controls: {
@@ -8,3 +11,14 @@ export const parameters = {
     },
   },
 }
+
+export const decorators = [
+  withThemeByDataAttribute({
+    themes: {
+      light: 'light',
+      dark: 'dark',
+    },
+    defaultTheme: 'light',
+    attributeName: 'data-theme',
+  }),
+]

--- a/.storybook/sb-theming.css
+++ b/.storybook/sb-theming.css
@@ -1,0 +1,4 @@
+/* Enabled dark mode preview inside Canvas blocks */
+.docs-story:first-child {
+    @apply !bg-background;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@storybook/addon-essentials": "7.0.0-rc.5",
         "@storybook/addon-interactions": "7.0.0-rc.5",
         "@storybook/addon-links": "7.0.0-rc.5",
+        "@storybook/addon-styling": "^1.0.0-next.1",
         "@storybook/blocks": "7.0.0-rc.5",
         "@storybook/react": "7.0.0-rc.5",
         "@storybook/react-vite": "7.0.0-rc.5",
@@ -2077,6 +2078,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9687,6 +9689,41 @@
         }
       }
     },
+    "node_modules/@storybook/addon-styling": {
+      "version": "1.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-styling/-/addon-styling-1.0.0-next.1.tgz",
+      "integrity": "sha512-VtR+pqLO4t61ntWgGNIFRXnnLmlUoTtqgyd2TyCHJS70475+g7U4O+tU2wzdGsHak5YsUbk7FE7D7Ktbj1mKJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "next",
+        "@storybook/components": "next",
+        "@storybook/core-events": "next",
+        "@storybook/manager-api": "next",
+        "@storybook/preview-api": "next",
+        "@storybook/theming": "next",
+        "@storybook/types": "next"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "resolve-url-loader": "^5.0.0",
+        "sass-loader": "^10.4.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "resolve-url-loader": {
+          "optional": true
+        },
+        "sass-loader": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/addon-toolbars": {
       "version": "7.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-7.0.0-rc.5.tgz",
@@ -9748,6 +9785,184 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@storybook/api": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.0-rc.8.tgz",
+      "integrity": "sha512-o5RwlYsDXrJMd6UpYuZ9jGmqKYw52ZMJDU9S2LbEDL6D8M8HwVbwD2B2pCQ95c+bo+BnXQGrK3XiFLxZx72enA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.0-rc.8",
+        "@storybook/manager-api": "7.0.0-rc.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/channels": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-rc.8.tgz",
+      "integrity": "sha512-2tI/ECbQcXjncYGLVdrttNT8adIp6kV/bnQGJWmF5hBXZ7Izwyq1WRPTgPT++RihmOOTHvkRx4GCKfwluOrNpA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/client-logger": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-rc.8.tgz",
+      "integrity": "sha512-6pBwnK0vB0mgkO8opiHbZxBVGyaKFSpJXglfx8F15gIwA3r1njgtOZvvYx+03DCz0ExaTiSXrrbWp39mI8mo5w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/core-events": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.0-rc.8.tgz",
+      "integrity": "sha512-KsKf+Ob6zQ8+IJ9oDD5xqASwYGzcjT08azBjSt4yocHIJ3mY741h88YDS0wcwnM+JrV6iFYlY0hiK35lnBEddA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/manager-api": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.0-rc.8.tgz",
+      "integrity": "sha512-PV3N2tvUp6BTehgKt7JwwYH+ALoe7k2iKMeMKPNGwoRvbESmJfFEdAK95DyIZoLm8LUUtX1FpzcUek/7YWJ17w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.0.0-rc.8",
+        "@storybook/client-logger": "7.0.0-rc.8",
+        "@storybook/core-events": "7.0.0-rc.8",
+        "@storybook/csf": "next",
+        "@storybook/global": "^5.0.0",
+        "@storybook/router": "7.0.0-rc.8",
+        "@storybook/theming": "7.0.0-rc.8",
+        "@storybook/types": "7.0.0-rc.8",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "semver": "^7.3.7",
+        "store2": "^2.14.2",
+        "telejson": "^7.0.3",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/router": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.0-rc.8.tgz",
+      "integrity": "sha512-qIf29UswevSrhLPGaHXKg4Pm8qnkzSinSTSSnU/D9SOTBFtJM0oelvtxiTcKGpdFCiiM7z1VtxMkrVRqzOUOaQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.0-rc.8",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/theming": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.0-rc.8.tgz",
+      "integrity": "sha512-T5+UinKRSvwi98cvEJN5XkapGbCHEqz6E7z2kQTWaa3aLcY3daBCy0z5s2XUhv3Ko3Va1PCHsz+rDrI/dzBskg==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@storybook/client-logger": "7.0.0-rc.8",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/types": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-rc.8.tgz",
+      "integrity": "sha512-Jz3MLLKs+Jy8dZVd+HVHuKAbxa7xcF/MLfUNldu0HxtJr3b7ybUlvjWjT5h2I60V5TYkWGf9wcKmegI6TGiJXQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.0.0-rc.8",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@storybook/blocks": {
       "version": "7.0.0-rc.5",
@@ -32426,7 +32641,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },
@@ -38411,6 +38627,21 @@
         "ts-dedent": "^2.0.0"
       }
     },
+    "@storybook/addon-styling": {
+      "version": "1.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-styling/-/addon-styling-1.0.0-next.1.tgz",
+      "integrity": "sha512-VtR+pqLO4t61ntWgGNIFRXnnLmlUoTtqgyd2TyCHJS70475+g7U4O+tU2wzdGsHak5YsUbk7FE7D7Ktbj1mKJA==",
+      "dev": true,
+      "requires": {
+        "@storybook/api": "next",
+        "@storybook/components": "next",
+        "@storybook/core-events": "next",
+        "@storybook/manager-api": "next",
+        "@storybook/preview-api": "next",
+        "@storybook/theming": "next",
+        "@storybook/types": "next"
+      }
+    },
     "@storybook/addon-toolbars": {
       "version": "7.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-7.0.0-rc.5.tgz",
@@ -38439,6 +38670,121 @@
         "@storybook/theming": "7.0.0-rc.5",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.7.2"
+      }
+    },
+    "@storybook/api": {
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-7.0.0-rc.8.tgz",
+      "integrity": "sha512-o5RwlYsDXrJMd6UpYuZ9jGmqKYw52ZMJDU9S2LbEDL6D8M8HwVbwD2B2pCQ95c+bo+BnXQGrK3XiFLxZx72enA==",
+      "dev": true,
+      "requires": {
+        "@storybook/client-logger": "7.0.0-rc.8",
+        "@storybook/manager-api": "7.0.0-rc.8"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.0-rc.8.tgz",
+          "integrity": "sha512-2tI/ECbQcXjncYGLVdrttNT8adIp6kV/bnQGJWmF5hBXZ7Izwyq1WRPTgPT++RihmOOTHvkRx4GCKfwluOrNpA==",
+          "dev": true
+        },
+        "@storybook/client-logger": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.0-rc.8.tgz",
+          "integrity": "sha512-6pBwnK0vB0mgkO8opiHbZxBVGyaKFSpJXglfx8F15gIwA3r1njgtOZvvYx+03DCz0ExaTiSXrrbWp39mI8mo5w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.0-rc.8.tgz",
+          "integrity": "sha512-KsKf+Ob6zQ8+IJ9oDD5xqASwYGzcjT08azBjSt4yocHIJ3mY741h88YDS0wcwnM+JrV6iFYlY0hiK35lnBEddA==",
+          "dev": true
+        },
+        "@storybook/manager-api": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.0-rc.8.tgz",
+          "integrity": "sha512-PV3N2tvUp6BTehgKt7JwwYH+ALoe7k2iKMeMKPNGwoRvbESmJfFEdAK95DyIZoLm8LUUtX1FpzcUek/7YWJ17w==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "7.0.0-rc.8",
+            "@storybook/client-logger": "7.0.0-rc.8",
+            "@storybook/core-events": "7.0.0-rc.8",
+            "@storybook/csf": "next",
+            "@storybook/global": "^5.0.0",
+            "@storybook/router": "7.0.0-rc.8",
+            "@storybook/theming": "7.0.0-rc.8",
+            "@storybook/types": "7.0.0-rc.8",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "semver": "^7.3.7",
+            "store2": "^2.14.2",
+            "telejson": "^7.0.3",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/router": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.0-rc.8.tgz",
+          "integrity": "sha512-qIf29UswevSrhLPGaHXKg4Pm8qnkzSinSTSSnU/D9SOTBFtJM0oelvtxiTcKGpdFCiiM7z1VtxMkrVRqzOUOaQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "7.0.0-rc.8",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.0-rc.8.tgz",
+          "integrity": "sha512-T5+UinKRSvwi98cvEJN5XkapGbCHEqz6E7z2kQTWaa3aLcY3daBCy0z5s2XUhv3Ko3Va1PCHsz+rDrI/dzBskg==",
+          "dev": true,
+          "requires": {
+            "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+            "@storybook/client-logger": "7.0.0-rc.8",
+            "@storybook/global": "^5.0.0",
+            "memoizerific": "^1.11.3"
+          }
+        },
+        "@storybook/types": {
+          "version": "7.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.0-rc.8.tgz",
+          "integrity": "sha512-Jz3MLLKs+Jy8dZVd+HVHuKAbxa7xcF/MLfUNldu0HxtJr3b7ybUlvjWjT5h2I60V5TYkWGf9wcKmegI6TGiJXQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "7.0.0-rc.8",
+            "@types/babel__core": "^7.0.0",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "^2.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@storybook/blocks": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@storybook/addon-essentials": "7.0.0-rc.5",
     "@storybook/addon-interactions": "7.0.0-rc.5",
     "@storybook/addon-links": "7.0.0-rc.5",
+    "@storybook/addon-styling": "^1.0.0-next.1",
     "@storybook/blocks": "7.0.0-rc.5",
     "@storybook/react": "7.0.0-rc.5",
     "@storybook/react-vite": "7.0.0-rc.5",


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #486 

### Description, Motivation and Context

Spark having 2 themes (light and dark), I used the recently reeleased storybook addon for theme management to preview it inside both Docs and CSF stories: https://storybook.js.org/blog/styling-addon-configure-styles-and-themes-in-storybook/

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 📷 Demo
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations

https://user-images.githubusercontent.com/2033710/228315799-fa565147-2962-47cd-ab85-305581dd552e.mov


