### PR TITLE
docs: deprecated ArgsTable with V7 of storybook

### DIFF
--- a/documentation/contributing/WritingStories.mdx
+++ b/documentation/contributing/WritingStories.mdx
@@ -73,23 +73,23 @@ import { RadioGroup, Radio } from '@spark-ui/radio'
 
 #### Props for single components
 
-For prop, we rely on `ArgsTable` to read TS files and generate them automatically.
+For prop, we rely on `ArgTypes` to read TS files and generate them automatically.
 
 ```
 // Radio.doc.mdx
 
-import { ArgsTable } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks';
 
 import { Radio } from '.'
 
 ## Props
 
-<ArgsTable of={Radio} />
+<ArgTypes of={Radio} />
 ```
 
-**Here is what the ArgsTable looks like for a simple component:**
+**Here is what the ArgTypes looks like for a simple component:**
 
-<img width={800} src={ArgstableImg} alt="Argstable shows a table of the component's props" />
+<img width={800} src={ArgstableImg} alt="ArgTypes shows a table of the component's props" />
 
 #### Props for compound components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,6 +2084,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -34783,7 +34784,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -1,5 +1,5 @@
-import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs'
-import { Source } from '@storybook/blocks'
+import { Canvas, Meta } from '@storybook/addon-docs'
+import { ArgTypes, Source } from '@storybook/blocks'
 
 import { Button } from '.'
 
@@ -25,7 +25,7 @@ import { Button } from '@spark-ui/button'
 
 ## Props
 
-<ArgsTable of={Button} />
+<ArgTypes of={Button} />
 
 ## Default
 

--- a/packages/components/checkbox/src/Checkbox.doc.mdx
+++ b/packages/components/checkbox/src/Checkbox.doc.mdx
@@ -1,4 +1,5 @@
-import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
+import { Meta, Canvas } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks'
 
 import { Checkbox } from '.'
 
@@ -24,22 +25,28 @@ import { Checkbox } from "@spark-ui/checkbox"
 
 ## Props
 
-<ArgsTable of={Checkbox} />
+<ArgTypes of={Checkbox} />
 
 ## Usage
+
 <Canvas of={CheckboxStories.Default} />
 
 ## Disabled
+
 <Canvas of={CheckboxStories.Disabled} />
 
 ## DefaultChecked
+
 <Canvas of={CheckboxStories.DefaultChecked} />
 
 ## Controlled
+
 <Canvas of={CheckboxStories.Controlled} />
 
 ## Intent
+
 <Canvas of={CheckboxStories.Intent} />
 
 ## Icon
+
 <Canvas of={CheckboxStories.Icon} />

--- a/packages/components/icon/src/Icon.doc.mdx
+++ b/packages/components/icon/src/Icon.doc.mdx
@@ -1,4 +1,5 @@
-import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
+import { Meta, Canvas } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks'
 
 import { Icon } from '.'
 
@@ -24,9 +25,10 @@ import { Icon } from "@spark-ui/icon"
 
 ## Props
 
-<ArgsTable of={Icon} />
+<ArgTypes of={Icon} />
 
 ## Default
+
 <Canvas of={IconStories.Default} />
 
 ## Sizes

--- a/packages/components/portal/src/Portal.doc.mdx
+++ b/packages/components/portal/src/Portal.doc.mdx
@@ -1,5 +1,6 @@
-import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
+import { Meta, Canvas } from '@storybook/addon-docs'
 import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+import { ArgTypes } from '@storybook/blocks'
 
 import { Portal } from '.'
 
@@ -28,7 +29,7 @@ import { Portal } from "@spark-ui/portal"
 
 ## Props
 
-<ArgsTable of={Portal} />
+<ArgTypes of={Portal} />
 
 ## Usage
 

--- a/packages/components/radio/src/Radio.doc.mdx
+++ b/packages/components/radio/src/Radio.doc.mdx
@@ -1,5 +1,6 @@
-import { Canvas, ArgsTable, Meta } from '@storybook/addon-docs'
+import { Canvas, Meta } from '@storybook/addon-docs'
 import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+import { ArgTypes } from '@storybook/blocks'
 
 import { Radio, RadioGroup } from '.'
 
@@ -27,11 +28,11 @@ import { RadioGroup, Radio } from '@spark-ui/radio'
 
 ### RadioGroup
 
-<ArgsTable of={RadioGroup} />
+<ArgTypes of={RadioGroup} />
 
 ### Radio
 
-<ArgsTable of={Radio} />
+<ArgTypes of={Radio} />
 
 ## Default
 

--- a/packages/components/slot/src/Slot.doc.mdx
+++ b/packages/components/slot/src/Slot.doc.mdx
@@ -1,5 +1,4 @@
-import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
-import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+import { Meta, Canvas } from '@storybook/addon-docs'
 
 import { Slot } from '.'
 

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -1,4 +1,5 @@
-import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs'
+import { Canvas, Meta } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks'
 
 import { Switch } from '.'
 
@@ -24,16 +25,20 @@ import { Switch } from "@spark-ui/switch"
 
 ## Props
 
-<ArgsTable of={Switch} />
+<ArgTypes of={Switch} />
 
 ## Usage
+
 <Canvas of={stories.Default} />
 
 ## Disabled
+
 <Canvas of={stories.Disabled} />
 
 ## Sizes
+
 <Canvas of={stories.Sizes} />
 
 ## Colors
+
 <Canvas of={stories.Colors} />

--- a/packages/components/tag/src/Tag.doc.mdx
+++ b/packages/components/tag/src/Tag.doc.mdx
@@ -1,5 +1,5 @@
-import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs'
-import { Source } from '@storybook/blocks'
+import { Canvas, Meta } from '@storybook/addon-docs'
+import { ArgTypes, Source } from '@storybook/blocks'
 
 import { Tag } from '.'
 
@@ -25,9 +25,10 @@ import { Tag } from '@spark-ui/tag'
 
 ## Props
 
-<ArgsTable of={Tag} />
+<ArgTypes of={Tag} />
 
 ## Default
+
 <Canvas of={TagStories.Default} />
 
 ## Design

--- a/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
+++ b/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
@@ -1,5 +1,4 @@
-import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
-import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+import { Meta, Canvas } from '@storybook/addon-docs'
 
 import { VisuallyHidden } from '.'
 

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.doc.mdx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.doc.mdx].js
@@ -3,7 +3,8 @@ import { pascalCase } from 'pascal-case'
 export default ({ name, description }) => {
   const componentName = pascalCase(name)
 
-  return `import { ArgsTable, Meta, Canvas } from '@storybook/addon-docs'
+  return `import { Meta, Canvas } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks';
 
 import { ${componentName} } from '.'
 
@@ -29,7 +30,7 @@ import { ${componentName} } from "@spark-ui/${name}"
 
 ## Props
 
-<ArgsTable of={${componentName}} />
+<ArgTypes of={${componentName}} />
 
 ## Variants
 <Canvas of={stories.Default} />

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
@@ -7,7 +7,7 @@ export default ({ name, description }) => {
 
 import { ${componentName} } from '.'
 
-const meta: Meta<typeof Portal> = {
+const meta: Meta<typeof ${componentName}> = {
   title: 'Components/${componentName}',
   component: ${componentName},
 }

--- a/packages/utils/cli/src/generate/templates/hook/src/[name.stories.mdx].js
+++ b/packages/utils/cli/src/generate/templates/hook/src/[name.stories.mdx].js
@@ -3,8 +3,8 @@ import { camelCase } from 'camel-case'
 export default ({ name, description }) => {
   const hookName = camelCase(name)
 
-  return `import { ArgsTable, Meta, Story } from '@storybook/addon-docs'
-import { ReactLiveBlock } from '@docs/helpers/ReactLiveBlock'
+  return `import { Meta, Story } from '@storybook/addon-docs'
+  import { ArgTypes } from '@storybook/blocks';
 
 import { ${hookName} } from '.'
 
@@ -30,7 +30,7 @@ import { ${hookName} } from "@spark-ui/${name}"
 
 ## Usage
 
-<ArgsTable of={${hookName}} />
+<ArgTypes of={${hookName}} />
 
 \`\`\`jsx
 import { ${hookName} } from "@spark-ui/${name}"


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #552 

### Description, Motivation and Context

V7 of storybook deprecated `ArgsTable`. We should use `ArgTypes` instead.
Unfortunately this means that it's no longer compatible for compound components. I have a solution for that that requires us to merge our Tabs package first (future PR).

### Types of changes
- [x] 🧾 Documentation
- [x] 🧠 Refactor

