### PR TITLE
feat(checkbox): add neutral and info intents

### DIFF
--- a/packages/components/checkbox/src/Checkbox.stories.tsx
+++ b/packages/components/checkbox/src/Checkbox.stories.tsx
@@ -73,7 +73,7 @@ export const ControlledState: StoryFn = _args => {
   )
 }
 
-const intent = ['primary', 'success', 'alert', 'error'] as const
+const intent = ['primary', 'success', 'alert', 'error', 'info', 'neutral'] as const
 
 export const Intent: StoryFn = _args => (
   <>

--- a/packages/components/checkbox/src/CheckboxInput.styles.ts
+++ b/packages/components/checkbox/src/CheckboxInput.styles.ts
@@ -11,7 +11,7 @@ export const inputStyles = cva(
   ],
   {
     variants: {
-      intent: makeVariants<'intent', ['primary', 'success', 'alert', 'error']>({
+      intent: makeVariants<'intent', ['primary', 'success', 'alert', 'error', 'info', 'neutral']>({
         primary: [
           'spark-state-unchecked:border-outline',
           'spark-state-indeterminate:border-primary spark-state-indeterminate:bg-primary',
@@ -31,6 +31,16 @@ export const inputStyles = cva(
           'spark-state-unchecked:border-error',
           'spark-state-indeterminate:border-error spark-state-indeterminate:bg-error',
           'spark-state-checked:border-error spark-state-checked:bg-error',
+        ],
+        info: [
+          'spark-state-unchecked:border-info',
+          'spark-state-indeterminate:border-info spark-state-indeterminate:bg-info',
+          'spark-state-checked:border-info spark-state-checked:bg-info',
+        ],
+        neutral: [
+          'spark-state-unchecked:border-neutral',
+          'spark-state-indeterminate:border-neutral spark-state-indeterminate:bg-neutral',
+          'spark-state-checked:border-neutral spark-state-checked:bg-neutral',
         ],
       }),
     },


### PR DESCRIPTION
## feat(checkbox): add neutral and info intents
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
<!---
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
 -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
