### PR TITLE
fix(tabs): add scroll to focused tab element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2096,6 +2096,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33913,7 +33914,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/packages/components/tabs/src/Tabs.test.tsx
+++ b/packages/components/tabs/src/Tabs.test.tsx
@@ -31,9 +31,16 @@ const tabsWithOverflow = [
 ]
 
 describe('Tabs', () => {
+  const scrollIntoViewSpy = vi.fn()
+
   beforeAll(() => {
+    Object.defineProperty(HTMLButtonElement.prototype, 'scrollIntoView', {
+      value: scrollIntoViewSpy,
+    })
     mockResizeObserver()
   })
+
+  beforeEach(() => vi.clearAllMocks())
 
   it('should render tabs and handle callback on value change', async () => {
     const user = userEvent.setup()
@@ -47,6 +54,16 @@ describe('Tabs', () => {
 
     expect(rootProps.onValueChange).toHaveBeenCalledTimes(1)
     expect(rootProps.onValueChange).toHaveBeenCalledWith('tab2')
+  })
+
+  it('should scroll into focused tab item', async () => {
+    const user = userEvent.setup()
+
+    render(createTabs({ tabs }))
+
+    await user.click(screen.getByText('Today'))
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should not trigger any event on disabled tab item click', async () => {

--- a/packages/components/tabs/src/TabsTrigger.tsx
+++ b/packages/components/tabs/src/TabsTrigger.tsx
@@ -1,5 +1,5 @@
 import * as RadixTabs from '@radix-ui/react-tabs'
-import { forwardRef } from 'react'
+import { type FocusEvent, forwardRef } from 'react'
 
 import { useTabsContext } from './TabsContext'
 import { triggerVariants } from './TabsTrigger.styles'
@@ -38,6 +38,13 @@ export const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
   ) => {
     const { intent, size } = useTabsContext()
 
+    const scrollToFocusedElement = ({ target }: FocusEvent<HTMLButtonElement>) =>
+      target.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      })
+
     return (
       <RadixTabs.Trigger
         ref={ref}
@@ -45,6 +52,7 @@ export const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
         asChild={asChild}
         disabled={disabled}
         value={value}
+        onFocus={scrollToFocusedElement}
       >
         {children}
       </RadixTabs.Trigger>


### PR DESCRIPTION
**TASK**: #744 

### Description, Motivation and Context
We (I, mostly...) missed to manage the tab item focus on overflowing content. Just needed a little scroll to it!

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test
