### PR TITLE
docs: new docs index and structure

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -18,8 +18,8 @@ module.exports = {
   },
 
   stories: [
-    '../documentation/getting-started/GettingStarted.mdx',
-    '../documentation/**/!(getting-started)/*.mdx',
+    '../documentation/*.mdx',
+    '../documentation/**/*.mdx',
     '../packages/**/*.doc.mdx',
     '../packages/**/*.stories.tsx',
   ],

--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -4,6 +4,19 @@ import './sb-theming.css'
 import { withThemeByDataAttribute } from '@storybook/addon-styling'
 
 export const parameters = {
+  options: {
+    storySort: {
+      order: [
+        'Getting Started',
+        'Using Spark',
+        'Components',
+        'Utils',
+        'Hooks',
+        'Contributing',
+        '*',
+      ],
+    },
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/documentation/GettingStarted.mdx
+++ b/documentation/GettingStarted.mdx
@@ -1,0 +1,74 @@
+import { Meta } from '@storybook/blocks'
+import { Callout } from '@docs/helpers/Callout'
+import { Card } from '@docs/helpers/Card'
+import { cva, cx } from 'class-variance-authority'
+
+<Meta title="Getting Started" />
+
+<div className="flex flex-col gap-xl pb-3xl">
+<p className="text-center text-on-background sb-unstyled text-display-1-expanded">
+  Create <span className="text-primary">accessible</span> React apps
+  <span className="text-secondary">with ease</span>.
+</p>
+<p className="text-center text-on-neutral-container sb-unstyled text-headline-1">
+  **Spark UI** is a React based design system focused on modularity and accessibility, using
+  TailwindCSS and Radix UI.
+</p>
+
+</div>
+
+# Getting started
+
+## What is Spark ?
+
+**Spark offers you two things:**
+
+- A full set of React components, with an emphasis on modularity and accessibility
+- A theming/styling system based on TailwindCSS, which allows you to theme your apps and style your own components
+
+## Using Spark
+
+New to Spark or looking for information ? The following sections should help you find what you need
+
+<div className="sb-unstyled flex flex-row flex-wrap gap-lg my-xl">
+  <Card href="/?path=/docs/using-spark-setup--docs" description="Enable Spark on your project">
+    Setup
+  </Card>
+  <Card
+    href="/?path=/docs/using-spark-styling-overview--docs"
+    description="Apply styles to your components and markup"
+  >
+    Styling
+  </Card>
+  <Card
+    isExternalLink
+    href="https://sparkui.vercel.app/viewer/"
+    description="Visualize colors, spacing, typography, etc."
+  >
+    Spark Tokens
+  </Card>
+  <Card href="/?path=/docs/utils-theme--docs" description="Customize as many as you want">
+    Create your own themes
+  </Card>
+  <Card href="/?path=/docs/using-spark-guide-migrating-from-styled-components--docs">
+    Guide - Migrating from styled-components
+  </Card>
+  <Card disabled description="¯\_(ツ)_/¯">
+    F.A.Q (TODO)
+  </Card>
+</div>
+
+## Contribute to Spark
+
+You want to contribute to Spark ? First you should get familiar with our global guidelines and Code of Conduct.
+
+<div className="sb-unstyled flex flex-row flex-wrap gap-lg my-xl">
+  <Card href="/?path=/docs/contributing-code-of-conduct-index--docs">Code of Conduct</Card>
+  <Card href="/?path=/docs/contributing-guidelines-commit--docs">Guidelines</Card>
+  <Card href="/?path=/docs/contributing-writing-packages-structure--docs">Writing packages</Card>
+</div>
+
+## Resources
+
+- [Spark - Issues](https://github.com/adevinta/spark/issues)
+- [Spark - Discussions](https://github.com/adevinta/spark/discussions)

--- a/documentation/contributing/code-of-conduct/CodeOfConduct.mdx
+++ b/documentation/contributing/code-of-conduct/CodeOfConduct.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Code of Conduct/Index" />
+<Meta title="Contributing/Code of Conduct/Index" />
 
 # Code of Conduct
 

--- a/documentation/contributing/code-of-conduct/Communication.mdx
+++ b/documentation/contributing/code-of-conduct/Communication.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Code of Conduct/Communication" />
+<Meta title="Contributing/Code of Conduct/Communication" />
 
 ## [Communication](https://zeroheight.com/2c2e9ba82/p/77af7e-comunication)
 

--- a/documentation/contributing/code-of-conduct/Implementation.mdx
+++ b/documentation/contributing/code-of-conduct/Implementation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Code of Conduct/Implementation" />
+<Meta title="Contributing/Code of Conduct/Implementation" />
 
 ## [Implementation](https://zeroheight.com/2c2e9ba82/p/85d5e7-implementation)
 

--- a/documentation/contributing/code-of-conduct/Innovation.mdx
+++ b/documentation/contributing/code-of-conduct/Innovation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Code of Conduct/Innovation" />
+<Meta title="Contributing/Code of Conduct/Innovation" />
 
 ## [Innovation](https://zeroheight.com/2c2e9ba82/p/255e7f-innovation)
 

--- a/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
+++ b/documentation/contributing/code-of-conduct/JudgmentAndDecisionMaking.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Code of Conduct/Judgment and Decision-making" />
+<Meta title="Contributing/Code of Conduct/Judgment and Decision-making" />
 
 ## [Judgment and Decision-making](https://zeroheight.com/2c2e9ba82/p/177da9-judgment-and-decision-making)
 

--- a/documentation/contributing/guidelines/CommitStrategy.mdx
+++ b/documentation/contributing/guidelines/CommitStrategy.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Contributing/Commit" />
+<Meta title="Contributing/Guidelines/Commit" />
 
 # Commit strategy
 

--- a/documentation/contributing/guidelines/Naming.mdx
+++ b/documentation/contributing/guidelines/Naming.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Practices/Naming" />
+<Meta title="Contributing/Guidelines/Naming" />
 
 # Naming
 

--- a/documentation/contributing/guidelines/ProjectStructure.mdx
+++ b/documentation/contributing/guidelines/ProjectStructure.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Definitions/Project Structure" />
+<Meta title="Contributing/Guidelines/Project architecture" />
 
 # Project structure
 

--- a/documentation/contributing/writing-packages/Build.mdx
+++ b/documentation/contributing/writing-packages/Build.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Build/Build" />
+<Meta title="Contributing/Writing packages/Build" />
 
 # Build strategy
 

--- a/documentation/contributing/writing-packages/ComponentDoD.mdx
+++ b/documentation/contributing/writing-packages/ComponentDoD.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Developer/Practices/Component - Definition of Done" />
+<Meta title="Contributing/Writing packages/Definition of Done" />
 
 # Component - Definition of Done
 
@@ -263,4 +263,4 @@ export const MySparkComponent = ({
 
 ## 7. Must be documented according to our Storybook guidelines
 
-[Go to stories guidelines](?path=/docs/contributing-writing-stories--docs)
+[Go to stories guidelines](?path=/docs/contributing-writing-packages-documentation--docs#writing-stories)

--- a/documentation/contributing/writing-packages/ComponentDoR.mdx
+++ b/documentation/contributing/writing-packages/ComponentDoR.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Developer/Practices/Component - Definition of Ready" />
+<Meta title="Contributing/Writing packages/Definition of Ready" />
 
 # Component - Definition of Ready
 

--- a/documentation/contributing/writing-packages/PackageStructure.mdx
+++ b/documentation/contributing/writing-packages/PackageStructure.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Developer/Definitions/Package Structure" />
+<Meta title="Contributing/Writing packages/Structure" />
 
 # Package structure
 

--- a/documentation/contributing/writing-packages/TestingStrategy.mdx
+++ b/documentation/contributing/writing-packages/TestingStrategy.mdx
@@ -1,9 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { StoryStatus } from '@docs/helpers/StoryStatus'
 
-<Meta title="Developer/Contributing/Testing" />
-
-<StoryStatus status="draft" />
+<Meta title="Contributing/Writing packages/Testing" />
 
 # Testing strategy
 

--- a/documentation/contributing/writing-packages/WritingStories.mdx
+++ b/documentation/contributing/writing-packages/WritingStories.mdx
@@ -3,7 +3,7 @@ import { Callout } from '@docs/helpers/Callout'
 
 import ArgstableImg from '@docs/assets/argstable.png'
 
-<Meta title="Developer/Contributing/Writing stories" />
+<Meta title="Contributing/Writing packages/Documentation" />
 
 # Writing stories
 

--- a/documentation/helpers/Card/index.tsx
+++ b/documentation/helpers/Card/index.tsx
@@ -1,0 +1,66 @@
+import { cva } from 'class-variance-authority'
+import { type ReactNode } from 'react'
+
+export const cardStyles = cva(
+  [
+    'sb-unstyled group',
+    'p-lg w-sz-224 min-h-sz-96 inline-flex flex-col justify-between overflow-hidden rounded-md',
+    'transition-all duration-200',
+    '!text-on-secondary text-body-1 text-left font-bold',
+    'from-primary to-secondary bg-gradient-to-br shadow',
+    'focus-visible:ring-outline-high outline-none focus-visible:ring-2',
+  ],
+  {
+    variants: {
+      disabled: {
+        true: 'opacity-dim-3 hover:cursor-not-allowed',
+        false:
+          'hover:from-primary-hovered hover:to-secondary-hovered hover:cursor-pointer hover:shadow-lg',
+      },
+    },
+    defaultVariants: {
+      disabled: false,
+    },
+  }
+)
+
+export const descriptionStyles = cva(
+  [
+    'text-caption font-regular',
+    'translate-y-[calc(100%+16px)] opacity-0',
+    'transition-all duration-300 ease-out',
+  ],
+  {
+    variants: {
+      disabled: {
+        false: 'group-hover:translate-y-none group-hover:opacity-[1]',
+      },
+    },
+    defaultVariants: {
+      disabled: false,
+    },
+  }
+)
+
+interface Props {
+  children: ReactNode
+  description?: string
+  href?: string
+  isExternalLink?: boolean
+}
+
+export const Card = ({ children, description, href, isExternalLink = false, ...rest }: Props) => {
+  const dynamicProps = isExternalLink
+    ? {
+        target: '_blank',
+        rel: 'noreferrer',
+      }
+    : {}
+
+  return (
+    <a className={cardStyles(rest)} href={href} {...dynamicProps}>
+      {children}
+      {description && <p className={descriptionStyles(rest)}>{description}</p>}
+    </a>
+  )
+}

--- a/documentation/using-spark/Setup.mdx
+++ b/documentation/using-spark/Setup.mdx
@@ -1,32 +1,21 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Getting Started" />
+<Meta title="Using Spark/Setup" />
 
-# Getting started
+# Setup
 
-<Callout marginBottom="medium">
-  **The Spark Design System** is built using the **Tailwind CSS** framework.
-</Callout>
+## 1. Setup TailwindCSS
 
-<Callout marginBottom="medium">
-  For those of you who prefer code over documentation, check out our [github
-  repository](https://github.com/adevinta/spark) instead 🕵️‍♂️👩‍💻
-</Callout>
+If you haven't installed **TailwindCSS** on your project yet, you **must** follow the [TailwindCSS installation guide](https://tailwindcss.com/docs/installation).
 
-## Set up TailwindCSS
-
-#### Installation
-
-If you haven't installed **TailwindCSS** on your project yet, you can follow the [TailwindCSS installation guide](https://tailwindcss.com/docs/installation).
-
-#### IntelliSense
+## 2. IntelliSense
 
 The official Tailwind CSS [IntelliSense extension](https://tailwindcss.com/docs/editor-setup#intelli-sense-for-vs-code) for **Visual Studio Code** enhances the Tailwind development experience by providing users with advanced features such as autocomplete, syntax highlighting, and linting.
 
 **JetBrains IDEs** like WebStorm, PhpStorm, and others include [support](https://www.jetbrains.com/help/webstorm/tailwind-css.html) for intelligent Tailwind CSS completions in your HTML and when using @apply.
 
-## Installation
+## 3. Setup Spark
 
 After setting up **Tailwind** for your application, install the following packages via your command line:
 
@@ -131,4 +120,4 @@ That's all there is to it! 🎉
   of these class names.
 </Callout>
 
-**Next: [Spark styling solution overview](?path=/docs/styling-overview--docs#overview-of-spark-styling-solution)**
+**Next: [Spark styling solution overview](?path=/docs/using-spark-styling-overview--docs#overview-of-spark-styling-solution)**

--- a/documentation/using-spark/StyledComponents.mdx
+++ b/documentation/using-spark/StyledComponents.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Developer/Migration/Styled Components" />
+<Meta title="Using Spark/Guide - Migrating from Styled Components" />
 
 # Migrating from styled-components
 

--- a/documentation/using-spark/StylingOverview.mdx
+++ b/documentation/using-spark/StylingOverview.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-<Meta title="Styling overview" />
+<Meta title="Using Spark/Styling overview" />
 
 # Overview of Spark styling solution
 
@@ -17,34 +17,45 @@ At its core, the Spark styling solution is a **set** of Tailwind plugins that cu
 
 ## Tokens
 
-Tailwind's default theme tends to favor numerical scales to manage its tokens.
+It is important to note that although Spark is using TailwindCSS class prefixed, most of the class suffixes does not follow the same naming/semantics.
 
-For instance, **margins** are declared as follows:
+<div className="flex gap-lg">
+  <div className=" bg-error-container text-on-error-container rounded-md flex-1 p-lg">
+    <h3>❌ With Tailwind (arbitrary values)</h3>
+    Tailwind's default theme tends to favor numerical scales to manage its tokens.
 
-- `m-1` // 4px
-- `m-1.5` // 6px
-- `m-2` // 8px
-- and so on
+    For instance, **margins** are declared as follows:
+    - `m-1` // 4px
+    - `m-1.5` // 6px
+    - `m-2` // 8px
+    - and so on
 
-A similar approach is used for **colors**:
+    A similar approach is used for **colors**:
 
-- `bg-blue-100`
-- `bg-blue-200`
-- and so on
+    - `bg-blue-100`
+    - `bg-blue-200`
+    - and so on
 
-In contrast, our Spark design system adopts a semantic approach. For **margins**, we use:
+  </div>
 
-- `m-sm` // 4px
-- `m-md` // 8px
-- `m-lg` // 16px
-- and so on
+  <div className="bg-success-container text-on-success-container rounded-md flex-1 p-lg">
+    <h3>✅ With Spark (semantic values)</h3>
+    In contrast, our Spark design system adopts a semantic approach. For **margins**, we use:
 
-For colors, we use:
+    - `m-sm` // 4px
+    - `m-md` // 8px
+    - `m-lg` // 16px
+    - and so on
 
-- `bg-primary`
-- `bg-secondary`
-- `bg-success`
-- and so on
+    For colors, we use:
+
+    - `bg-primary`
+    - `bg-secondary`
+    - `bg-success`
+    - and so on
+
+  </div>
+</div>
 
 ## Anatomy of a Tailwind token-related class:
 
@@ -52,7 +63,7 @@ If we step back and take a closer look at how a typical Tailwind token-related c
 
 The first part, is the **prefix** (appearing before the `*` in the examples below):
 
-- `m-*` for margin, `m-b-*` for margin-bottom, `p-*` for padding, `p-l-*` for padding-left, etc.
+- `m-*` for margin, `mb-*` for margin-bottom, `p-*` for padding, `pl-*` for padding-left, etc.
 - `text-*` for text colors
 - `bg-*` for background colors
 - …
@@ -92,4 +103,4 @@ In essence, **every class not related to tokens is kept untouched**.
 
 So, if you don't find the class you're seeking within our [dedicated page](https://sparkui.vercel.app/viewer/), the answer is probably on the [Tailwind website](https://tailwindcss.com).
 
-**Next: [Check out our migration guide for transitioning from styled components to Spark's styling solution](?path=/docs/developer-migration-styled-components--docs#migrating-from-styled-components)**
+**Next: [Check out our migration guide for transitioning from styled components to Spark's styling solution](?path=/docs/using-spark-guide-migrating-from-styled-components--docs#migrating-from-styled-components)**

--- a/documentation/using-spark/TCV.mdx
+++ b/documentation/using-spark/TCV.mdx
@@ -1,5 +1,7 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Tailwind config viewer" />
+<Meta title="Using Spark/Tailwind config viewer" />
 
 Don't hesitate to check our [**dedicated page**](https://sparkui.vercel.app/viewer/) that provides a visual representation of our Tailwind CSS configuration file.
+
+<iframe src="https://sparkui.vercel.app/viewer/" width="100%" height="100%" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2096,6 +2096,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33913,7 +33914,8 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/packages/utils/cli/src/index.doc.mdx
+++ b/packages/utils/cli/src/index.doc.mdx
@@ -12,7 +12,6 @@ This package provides some CLI commands to improve the development experience wh
 
 - [Installation](#installation)
 - [Generating a new package](#generating-a-new-package)
-- [Setting up your themes](#setting-up-your-themes)
 
 ## Installation
 

--- a/packages/utils/tailwind-plugins/index.doc.mdx
+++ b/packages/utils/tailwind-plugins/index.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="utils/Tailwind plugins" />
+<Meta title="utils/Tailwind plugins/Index" />
 
 # Tailwind plugins
 

--- a/packages/utils/theme/src/defaultTheme.ts
+++ b/packages/utils/theme/src/defaultTheme.ts
@@ -201,6 +201,7 @@ export const defaultTheme: Theme = {
   },
   opacity: {
     0: '0',
+    none: '1',
     dim1: '0.72',
     dim2: '0.56',
     dim3: '0.40',

--- a/packages/utils/theme/src/types.ts
+++ b/packages/utils/theme/src/types.ts
@@ -219,6 +219,7 @@ export interface Theme {
   }
   opacity: {
     0: string
+    none: string
     dim1: string
     dim2: string
     dim3: string


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #743 

### Description, Motivation and Context

We gathered feedback from the first users and it appears the Getting Started section was perceived as having too much raw text (not user-friendly). I updated it and reordered the sections to make it easier to read.

Also, most documentation for contributers was under `Developer`. I renamed it to `Contributing` to make it explicit that this doc is not for users.

### Types of changes
- [x] 🧾 Documentation
- [x] 🧠 Refactor

### Screenshots - Animations
![Capture d’écran 2023-05-09 à 11 56 37](https://user-images.githubusercontent.com/2033710/237062888-a6d7e92f-7472-4a1a-ac5d-1c43a47a12bd.png)

