### PR TITLE
fix: global fix for custom styles and cva

### DIFF
--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -9,8 +9,8 @@ export type CheckboxProps = InputProps
 export const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
->(({ children, ...props }, ref) => (
-  <Label data-spark-component="checkbox" disabled={props.disabled}>
+>(({ children, className, ...props }, ref) => (
+  <Label data-spark-component="checkbox" className={className} disabled={props.disabled}>
     <Input ref={ref} {...props} />
     {children}
   </Label>

--- a/packages/components/checkbox/src/CheckboxInput.tsx
+++ b/packages/components/checkbox/src/CheckboxInput.tsx
@@ -60,7 +60,7 @@ export interface InputProps
     Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'checked' | 'defaultChecked'> {} // Native HTML props
 
 export const Input = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, InputProps>(
-  ({ intent, icon, ...props }, forwardedRef) => {
+  ({ intent, icon, className, ...props }, forwardedRef) => {
     const [innerChecked, setInnerChecked] = useState<'true' | 'false' | 'mixed'>()
     const ref = useMergeRefs(forwardedRef, node => {
       setInnerChecked(node?.getAttribute('aria-checked') as AriaCheckedStatus)
@@ -68,7 +68,7 @@ export const Input = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Input
     const innerIcon = useIcon({ icon, checked: innerChecked })
 
     return (
-      <CheckboxPrimitive.Root ref={ref} className={inputStyles({ intent })} {...props}>
+      <CheckboxPrimitive.Root ref={ref} className={inputStyles({ intent, className })} {...props}>
         <CheckboxPrimitive.Indicator className="text-surface flex items-center justify-center">
           {innerIcon}
         </CheckboxPrimitive.Indicator>

--- a/packages/components/icon-button/src/IconButton.tsx
+++ b/packages/components/icon-button/src/IconButton.tsx
@@ -10,12 +10,12 @@ export interface IconButtonProps extends ButtonProps {
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
-      className,
       design = 'filled',
       disabled = false,
       intent = 'primary',
       shape = 'rounded',
       size = 'md',
+      className,
       ...others
     },
     ref
@@ -23,7 +23,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     return (
       <Button
         ref={ref}
-        className={iconButtonVariants({ size })}
+        className={iconButtonVariants({ size, className })}
         design={design}
         disabled={disabled}
         intent={intent}

--- a/packages/components/radio/src/Radio.tsx
+++ b/packages/components/radio/src/Radio.tsx
@@ -17,7 +17,7 @@ export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
     const disabled = disabledProp || context.disabled
 
     return (
-      <RadioLabel disabled={disabled}>
+      <RadioLabel className={className} disabled={disabled}>
         <RadioInput ref={ref} intent={intent} size={size} {...others} />
         {children}
       </RadioLabel>

--- a/packages/components/radio/src/RadioIndicator.tsx
+++ b/packages/components/radio/src/RadioIndicator.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from 'react'
 import { radioIndicatorVariants, RadioIndicatorVariantsProps } from './RadioIndicator.variants'
 
 export interface RadioIndicatorProps extends RadioIndicatorVariantsProps {
+  className?: string
   /**
    * Change the component to the HTML tag or custom component of the only child.
    */
@@ -15,11 +16,11 @@ export interface RadioIndicatorProps extends RadioIndicatorVariantsProps {
 }
 
 export const RadioIndicator = forwardRef<HTMLSpanElement, RadioIndicatorProps>(
-  ({ intent, size, ...others }, ref) => {
+  ({ intent, size, className, ...others }, ref) => {
     return (
       <RadioIndicatorPrimitive
         ref={ref}
-        className={radioIndicatorVariants({ intent, size })}
+        className={radioIndicatorVariants({ intent, size, className })}
         {...others}
       />
     )

--- a/packages/components/radio/src/RadioInput.tsx
+++ b/packages/components/radio/src/RadioInput.tsx
@@ -26,9 +26,13 @@ export interface RadioInputProps
 }
 
 export const RadioInput = forwardRef<HTMLButtonElement, RadioInputProps>(
-  ({ intent, size, ...others }, ref) => {
+  ({ intent, size, className, ...others }, ref) => {
     return (
-      <RadioPrimitive ref={ref} className={radioInputVariants({ size, intent })} {...others}>
+      <RadioPrimitive
+        ref={ref}
+        className={radioInputVariants({ size, intent, className })}
+        {...others}
+      >
         <RadioIndicator intent={intent} size={size} forceMount />
       </RadioPrimitive>
     )

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -6,9 +6,9 @@ import { Label } from './SwitchLabel'
 export type SwitchProps = InputProps
 
 export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ value = 'on', size = 'md', children, ...rest }, ref) => {
+  ({ value = 'on', size = 'md', children, className, ...rest }, ref) => {
     return (
-      <Label data-spark-component="switch" disabled={rest.disabled}>
+      <Label data-spark-component="switch" disabled={rest.disabled} className={className}>
         <Input ref={ref} size={size} {...rest} />
         <div className="block">{children}</div>
       </Label>

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -61,6 +61,7 @@ export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
       size = 'md',
       value = 'on',
       onCheckedChange,
+      className,
       ...rest
     },
     ref
@@ -75,7 +76,7 @@ export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
     return (
       <SwitchPrimitive.Root
         ref={ref}
-        className={styles({ intent, size })}
+        className={styles({ intent, size, className })}
         value={value}
         checked={checked}
         defaultChecked={defaultChecked}


### PR DESCRIPTION
### Description, Motivation and Context
We forgot sometimes to pass the `className` prop to our cva functions. Leading custom styles to break default ones...

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
