### PR TITLE
docs: grouped developer related docs together in a folder

### DIFF
--- a/documentation/build/Build.mdx
+++ b/documentation/build/Build.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Build/Build" />
+<Meta title="Developer/Build/Build" />
 
 # Build strategy
 

--- a/documentation/contributing/CommitStrategy.mdx
+++ b/documentation/contributing/CommitStrategy.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Commit" />
+<Meta title="Developer/Contributing/Commit" />
 
 # Commit strategy
 

--- a/documentation/contributing/TestingStrategy.mdx
+++ b/documentation/contributing/TestingStrategy.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { StoryStatus } from '@docs/helpers/StoryStatus'
 
-<Meta title="Contributing/Testing" />
+<Meta title="Developer/Contributing/Testing" />
 
 <StoryStatus status="draft" />
 

--- a/documentation/contributing/WritingStories.mdx
+++ b/documentation/contributing/WritingStories.mdx
@@ -3,7 +3,7 @@ import { Callout } from '@docs/helpers/Callout'
 
 import ArgstableImg from '@docs/assets/argstable.png'
 
-<Meta title="Contributing/Writing stories" />
+<Meta title="Developer/Contributing/Writing stories" />
 
 # Writing stories
 

--- a/documentation/contributing/code-of-conduct/CodeOfConduct.mdx
+++ b/documentation/contributing/code-of-conduct/CodeOfConduct.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Code of Conduct/Index" />
+<Meta title="Developer/Contributing/Code of Conduct/Index" />
 
 # Code of Conduct
 

--- a/documentation/contributing/code-of-conduct/Communication.mdx
+++ b/documentation/contributing/code-of-conduct/Communication.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Code of Conduct/Communication" />
+<Meta title="Developer/Contributing/Code of Conduct/Communication" />
 
 ## [Communication](https://zeroheight.com/2c2e9ba82/p/77af7e-comunication)
 

--- a/documentation/contributing/code-of-conduct/Implementation.mdx
+++ b/documentation/contributing/code-of-conduct/Implementation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Code of Conduct/Implementation" />
+<Meta title="Developer/Contributing/Code of Conduct/Implementation" />
 
 ## [Implementation](https://zeroheight.com/2c2e9ba82/p/85d5e7-implementation)
 

--- a/documentation/contributing/code-of-conduct/Innovation.mdx
+++ b/documentation/contributing/code-of-conduct/Innovation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Code of Conduct/Innovation" />
+<Meta title="Developer/Contributing/Code of Conduct/Innovation" />
 
 ## [Innovation](https://zeroheight.com/2c2e9ba82/p/255e7f-innovation)
 

--- a/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
+++ b/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Contributing/Code of Conduct/Judgment and Decision-making" />
+<Meta title="Developer/Contributing/Code of Conduct/Judgment and Decision-making" />
 
 ## [Judgment and Decision-making](https://zeroheight.com/2c2e9ba82/p/177da9-judgment-and-decision-making)
 

--- a/documentation/definitions/PackageStructure.mdx
+++ b/documentation/definitions/PackageStructure.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Definitions/Package Structure" />
+<Meta title="Developer/Definitions/Package Structure" />
 
 # Package structure
 

--- a/documentation/definitions/ProjectStructure.mdx
+++ b/documentation/definitions/ProjectStructure.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Definitions/Project Structure" />
+<Meta title="Developer/Definitions/Project Structure" />
 
 # Project structure
 

--- a/documentation/migration/StyledComponents.mdx
+++ b/documentation/migration/StyledComponents.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Migration/Styled Components" />
+<Meta title="Developer/Migration/Styled Components" />
 
 # Migrating from styled-components
 

--- a/documentation/practices/ComponentDoD.mdx
+++ b/documentation/practices/ComponentDoD.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 import AtomicDesignPNG from '@docs/assets/atomic-design.png'
 
-<Meta title="Practices/Component - Definition of Done" />
+<Meta title="Developer/Practices/Component - Definition of Done" />
 
 # Component - Definition of Done
 

--- a/documentation/practices/ComponentDoR.mdx
+++ b/documentation/practices/ComponentDoR.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Practices/Component - Definition of Ready" />
+<Meta title="Developer/Practices/Component - Definition of Ready" />
 
 # Component - Definition of Ready
 

--- a/documentation/practices/Naming.mdx
+++ b/documentation/practices/Naming.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Practices/Naming" />
+<Meta title="Developer/Practices/Naming" />
 
 # Naming
 


### PR DESCRIPTION
### Description, Motivation and Context

Developer related doc tales too much focus in the sidebar. IMHO the focus of Spark should remain on the components.

I grouped all developer-related doc in a "developer" section to reduce the visual noise.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations
![Capture d’écran 2023-04-12 à 12 26 20](https://user-images.githubusercontent.com/2033710/231430793-d6c1ec27-8471-4002-a5a4-49dcf0ed114f.png)

