### PR TITLE
feat(switch): allowing formfield usage for switch component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31952,6 +31952,7 @@
       "dependencies": {
         "@radix-ui/react-switch": "1.0.2",
         "@spark-ui/icons": "^1.13.0",
+        "@spark-ui/form-field": "^0.1.0",
         "@spark-ui/internal-utils": "^1.6.0",
         "@spark-ui/slot": "^1.5.0",
         "@spark-ui/use-combined-state": "^0.4.4",
@@ -39067,6 +39068,7 @@
       "requires": {
         "@radix-ui/react-switch": "1.0.2",
         "@spark-ui/icons": "^1.13.0",
+        "@spark-ui/form-field": "^0.1.0",
         "@spark-ui/internal-utils": "^1.6.0",
         "@spark-ui/slot": "^1.5.0",
         "@spark-ui/use-combined-state": "^0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31951,9 +31951,10 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-switch": "1.0.2",
-        "@spark-ui/icons": "^1.13.0",
         "@spark-ui/form-field": "^0.1.0",
+        "@spark-ui/icons": "^1.13.0",
         "@spark-ui/internal-utils": "^1.6.0",
+        "@spark-ui/label": "^1.1.1",
         "@spark-ui/slot": "^1.5.0",
         "@spark-ui/use-combined-state": "^0.4.4",
         "class-variance-authority": "0.5.2"
@@ -39067,9 +39068,10 @@
       "version": "file:packages/components/switch",
       "requires": {
         "@radix-ui/react-switch": "1.0.2",
-        "@spark-ui/icons": "^1.13.0",
         "@spark-ui/form-field": "^0.1.0",
+        "@spark-ui/icons": "^1.13.0",
         "@spark-ui/internal-utils": "^1.6.0",
+        "@spark-ui/label": "^1.1.1",
         "@spark-ui/slot": "^1.5.0",
         "@spark-ui/use-combined-state": "^0.4.4",
         "class-variance-authority": "0.5.2"

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -18,9 +18,10 @@
   },
   "dependencies": {
     "@radix-ui/react-switch": "1.0.2",
-    "@spark-ui/icons": "^1.13.0",
     "@spark-ui/form-field": "^0.1.0",
+    "@spark-ui/icons": "^1.13.0",
     "@spark-ui/internal-utils": "^1.6.0",
+    "@spark-ui/label": "^1.1.1",
     "@spark-ui/slot": "^1.5.0",
     "@spark-ui/use-combined-state": "^0.4.4",
     "class-variance-authority": "0.5.2"

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@radix-ui/react-switch": "1.0.2",
     "@spark-ui/icons": "^1.13.0",
+    "@spark-ui/form-field": "^0.1.0",
     "@spark-ui/internal-utils": "^1.6.0",
     "@spark-ui/slot": "^1.5.0",
     "@spark-ui/use-combined-state": "^0.4.4",

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -29,6 +29,12 @@ import { Switch } from "@spark-ui/switch"
 
 <Canvas of={stories.Default} />
 
+## Using a FormField
+
+If you need to provide more context about the Switch (for example, a helper message or an error message) the FormField component could be used. See [documentation](./?path=/docs/experimental-formfield--docs) for more details.
+
+<Canvas of={stories.ImprovedField} />
+
 ## Disabled
 
 <Canvas of={stories.Disabled} />

--- a/packages/components/switch/src/Switch.stories.tsx
+++ b/packages/components/switch/src/Switch.stories.tsx
@@ -1,5 +1,6 @@
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { Button } from '@spark-ui/button'
+import { FormField } from '@spark-ui/form-field'
 import { EyeFill } from '@spark-ui/icons/dist/icons/EyeFill'
 import { EyeOffFill } from '@spark-ui/icons/dist/icons/EyeOffFill'
 import { Meta, StoryFn } from '@storybook/react'
@@ -26,6 +27,18 @@ export const Default: StoryFn = _args => (
       <Switch defaultChecked>Agreed</Switch>
     </div>
   </div>
+)
+
+export const ImprovedField: StoryFn = _args => (
+  <FormField name="agreement" isRequired>
+    <FormField.Label asChild>
+      <p>Agreement</p>
+    </FormField.Label>
+
+    <Switch>I agree</Switch>
+
+    <FormField.HelperMessage>Your agreement is important to us.</FormField.HelperMessage>
+  </FormField>
 )
 
 export const Disabled: StoryFn = _args => (

--- a/packages/components/switch/src/Switch.test.tsx
+++ b/packages/components/switch/src/Switch.test.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable max-lines-per-function */
 /* eslint-disable max-nested-callbacks */
+import { FormField } from '@spark-ui/form-field'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
@@ -99,6 +101,51 @@ describe('Switch', () => {
 
       expect(spyOnCheckedChange).toHaveBeenCalledTimes(1)
       expect(screen.getByRole('switch')).toBeChecked()
+    })
+  })
+
+  describe('with FormField', () => {
+    it('should render with label and name', () => {
+      render(
+        <FormField name="agreement">
+          <FormField.Label asChild>
+            <p>Agreement</p>
+          </FormField.Label>
+
+          <Switch />
+        </FormField>
+      )
+
+      expect(screen.getByRole('switch', { name: 'Agreement' })).toBeInTheDocument()
+    })
+
+    it('should render aria-attributes following FormField implementation', () => {
+      render(
+        <FormField name="agreement" isRequired isInvalid>
+          <FormField.Label asChild>
+            <p>Agreement</p>
+          </FormField.Label>
+
+          <Switch />
+
+          <FormField.ErrorMessage>Agreement is required</FormField.ErrorMessage>
+        </FormField>
+      )
+
+      expect(screen.getByRole('switch', { name: 'Agreement' })).toHaveAttribute(
+        'aria-required',
+        'true'
+      )
+
+      expect(screen.getByRole('switch', { name: 'Agreement' })).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      )
+
+      expect(screen.getByRole('switch', { name: 'Agreement' })).toHaveAttribute(
+        'aria-describedby',
+        screen.getByText('Agreement is required').getAttribute('id')
+      )
     })
   })
 })

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import { forwardRef } from 'react'
 
 import { Input, type InputProps } from './SwitchInput'
 import { Label } from './SwitchLabel'
 
 export type SwitchProps = InputProps
 
-export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ value = 'on', size = 'md', children, className, ...rest }, ref) => {
     return (
       <Label data-spark-component="switch" disabled={rest.disabled} className={className}>

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -98,7 +98,6 @@ export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
         id={id || controlledId}
         name={name || controlledName}
         required={required || isRequired}
-        aria-required={required || isRequired}
         aria-invalid={isInvalid}
         aria-labelledby={labelId}
         aria-describedby={description}

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable complexity */
 import * as SwitchPrimitive from '@radix-ui/react-switch'
+import { useFormFieldState } from '@spark-ui/form-field'
 import { Check } from '@spark-ui/icons/dist/icons/Check'
 import { Close } from '@spark-ui/icons/dist/icons/Close'
 import { Slot } from '@spark-ui/slot'
@@ -63,11 +65,22 @@ export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
       value = 'on',
       onCheckedChange,
       className,
+      id,
+      name,
+      required,
       ...rest
     },
     ref
   ) => {
     const [isChecked, setIsChecked] = useCombinedState(checked, defaultChecked)
+    const {
+      id: controlledId,
+      name: controlledName,
+      labelId,
+      description,
+      isRequired,
+      isInvalid,
+    } = useFormFieldState()
 
     const handleCheckedChange = (updatedValue: boolean): void => {
       setIsChecked(updatedValue)
@@ -82,6 +95,13 @@ export const Input = React.forwardRef<HTMLButtonElement, InputProps>(
         checked={checked}
         defaultChecked={defaultChecked}
         onCheckedChange={handleCheckedChange}
+        id={id || controlledId}
+        name={name || controlledName}
+        required={required || isRequired}
+        aria-required={required || isRequired}
+        aria-invalid={isInvalid}
+        aria-labelledby={labelId}
+        aria-describedby={description}
         {...rest}
       >
         <SwitchPrimitive.Thumb className={thumbStyles({ size, checked: isChecked })}>

--- a/packages/components/switch/src/SwitchLabel.tsx
+++ b/packages/components/switch/src/SwitchLabel.tsx
@@ -1,5 +1,5 @@
-import { Label as RadixLabel } from '@radix-ui/react-label'
 import { useFormFieldState } from '@spark-ui/form-field'
+import { Label as SparkLabel } from '@spark-ui/label'
 import type { PropsWithChildren } from 'react'
 
 import { labelStyles, LabelStylesProps } from './SwitchLabel.styles'
@@ -25,7 +25,7 @@ export const Label = ({ className, disabled, htmlFor, ...others }: LabelProps) =
   const { labelId } = useFormFieldState()
 
   return (
-    <RadixLabel
+    <SparkLabel
       className={labelStyles({ className, disabled })}
       htmlFor={htmlFor || labelId}
       {...others}

--- a/packages/components/switch/src/SwitchLabel.tsx
+++ b/packages/components/switch/src/SwitchLabel.tsx
@@ -1,5 +1,6 @@
 import { Label as RadixLabel } from '@radix-ui/react-label'
-import { PropsWithChildren } from 'react'
+import { useFormFieldState } from '@spark-ui/form-field'
+import type { PropsWithChildren } from 'react'
 
 import { labelStyles, LabelStylesProps } from './SwitchLabel.styles'
 
@@ -20,6 +21,14 @@ export interface LabelProps
   disabled?: boolean
 }
 
-export const Label = ({ className, disabled, ...others }: LabelProps) => {
-  return <RadixLabel className={labelStyles({ className, disabled })} {...others} />
+export const Label = ({ className, disabled, htmlFor, ...others }: LabelProps) => {
+  const { labelId } = useFormFieldState()
+
+  return (
+    <RadixLabel
+      className={labelStyles({ className, disabled })}
+      htmlFor={htmlFor || labelId}
+      {...others}
+    />
+  )
 }


### PR DESCRIPTION
**TASK**: #734 

### Description, Motivation and Context
We now want to enable the usage of `FormField` with our form components, to improve field state management and so.
- [x] adds `useFormFieldState()` hook within `Switch` component (it will default without throwing when no provider will be given)
- [x] adds dedicated tests, to improve confidence about the interaction between `Switch` and `FormField` (aria attributes completion, ...)
- [x] adds dedicated documentation section, with a link to `FormField` one for more details.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧪 Test
- [x] 🧠 Refactor

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/2c6b9944-1aa5-45be-b5b1-a1da290e8b0b)

