### PR TITLE
fix(button): fixed default font size of buttons

### DIFF
--- a/packages/components/button/src/Button.styles.tsx
+++ b/packages/components/button/src/Button.styles.tsx
@@ -12,7 +12,7 @@ import {
 export const buttonStyles = cva(
   [
     'gap-md box-border flex items-center justify-center whitespace-nowrap',
-    'text-headline-1 font-bold',
+    'text-body-1 font-bold',
     'focus-visible:ring-outline-high ring-inset focus-visible:outline-none focus-visible:ring-2',
   ],
   {


### PR DESCRIPTION
### Description, Motivation and Context

incorrect font size on button, should have been `body 1`

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
