### PR TITLE
801 checkbox icon not visible in safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,7 +2164,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31808,6 +31807,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "1.0.3",
+        "@spark-ui/icon": "^1.7.1",
         "@spark-ui/icons": "^1.11.0",
         "@spark-ui/internal-utils": "^1.6.0",
         "@spark-ui/label": "^1.1.1",
@@ -33577,8 +33577,7 @@
       "dependencies": {
         "is-unicode-supported": {
           "version": "1.3.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         }
       }
     },
@@ -38959,6 +38958,7 @@
       "version": "file:packages/components/checkbox",
       "requires": {
         "@radix-ui/react-checkbox": "1.0.3",
+        "@spark-ui/icon": "^1.7.1",
         "@spark-ui/icons": "^1.11.0",
         "@spark-ui/internal-utils": "^1.6.0",
         "@spark-ui/label": "^1.1.1",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -17,7 +17,8 @@
     "@spark-ui/icons": "^1.11.0",
     "@spark-ui/internal-utils": "^1.6.0",
     "@spark-ui/use-merge-refs": "^0.3.3",
-    "@spark-ui/label": "^1.1.1"
+    "@spark-ui/label": "^1.1.1",
+    "@spark-ui/icon": "^1.7.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/components/checkbox/src/CheckboxIndicator.tsx
+++ b/packages/components/checkbox/src/CheckboxIndicator.tsx
@@ -10,7 +10,7 @@ export const CheckboxIndicator = forwardRef<HTMLSpanElement, CheckboxIndicatorPr
   (props, ref) => (
     <CheckboxIndicatorPrimitive
       ref={ref}
-      className="text-surface flex items-center justify-center"
+      className="text-surface flex h-full w-full items-center justify-center"
       {...props}
     />
   )

--- a/packages/components/checkbox/src/CheckboxInput.styles.ts
+++ b/packages/components/checkbox/src/CheckboxInput.styles.ts
@@ -3,10 +3,10 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const checkboxInputStyles = cva(
   [
-    'h-sz-20 w-sz-20 border-md peer my-[var(--sz-1)] shrink-0 items-center justify-center self-baseline rounded-sm bg-transparent',
+    'h-sz-16 w-sz-16 border-md box-content items-center justify-center rounded-sm bg-transparent outline-none',
     'spark-disabled:opacity-dim-3 spark-disabled:cursor-not-allowed spark-disabled:hover:ring-0',
-    'focus-visible:ring-outline-high focus-visible:outline-none focus-visible:ring-2',
-    'hover:border-primary-container hover:outline-none hover:ring-2',
+    'focus-visible:ring-outline-high focus-visible:ring-2',
+    'hover:border-primary-container hover:ring-2',
     'u-shadow-border-transition',
   ],
   {

--- a/packages/components/checkbox/src/CheckboxInput.tsx
+++ b/packages/components/checkbox/src/CheckboxInput.tsx
@@ -1,4 +1,5 @@
 import { Checkbox as CheckboxPrimitive } from '@radix-ui/react-checkbox'
+import { Icon } from '@spark-ui/icon'
 import { Check } from '@spark-ui/icons/dist/icons/Check'
 import { Minus } from '@spark-ui/icons/dist/icons/Minus'
 import { ComponentPropsWithoutRef, forwardRef, ReactNode } from 'react'
@@ -62,7 +63,7 @@ export const CheckboxInput = forwardRef<HTMLButtonElement, CheckboxInputProps>(
         {...others}
       >
         <CheckboxIndicator>
-          {checked === 'indeterminate' ? indeterminateIcon : icon}
+          <Icon size="sm">{checked === 'indeterminate' ? indeterminateIcon : icon}</Icon>
         </CheckboxIndicator>
       </CheckboxPrimitive>
     )

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -1,5 +1,5 @@
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
-import React from 'react'
+import { Children, cloneElement, ReactNode } from 'react'
 
 import { iconStyles, IconVariantsProps } from './Icon.styles'
 
@@ -7,7 +7,7 @@ export interface IconProps extends IconVariantsProps, React.SVGProps<SVGElement>
   /**
    * The svg icon that will be wrapped
    */
-  children: React.ReactElement
+  children: ReactNode
   /**
    * The accessible label for the icon. This label will be visually hidden but announced to screen
    * reader users, similar to `alt` text for `img` tags.
@@ -23,11 +23,11 @@ export function Icon({
   children,
   ...others
 }: IconProps) {
-  const child = React.Children.only(children)
+  const child = Children.only(children)
 
   return (
     <>
-      {React.cloneElement(child as React.ReactElement, {
+      {cloneElement(child as React.ReactElement, {
         className: iconStyles({ className, size, intent }),
         'data-spark-component': 'icon',
         'aria-hidden': 'true',


### PR DESCRIPTION
## Checkbox icon not visible in safari

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #801 

### Description, Motivation and Context
This PR fixes an issue where checked icon is not visible in Safari

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations

Before
![Screen Shot 2023-05-24 at 08 28 06](https://github.com/adevinta/spark/assets/6877967/38bd753b-44dd-48b2-8615-9b87cddf764f)

After
![Screen Shot 2023-05-24 at 08 27 46](https://github.com/adevinta/spark/assets/6877967/b8601bd8-a9da-4ba8-b6c1-f434d49a830d)
