### PR TITLE
fix(switch): hover with disable state

### DIFF
--- a/packages/components/switch/src/Switch.variants.tsx
+++ b/packages/components/switch/src/Switch.variants.tsx
@@ -11,10 +11,10 @@ export const styles = cva(
     'group relative inline-flex flex-shrink-0 items-center',
     'cursor-pointer',
     'rounded-full border-transparent',
-    'transition-colors duration-200 ease-in-out',
-    'spark-disabled:opacity-dim-3 spark-disabled:cursor-not-allowed',
-    'focus-visible:outline-none focus-visible:ring focus-visible:ring-outline-high',
     'hover:ring-4',
+    'transition-colors duration-200 ease-in-out',
+    'spark-disabled:opacity-dim-3 disabled:hover:ring-transparent spark-disabled:cursor-not-allowed',
+    'focus-visible:outline-none focus-visible:ring focus-visible:ring-outline-high',
     'spark-state-unchecked:bg-on-surface/dim-4',
   ]),
   {


### PR DESCRIPTION
## Switch hover with disable state

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #532 

### Description, Motivation and Context
This PR remove the hover ring when the switch is disabled

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
