### PR TITLE
feat(theme-utils): setup shadow tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,7 +2079,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -30819,6 +30818,7 @@
       "name": "@spark-ui/tag",
       "version": "1.0.0",
       "dependencies": {
+        "@spark-ui/slot": "^1.2.0",
         "class-variance-authority": "0.4.0"
       }
     },
@@ -32663,8 +32663,7 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         }
       }
     },
@@ -38436,6 +38435,7 @@
     "@spark-ui/tag": {
       "version": "file:packages/components/tag",
       "requires": {
+        "@spark-ui/slot": "^1.2.0",
         "class-variance-authority": "0.4.0"
       }
     },

--- a/packages/components/switch/src/Switch.variants.tsx
+++ b/packages/components/switch/src/Switch.variants.tsx
@@ -51,7 +51,6 @@ export const thumbStyles = cva(
     'group-spark-state-unchecked:left-none group-spark-state-unchecked:translate-x-none',
     'pointer-events-none',
     'rounded-full',
-    'shadow-lg',
     'ring-0',
     'transform transition-all duration-200 ease-in-out',
   ],

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -12,6 +12,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "class-variance-authority": "0.4.0"
+    "class-variance-authority": "0.4.0",
+    "@spark-ui/slot": "^1.2.0"
   }
 }

--- a/packages/utils/theme/src/defaultTheme.ts
+++ b/packages/utils/theme/src/defaultTheme.ts
@@ -14,6 +14,14 @@ export const defaultTheme: Theme = {
     sm: '1px',
     md: '2px',
   },
+  boxShadow: {
+    sm: '0 1px 2px 0 rgb(0 0 0 / 0.2)',
+    DEFAULT: '0 4px 8px 0 rgb(0 0 0 / 0.2)',
+    md: '0 6px 12px 0 rgb(0 0 0 / 0.2)',
+    lg: '0 8px 16px 0 rgb(0 0 0 / 0.2)',
+    xl: '0 12px 24px 0 rgb(0 0 0 / 0.2)',
+    none: 'none',
+  },
   colors: {
     // Primary
     primary: '#2118C9',

--- a/packages/utils/theme/src/types.ts
+++ b/packages/utils/theme/src/types.ts
@@ -20,6 +20,14 @@ export interface Theme {
     sm: string
     md: string
   }
+  boxShadow: {
+    sm: string
+    DEFAULT: string
+    md: string
+    lg: string
+    xl: string
+    none: string
+  }
   /**
    * Spark color specifications: https://zeroheight.com/1186e1705/p/0879a9-colors/b/27d7a3
    */


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #502 

### Description, Motivation and Context

Decoupled shadow tokens from tailwind's default tokens.

Specs: https://zeroheight.com/1186e1705/p/39675a-elevation

### Types of changes
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations
![Capture d’écran 2023-03-30 à 16 23 30](https://user-images.githubusercontent.com/2033710/228868956-064539fa-48a9-4956-b3be-9ca399fb1366.png)


