### PR TITLE
docs: setup nunito font in storybook previews

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,10 +3,13 @@
 </script>
 
 <style>
+  @import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
   /* Enabled dark mode preview in story views */
   html {
     background-color: rgb(var(--colors-background));
     color: rgb(var(--colors-on-background));
+    font-family: var(--font-family-nunito-sans) !important;
   }
 </style>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,6 +2079,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32663,7 +32664,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -64,6 +64,7 @@ export const Intent: StoryFn = _args => (
     ))}
   </div>
 )
+
 export const Link: StoryFn = _args => (
   <div className="flex flex-row gap-md">
     <Button asChild>

--- a/packages/utils/theme/src/defaultTheme.ts
+++ b/packages/utils/theme/src/defaultTheme.ts
@@ -151,22 +151,23 @@ export const defaultTheme: Theme = {
     onOverlay: '#FFFFFF',
   },
   fontFamily: {
+    nunitoSans: '"Nunito Sans", sans-serif',
     openSans:
       'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol,"Noto Color Emoji"',
   },
   fontSize: {
-    display1: { fontSize: '2.5rem', lineHeight: '3.5rem' },
-    display1Expanded: { fontSize: '3rem', lineHeight: '4rem' },
-    display2: { fontSize: '2rem', lineHeight: '2.75rem' },
-    display2Expanded: { fontSize: '2.5rem', lineHeight: '3.5rem' },
-    display3: { fontSize: '1.5rem', lineHeight: '2rem' },
-    display3Expanded: { fontSize: '2rem', lineHeight: '2.75rem' },
-    headline1: { fontSize: '1.25rem', lineHeight: '1.75rem' },
-    headline1Expanded: { fontSize: '1.5rem', lineHeight: '2rem' }, //
-    headline2: { fontSize: '1.125rem', lineHeight: '1.5rem' }, //
-    headline2Expanded: { fontSize: '1.25rem', lineHeight: '1.75rem' }, //
-    subhead: { fontSize: '1rem', lineHeight: '1.5rem' },
-    subheadExpanded: { fontSize: '1rem', lineHeight: '1.5rem' },
+    display1: { fontSize: '2.5rem', lineHeight: '3.5rem', fontWeight: '700' },
+    display1Expanded: { fontSize: '3rem', lineHeight: '4rem', fontWeight: '700' },
+    display2: { fontSize: '2rem', lineHeight: '2.75rem', fontWeight: '700' },
+    display2Expanded: { fontSize: '2.5rem', lineHeight: '3.5rem', fontWeight: '700' },
+    display3: { fontSize: '1.5rem', lineHeight: '2rem', fontWeight: '700' },
+    display3Expanded: { fontSize: '2rem', lineHeight: '2.75rem', fontWeight: '700' },
+    headline1: { fontSize: '1.25rem', lineHeight: '1.75rem', fontWeight: '700' },
+    headline1Expanded: { fontSize: '1.5rem', lineHeight: '2rem', fontWeight: '700' }, //
+    headline2: { fontSize: '1.125rem', lineHeight: '1.5rem', fontWeight: '700' }, //
+    headline2Expanded: { fontSize: '1.25rem', lineHeight: '1.75rem', fontWeight: '700' }, //
+    subhead: { fontSize: '1rem', lineHeight: '1.5rem', fontWeight: '700' },
+    subheadExpanded: { fontSize: '1rem', lineHeight: '1.5rem', fontWeight: '700' },
     body1: { fontSize: '1rem', lineHeight: '1.5rem' },
     body2: { fontSize: '0.875rem', lineHeight: '1.25rem' },
     caption: { fontSize: '0.75rem', lineHeight: '1rem' },

--- a/packages/utils/theme/src/types.ts
+++ b/packages/utils/theme/src/types.ts
@@ -153,6 +153,7 @@ export interface Theme {
     onOverlay: string
   }
   fontFamily: {
+    nunitoSans: string
     openSans: string
   }
   /**


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #523 

### Description, Motivation and Context

Setup Nunito font family tokens.
Setup nuni font family for stories previews (components).

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧠 Refactor
- [x] 💄 Styles
