### PR TITLE
docs(button): add left and right icons example

### DIFF
--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -63,7 +63,7 @@ Use `intent` prop to set the color intent of a button.
 
 ## Icons
 
-Use `Icon` component to add an icon to the left or right.
+Compose the content of the button using the `Icon` component to add an icon to the left or right.
 
 <Canvas of={ButtonStories.Icons} />
 

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -61,6 +61,12 @@ Use `intent` prop to set the color intent of a button.
 
 <Canvas of={ButtonStories.Intent} />
 
+## Icons
+
+Use `Icon` component to add an icon to the left or right.
+
+<Canvas of={ButtonStories.Icons} />
+
 ## Link
 
 Use `intent` prop to set the color intent of a button.

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@spark-ui/icon'
+import { Check, FavoriteOutline } from '@spark-ui/icons'
 import { Meta, StoryFn } from '@storybook/react'
 import { type ComponentProps } from 'react'
 
@@ -28,7 +30,7 @@ const shapes: ButtonProps['shape'][] = ['rounded', 'square', 'pill']
 export const Default: StoryFn = _args => <Button>Default button</Button>
 
 export const Sizes: StoryFn = _args => (
-  <div className="gap-md flex items-center">
+  <div className="gap-md flex flex-wrap items-center">
     {sizes.map(size => {
       return (
         <Button key={size} size={size}>
@@ -40,7 +42,7 @@ export const Sizes: StoryFn = _args => (
 )
 
 export const Shapes: StoryFn = _args => (
-  <div className="gap-md flex items-center">
+  <div className="gap-md flex flex-wrap items-center">
     {shapes.map(shape => {
       return (
         <Button key={shape} shape={shape}>
@@ -54,7 +56,7 @@ export const Shapes: StoryFn = _args => (
 export const Disabled: StoryFn = _args => <Button disabled>Disabled button</Button>
 
 export const Design: StoryFn = _args => (
-  <div className="gap-md flex flex-row">
+  <div className="gap-md flex flex-wrap">
     {designs.map(design => (
       <Button key={design} design={design}>
         {design} button
@@ -64,7 +66,7 @@ export const Design: StoryFn = _args => (
 )
 
 export const Intent: StoryFn = _args => (
-  <div className="gap-md flex flex-row">
+  <div className="gap-md flex flex-wrap">
     {intents.map(intent => (
       <Button key={intent} intent={intent}>
         {intent} button
@@ -73,8 +75,34 @@ export const Intent: StoryFn = _args => (
   </div>
 )
 
+export const Icons: StoryFn = _args => (
+  <div className="gap-md flex flex-wrap">
+    <Button>
+      Button
+      <Icon>
+        <FavoriteOutline />
+      </Icon>
+    </Button>
+    <Button>
+      <Icon>
+        <FavoriteOutline />
+      </Icon>
+      Button
+    </Button>
+    <Button>
+      <Icon>
+        <FavoriteOutline />
+      </Icon>
+      Button
+      <Icon>
+        <Check />
+      </Icon>
+    </Button>
+  </div>
+)
+
 export const Link: StoryFn = _args => (
-  <div className="gap-md flex flex-row">
+  <div className="gap-md flex flex-wrap">
     <Button asChild>
       <a href="/">button</a>
     </Button>

--- a/packages/components/button/src/Button.styles.tsx
+++ b/packages/components/button/src/Button.styles.tsx
@@ -57,7 +57,7 @@ export const buttonStyles = cva(
       }),
 
       size: makeVariants<'size', ['sm', 'md', 'lg']>({
-        sm: ['min-w-sz-24', 'h-sz-24'],
+        sm: ['min-w-sz-32', 'h-sz-32'],
         md: ['min-w-sz-44', 'h-sz-44'],
         lg: ['min-w-sz-56', 'h-sz-56'],
       }),


### PR DESCRIPTION
## Button icons

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #540 

### Description, Motivation and Context
This PR:
- Add a example of how icons could be added to a button (left, right and both)

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations

![Screen Shot 2023-04-24 at 16 00 14](https://user-images.githubusercontent.com/6877967/234019352-01634326-6190-48b7-8b68-a4628800f095.png)


