### PR TITLE
refactor: use tw from internal-utils package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30720,6 +30720,7 @@
       "name": "@spark-ui/button",
       "version": "1.3.2",
       "dependencies": {
+        "@spark-ui/internal-utils": "1.1.0",
         "@spark-ui/slot": "^1.2.0",
         "class-variance-authority": "0.4.0"
       }
@@ -30799,6 +30800,9 @@
     "packages/components/switch": {
       "name": "@spark-ui/switch",
       "version": "1.1.0",
+      "dependencies": {
+        "@spark-ui/internal-utils": "1.1.0"
+      },
       "peerDependencies": {
         "@radix-ui/react-switch": "1.0.2",
         "@spark-ui/icons": "1",
@@ -38151,6 +38155,7 @@
     "@spark-ui/button": {
       "version": "file:packages/components/button",
       "requires": {
+        "@spark-ui/internal-utils": "1.1.0",
         "@spark-ui/slot": "^1.2.0",
         "class-variance-authority": "0.4.0"
       }
@@ -38410,7 +38415,10 @@
       }
     },
     "@spark-ui/switch": {
-      "version": "file:packages/components/switch"
+      "version": "file:packages/components/switch",
+      "requires": {
+        "@spark-ui/internal-utils": "1.1.0"
+      }
     },
     "@spark-ui/tailwind-plugins": {
       "version": "file:packages/utils/tailwind-plugins",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@spark-ui/slot": "^1.2.0",
+    "@spark-ui/internal-utils": "1.1.0",
     "class-variance-authority": "0.4.0"
   }
 }

--- a/packages/components/button/src/variants/contrast.ts
+++ b/packages/components/button/src/variants/contrast.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const contrastVariants = [
   // Primary

--- a/packages/components/button/src/variants/default.ts
+++ b/packages/components/button/src/variants/default.ts
@@ -4,5 +4,3 @@ export const defaultVariants = {
   size: 'md',
   shape: 'rounded',
 } as const
-
-export const tw = <T>(a: T): T => a

--- a/packages/components/button/src/variants/filled.ts
+++ b/packages/components/button/src/variants/filled.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const filledVariants = [
   // Primary

--- a/packages/components/button/src/variants/ghost.ts
+++ b/packages/components/button/src/variants/ghost.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const ghostVariants = [
   // Primary

--- a/packages/components/button/src/variants/outlined.ts
+++ b/packages/components/button/src/variants/outlined.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const outlinedVariants = [
   // Primary

--- a/packages/components/button/src/variants/tinted.ts
+++ b/packages/components/button/src/variants/tinted.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const tintedVariants = [
   // Primary

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -16,6 +16,9 @@
     "url": "git@github.com:adevinta/spark.git",
     "directory": "packages/components/switch"
   },
+  "dependencies": {
+    "@spark-ui/internal-utils": "1.1.0"
+  },
   "peerDependencies": {
     "@radix-ui/react-switch": "1.0.2",
     "@spark-ui/icons": "1",

--- a/packages/components/switch/src/Switch.variants.tsx
+++ b/packages/components/switch/src/Switch.variants.tsx
@@ -1,6 +1,5 @@
+import { tw } from '@spark-ui/internal-utils'
 import { cva, VariantProps } from 'class-variance-authority'
-
-export const tw = <T,>(a: T): T => a
 
 const defaultVariants = {
   intent: 'primary',


### PR DESCRIPTION
## refactor: use tw from internal-utils packages

### Description, Motivation and Context
Use the `tw` function from the `internal-utils` package to avoid duplicating the same function across multiple locations in the codebase.

### Types of changes
- [] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
 -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
