### PR TITLE
docs: argtypes SB custom component for compound

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -40,6 +40,24 @@ module.exports = {
   typescript: {
     check: true,
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      propFilter: prop => {
+        const prohibitedPropsRegexes = [/node_modules\/\@types\/react\/index.d.ts/]
+
+        if (prop.declarations?.length > 0) {
+          const isProhibitedProps = prop.declarations.some(declaration =>
+            prohibitedPropsRegexes.some(regex => regex.test(declaration.fileName))
+          )
+
+          return !isProhibitedProps
+        }
+
+        return true
+      },
+      componentNameResolver: expression => {
+        return expression.getName()
+      },
+    },
   },
   docs: {
     autodocs: true,

--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -1,0 +1,29 @@
+import { Tabs } from '@spark-ui/tabs'
+import { ArgTypes as StorybookArgTypes } from '@storybook/blocks'
+
+interface Props {
+  of: any
+  subcomponents?: Record<string, any>
+}
+
+export const ArgTypes = ({ of, subcomponents = [] }: Props) => {
+  const componentsList = {
+    [of.displayName]: of,
+    ...subcomponents,
+  }
+
+  return (
+    <Tabs defaultValue={of.displayName} className="sb-unstyled">
+      <Tabs.List>
+        {Object.entries(componentsList).map(([name]) => (
+          <Tabs.Trigger key={name} value={name} label={name} />
+        ))}
+      </Tabs.List>
+      {Object.entries(componentsList).map(([name, component]) => (
+        <Tabs.Content key={name} value={name}>
+          <StorybookArgTypes of={component} />
+        </Tabs.Content>
+      ))}
+    </Tabs>
+  )
+}


### PR DESCRIPTION
### Description, Motivation and Context
As we're going to work on compound components, we found some issues when using `ArgTypes` from SB. Here is a workaround.

### Types of changes
- [x] 🛠️ Tool
- [x] 🧾 Documentation

### Screenshots - Animations
![image](https://user-images.githubusercontent.com/66770550/232739503-2c3d8079-08a1-4133-89d4-fc4967591ead.png)
