### PR TITLE
feat(switch): customisable icons for switch, controlled mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2083,6 +2083,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32116,9 +32117,10 @@
       "version": "1.7.0",
       "dependencies": {
         "@radix-ui/react-switch": "1.0.2",
-        "@spark-ui/icons": "^1.7.1",
-        "@spark-ui/internal-utils": "^1.5.0",
+        "@spark-ui/icons": "1",
+        "@spark-ui/internal-utils": "1",
         "@spark-ui/slot": "1",
+        "@spark-ui/use-combined-state": "0",
         "class-variance-authority": "0.4.0"
       },
       "peerDependencies": {
@@ -34011,7 +34013,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },
@@ -39799,9 +39802,10 @@
       "version": "file:packages/components/switch",
       "requires": {
         "@radix-ui/react-switch": "1.0.2",
-        "@spark-ui/icons": "^1.7.1",
-        "@spark-ui/internal-utils": "^1.5.0",
+        "@spark-ui/icons": "1",
+        "@spark-ui/internal-utils": "1",
         "@spark-ui/slot": "1",
+        "@spark-ui/use-combined-state": "0",
         "class-variance-authority": "0.4.0"
       }
     },

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -18,9 +18,10 @@
   },
   "dependencies": {
     "@radix-ui/react-switch": "1.0.2",
-    "@spark-ui/icons": "^1.7.1",
-    "@spark-ui/internal-utils": "^1.5.0",
+    "@spark-ui/icons": "1",
+    "@spark-ui/internal-utils": "1",
     "@spark-ui/slot": "1",
+    "@spark-ui/use-combined-state": "0",
     "class-variance-authority": "0.4.0"
   },
   "peerDependencies": {

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -42,3 +42,16 @@ import { Switch } from "@spark-ui/switch"
 ## Colors
 
 <Canvas of={stories.Colors} />
+
+## Icons
+
+<Canvas of={stories.Icons} />
+
+## Controlled mode
+
+When you decide to use the `checked` prop, the Switch is now controlled from the outside.
+This can be useful to trigger the switch to toggle when interacting with outside elements.
+
+It is then up to you to trigger update to its `checked` state to toggle it.
+
+<Canvas of={stories.ControlledMode} />

--- a/packages/components/switch/src/Switch.stories.tsx
+++ b/packages/components/switch/src/Switch.stories.tsx
@@ -1,5 +1,7 @@
+import { Button } from '@spark-ui/button'
+import { EyeFill, EyeOffFill } from '@spark-ui/icons'
 import { Meta, StoryFn } from '@storybook/react'
-import { type ComponentProps } from 'react'
+import { type ComponentProps, useState } from 'react'
 
 import { Switch } from '.'
 
@@ -10,18 +12,26 @@ const meta: Meta<typeof Switch> = {
 
 export default meta
 
-export const Default: StoryFn = _args => <Switch>Switch</Switch>
+export const Default: StoryFn = _args => (
+  <div className="gap-lg flex flex-col">
+    <Switch>Switch</Switch>
+    <Switch defaultChecked>Switch (default checked)</Switch>
+  </div>
+)
 
 export const Disabled: StoryFn = _args => (
-  <Switch id="disabled" disabled>
-    Disabled switch
-  </Switch>
+  <div className="gap-lg flex flex-col">
+    <Switch disabled>Disabled switch</Switch>
+    <Switch disabled defaultChecked>
+      Disabled switch (default checked)
+    </Switch>
+  </div>
 )
 
 const switchSizes: ComponentProps<typeof Switch>['size'][] = ['sm', 'md']
 
 export const Sizes: StoryFn = _args => (
-  <div className="gap-xl flex flex-col">
+  <div className="gap-lg flex flex-col">
     {switchSizes.map(size => (
       <Switch name="small" size={size}>
         {size}
@@ -41,7 +51,7 @@ const switchColors: ComponentProps<typeof Switch>['intent'][] = [
 ]
 
 export const Colors: StoryFn = _args => (
-  <div className="gap-xl flex flex-col">
+  <div className="gap-lg flex flex-col">
     {switchColors.map(color => (
       <Switch name="primary" intent={color} defaultChecked>
         {color}
@@ -49,3 +59,33 @@ export const Colors: StoryFn = _args => (
     ))}
   </div>
 )
+
+export const Icons: StoryFn = _args => (
+  <div className="gap-lg flex flex-col">
+    <Switch checkedIcon={null} uncheckedIcon={null}>
+      without icons
+    </Switch>
+    <Switch checkedIcon={<EyeFill />} uncheckedIcon={<EyeOffFill />}>
+      with custom icons
+    </Switch>
+  </div>
+)
+
+export const ControlledMode: StoryFn = () => {
+  const [checked, setChecked] = useState(true)
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <div className="gap-md flex">
+        <Button intent="danger" onClick={() => setChecked(false)}>
+          Toggle off
+        </Button>
+        <Button intent="success" onClick={() => setChecked(true)}>
+          Toggle on
+        </Button>
+      </div>
+
+      <Switch checked={checked}>controlled switch</Switch>
+    </div>
+  )
+}

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -10,7 +10,7 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
     return (
       <Label data-spark-component="switch" disabled={rest.disabled}>
         <Input ref={ref} size={size} {...rest} />
-        {children}
+        <div className="block">{children}</div>
       </Label>
     )
   }

--- a/packages/components/switch/src/SwitchInput.styles.ts
+++ b/packages/components/switch/src/SwitchInput.styles.ts
@@ -1,14 +1,9 @@
 import { makeVariants, tw } from '@spark-ui/internal-utils'
 import { cva, VariantProps } from 'class-variance-authority'
 
-const defaultVariants = {
-  intent: 'primary',
-  size: 'sm',
-} as const
-
 export const styles = cva(
   tw([
-    'group relative inline-flex flex-shrink-0 items-center',
+    'group relative inline-flex flex-shrink-0 items-center self-baseline',
     'cursor-pointer',
     'rounded-full border-transparent',
     'hover:ring-4',
@@ -37,7 +32,10 @@ export const styles = cva(
         neutral: ['spark-state-checked:bg-neutral', 'hover:ring-neutral-container', 'text-neutral'],
       }),
     },
-    defaultVariants,
+    defaultVariants: {
+      intent: 'primary',
+      size: 'sm',
+    },
   }
 )
 
@@ -60,20 +58,25 @@ export const thumbStyles = cva(
         sm: ['h-sz-20', 'w-sz-20'],
         md: ['h-sz-24', 'w-sz-24'],
       }),
+      checked: {
+        false: 'text-on-surface/dim-4',
+      },
     },
-    defaultVariants,
+    defaultVariants: {
+      size: 'sm',
+      checked: false,
+    },
   }
 )
 
-export const thumbCheckSVGStyles = cva(
-  ['transition-opacity duration-200', 'group-spark-state-unchecked:opacity-0 '],
-  {
-    variants: {
-      size: makeVariants<'size'>({
-        sm: ['h-sz-10 w-sz-10'],
-        md: ['h-sz-12 w-sz-12'],
-      }),
-    },
-    defaultVariants,
-  }
-)
+export const thumbCheckSVGStyles = cva(['transition-opacity duration-200'], {
+  variants: {
+    size: makeVariants<'size'>({
+      sm: ['h-sz-10 w-sz-10'],
+      md: ['h-sz-12 w-sz-12'],
+    }),
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+})

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -1,17 +1,31 @@
 import * as SwitchPrimitive from '@radix-ui/react-switch'
-import { Check } from '@spark-ui/icons'
+import { Check, Close } from '@spark-ui/icons'
 import { Slot } from '@spark-ui/slot'
-import React from 'react'
+import { useCombinedState } from '@spark-ui/use-combined-state'
+import React, { ReactNode } from 'react'
 
 import { styles, type StylesProps, thumbCheckSVGStyles, thumbStyles } from './SwitchInput.styles'
 
-interface RadixProps {
+export interface InputProps
+  extends StylesProps,
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {
   /**
    * The state of the switch when it is initially rendered. Use when you do not need to control its state.
    */
   defaultChecked?: boolean
   /**
+   * The controlled state of the switch. Must be used in conjunction with `onCheckedChange`.
+   */
+  checked?: boolean
+  /**
    * When true, prevents the user from interacting with the switch.
+   */
+  /**
+   * Event handler called when the state of the switch changes.
+   */
+  onCheckedChange?: (checked: boolean) => void
+  /**
+   * When `true`, prevents the user from interacting with the switch.
    */
   disabled?: boolean
   /**
@@ -27,28 +41,54 @@ interface RadixProps {
    */
   value?: string
   /**
-   * The controlled state of the switch. Must be used in conjunction with `onCheckedChange`.
+   * Icon shown inside the thumb of the Switch whenever it is checked
    */
-  checked?: boolean
+  checkedIcon?: ReactNode
   /**
-   * Event handler called when the state of the switch changes.
+   * Icon shown inside the thumb of the Switch whenever it is unchecked
    */
-  onCheckedChange?: (checked: boolean) => void
+  uncheckedIcon?: ReactNode
 }
 
-export interface InputProps
-  extends RadixProps,
-    StylesProps,
-    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {}
-
 export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
-  ({ intent, value = 'on', size = 'md', ...rest }, ref) => {
+  (
+    {
+      checked,
+      checkedIcon = <Check />,
+      defaultChecked,
+      intent,
+      uncheckedIcon = <Close />,
+      size = 'md',
+      value = 'on',
+      onCheckedChange,
+      ...rest
+    },
+    ref
+  ) => {
+    const [isChecked, setIsChecked] = useCombinedState(checked, defaultChecked)
+
+    const handleCheckedChange = (updatedValue: boolean): void => {
+      setIsChecked(updatedValue)
+      onCheckedChange?.(updatedValue)
+    }
+
     return (
-      <SwitchPrimitive.Root ref={ref} className={styles({ intent, size })} value={value} {...rest}>
-        <SwitchPrimitive.Thumb className={thumbStyles({ size })}>
-          <Slot className={thumbCheckSVGStyles({ size })}>
-            <Check />
-          </Slot>
+      <SwitchPrimitive.Root
+        ref={ref}
+        className={styles({ intent, size })}
+        value={value}
+        checked={checked}
+        defaultChecked={defaultChecked}
+        onCheckedChange={handleCheckedChange}
+        {...rest}
+      >
+        <SwitchPrimitive.Thumb className={thumbStyles({ size, checked: isChecked })}>
+          {isChecked && checkedIcon && (
+            <Slot className={thumbCheckSVGStyles({ size })}>{checkedIcon}</Slot>
+          )}
+          {!isChecked && uncheckedIcon && (
+            <Slot className={thumbCheckSVGStyles({ size })}>{uncheckedIcon}</Slot>
+          )}
         </SwitchPrimitive.Thumb>
       </SwitchPrimitive.Root>
     )

--- a/packages/hooks/use-combined-state/src/useCombinedState.tsx
+++ b/packages/hooks/use-combined-state/src/useCombinedState.tsx
@@ -2,25 +2,32 @@ import { useMountedState } from '@spark-ui/use-mounted-state'
 import isEqual from 'lodash.isequal'
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
-export function useCombinedState(
-  controlledValue?: any,
-  defaultValue?: any
-): [any, (newValue: any, forceFlag?: boolean) => any, boolean, any] {
+/**
+ * This hook must be used when a component have both a controlled and uncontrolled mode.
+ * It will take care of updating the state value when controlled mode (prop) is updated.
+ */
+export function useCombinedState<T>(
+  controlledValue?: T,
+  defaultValue?: T
+): [T | undefined, (newValue: T, forceFlag?: boolean) => void, boolean, T | undefined] {
   const { current: initialValue } = useRef(
     controlledValue === undefined ? defaultValue : controlledValue
   )
+
   const [value, setValue] = useState(initialValue)
   const isMounted = useMountedState()
+
   useLayoutEffect(() => {
-    isMounted() && setValue(controlledValue)
+    isMounted() && controlledValue != null && setValue(controlledValue)
   }, [controlledValue, setValue, isMounted])
+
   const updater = useCallback(
-    (newValue: any, forceFlag?: boolean) => {
+    (newValue: T, forceFlag?: boolean) => {
       if (controlledValue === undefined || forceFlag) {
         !isEqual(newValue, value) && setValue(newValue)
       }
     },
-    [controlledValue, setValue]
+    [controlledValue, setValue, value]
   )
 
   return [value, updater, controlledValue !== undefined, initialValue]


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #618 

### Description, Motivation and Context

Following specs review session, it seems some features needed to be added:
- icon removal
- icon customization
- controlled mode demo

As well as two others that we need to discuss before merging:

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 📷 Demo
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations
![Capture d’écran 2023-04-18 à 18 57 26](https://user-images.githubusercontent.com/2033710/232851704-332adf92-5858-410a-8c24-af9b61124aec.png)


