### PR TITLE
feat: harmonize dependency versions using carets

### DIFF
--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "@spark-ui/internal-utils": "^1.4.0",
     "@spark-ui/slot": "^1.2.4",
-    "class-variance-authority": "0.4.0"
+    "class-variance-authority": "^0.4.0"
   }
 }

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -12,9 +12,9 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-checkbox": "1.0.3",
+    "@radix-ui/react-checkbox": "^1.0.3",
     "@spark-ui/icons": "^1.3.7",
     "@spark-ui/internal-utils": "1",
-    "class-variance-authority": "0.4.0"
+    "class-variance-authority": "^0.4.0"
   }
 }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -17,7 +17,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-visually-hidden": "1.0.2",
+    "@radix-ui/react-visually-hidden": "^1.0.2",
     "@spark-ui/internal-utils": "1"
   }
 }

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -12,9 +12,9 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-label": "2.0.1",
-    "@radix-ui/react-radio-group": "1.1.2",
+    "@radix-ui/react-label": "^2.0.1",
+    "@radix-ui/react-radio-group": "^1.1.2",
     "@spark-ui/internal-utils": "1",
-    "class-variance-authority": "0.4.0"
+    "class-variance-authority": "^0.4.0"
   }
 }

--- a/packages/components/slot/package.json
+++ b/packages/components/slot/package.json
@@ -12,6 +12,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "1.0.1"
+    "@radix-ui/react-slot": "^1.0.1"
   }
 }

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -17,11 +17,9 @@
     "directory": "packages/components/switch"
   },
   "dependencies": {
-    "@spark-ui/internal-utils": "^1.4.0"
-  },
-  "peerDependencies": {
-    "@radix-ui/react-switch": "1.0.2",
     "@spark-ui/icons": "1",
+    "@radix-ui/react-switch": "^1.0.2",
+    "@spark-ui/internal-utils": "^1.4.0",
     "@spark-ui/slot": "^1.2.0",
     "class-variance-authority": "^0.4.0"
   }

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "@spark-ui/internal-utils": "1",
     "@spark-ui/slot": "^1.2.4",
-    "class-variance-authority": "0.4.0"
+    "class-variance-authority": "^0.4.0"
   }
 }

--- a/packages/components/visually-hidden/package.json
+++ b/packages/components/visually-hidden/package.json
@@ -17,6 +17,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-visually-hidden": "1.0.2"
+    "@radix-ui/react-visually-hidden": "^1.0.2"
   }
 }

--- a/packages/hooks/use-combined-state/package.json
+++ b/packages/hooks/use-combined-state/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@spark-ui/use-mounted-state": "0",
-    "@types/lodash.isequal": "4.5.6",
-    "lodash.isequal": "4.5.0"
+    "@types/lodash.isequal": "^4.5.6",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/utils/tailwind-plugins/package.json
+++ b/packages/utils/tailwind-plugins/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "dependencies": {
     "@spark-ui/theme-utils": "^2.12.4",
-    "tailwindcss-radix": "2.8.0"
+    "tailwindcss-radix": "^2.8.0"
   },
   "peerDependencies": {
     "tailwindcss": "^3.2.7"

--- a/packages/utils/theme/package.json
+++ b/packages/utils/theme/package.json
@@ -12,8 +12,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "deepmerge": "4.3.0",
-    "type-fest": "3.6.1"
+    "deepmerge": "^4.3.0",
+    "type-fest": "^3.6.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## feat: harmonize dependency versions using carets

### Description, Motivation and Context
This PR aims to update all dependencies across our monorepo packages to use caret (^) versions instead of fixed versions. By harmonizing the versions of shared dependencies, we can ensure that they will be deduped when consumed

### Types of changes
- [x] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
