### PR TITLE
ci: enable turbosnap for Chromatic

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -64,7 +64,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: 'storybook:build'
+          buildScriptName: 'storybook:build --onlyChanged=true'
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -64,7 +64,8 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: 'storybook:build --onlyChanged=true'
+          buildScriptName: 'storybook:build'
+          onlyChanged: true
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,7 +66,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'storybook:build'
           onlyChanged: true
-          untraced: 'packages/utils/**'
+          untraced: 'packages/utils/\*\*"'
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,6 +66,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'storybook:build'
           onlyChanged: true
+          untraced: 'packages/utils/**'
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,7 +1,13 @@
+const turbosnap = require('vite-plugin-turbosnap')
+const { mergeConfig } = require('vite');
+
 module.exports = {
   async viteFinal(config, { configType }) {
     // This is where we can override vite config for storybook
-    return config
+    return mergeConfig(config, {
+      plugins: configType === 'PRODUCTION' ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],
+      // ...And any other config you need to change...
+    });
   },
   stories: [
     '../documentation/getting-started/GettingStarted.mdx',

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "typescript": "4.9.5",
         "vite": "4.1.0",
         "vite-plugin-dts": "1.7.2",
+        "vite-plugin-turbosnap": "^1.0.1",
         "vite-tsconfig-paths": "4.0.5",
         "vitest": "0.29.2"
       }
@@ -2078,7 +2079,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29908,6 +29908,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/vite-plugin-turbosnap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.1.tgz",
+      "integrity": "sha512-isVvISdXZyflIsXYrpTMBnyrtZq92ftohL8/xHi1H0kUwXIFDegqedX1kCKIQ04tjUkphB0cFbGzuvOGVwVTnQ==",
+      "dev": true
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.5.tgz",
@@ -32641,8 +32647,7 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         }
       }
     },
@@ -53900,6 +53905,12 @@
           }
         }
       }
+    },
+    "vite-plugin-turbosnap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.1.tgz",
+      "integrity": "sha512-isVvISdXZyflIsXYrpTMBnyrtZq92ftohL8/xHi1H0kUwXIFDegqedX1kCKIQ04tjUkphB0cFbGzuvOGVwVTnQ==",
+      "dev": true
     },
     "vite-tsconfig-paths": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "typescript": "4.9.5",
     "vite": "4.1.0",
     "vite-plugin-dts": "1.7.2",
+    "vite-plugin-turbosnap": "^1.0.1",
     "vite-tsconfig-paths": "4.0.5",
     "vitest": "0.29.2"
   },


### PR DESCRIPTION
## CI(ALL): enable turbosnap for Chromatic

### Description, Motivation and Context

As proposed by @Powerplex, this PR enables turbosnap for Chromatic so that we only test the changed stories.

A `preview-stats.json` is needed by turbosnap. This file is generated by [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap).

### Types of changes
- [ x] 🛠️ Tool
