### PR TITLE
docs: add missing accessibility details on storybook

### DIFF
--- a/packages/components/badge/src/Badge.doc.mdx
+++ b/packages/components/badge/src/Badge.doc.mdx
@@ -68,3 +68,11 @@ Use `intent` prop to set the color intent of the badge.
 Use `size` prop to set the size of the badge.
 
 <Canvas of={stories.Sizes} />
+
+## Accessibility
+
+It is recommended to use the `aria-label` attribute to improve the component's readability by assistive technologies. There is no automatic addition as this attribute should be explicit (human readable) and be independent from any internationalization constraint.
+
+- Basic usecase: `[n] notifications`
+- Large numbers usecase: `More than [n] notifications`
+- Non-counting usecase: `New notification`

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -70,3 +70,12 @@ Compose the content of the button using the `Icon` component to add an icon to t
 Use `intent` prop to set the color intent of a button.
 
 <Canvas of={ButtonStories.Link} />
+
+## Accessibility
+
+This component adheres to the [`button` role requirements](https://www.w3.org/WAI/ARIA/apg/patterns/button).
+
+### Keyboard Interactions
+
+- `Space`: Activates the button
+- `Enter`: Activates the button

--- a/packages/components/checkbox/src/Checkbox.doc.mdx
+++ b/packages/components/checkbox/src/Checkbox.doc.mdx
@@ -139,3 +139,11 @@ Use the `isInvalid` prop to indicate that the checkbox group is invalid.
 If an individual checkbox is invalid, wrap it with a `FormField` component a set the `isInvalid` prop to `true`.
 
 <Canvas of={CheckboxStories.GroupIndividualValidation} />
+
+## Accessibility
+
+Adheres to the [`tri-state Checkbox WAI-ARIA design pattern`](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox).
+
+### Keyboard Interactions
+
+- `Space`: Checks/unchecks the checkbox.

--- a/packages/components/icon-button/src/IconButton.doc.mdx
+++ b/packages/components/icon-button/src/IconButton.doc.mdx
@@ -64,3 +64,12 @@ Use `intent` prop to set the color intent of a button.
 Use `intent` prop to set the color intent of a button.
 
 <Canvas of={stories.Link} />
+
+## Accessibility
+
+This component adheres to the [`button` role requirements](https://www.w3.org/WAI/ARIA/apg/patterns/button). In this specific usecase it is strongly recommended to define an accessible name through `aria-label` or `aria-labelledby` attributes.
+
+### Keyboard Interactions
+
+- `Space`: Activates the button
+- `Enter`: Activates the button

--- a/packages/components/label/src/Label.doc.mdx
+++ b/packages/components/label/src/Label.doc.mdx
@@ -27,6 +27,8 @@ import { Label } from '@spark-ui/label'
 
 ## Usage
 
-This component is based on the native label element, it will automatically apply the correct labelling when wrapping controls or using the `htmlFor` attribute.
-
 <Canvas of={stories.Default} />
+
+## Accessibility
+
+This component is based on the native `label` element, it will automatically apply the correct labelling when wrapping controls or using the `htmlFor` attribute. For your own custom controls to work correctly, ensure they use native elements such as `button` or `input` as a base.

--- a/packages/components/radio/src/Radio.doc.mdx
+++ b/packages/components/radio/src/Radio.doc.mdx
@@ -98,3 +98,16 @@ Use the `isRequired` prop to indicate that the radio group is required.
 Use the `isInvalid` prop to indicate that the radio group is invalid and show the error message.
 
 <Canvas of={RadioStories.Invalid} />
+
+## Accessibility
+
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+
+### Keyboard Interactions
+
+- `Tab`: Moves focus to either the checked radio item or the first radio item in the group.
+- `Space`: When focus is on an unchecked radio item, checks it.
+- `ArrowDown`: Moves focus and checks the next radio item in the group.
+- `ArrowRight`: Moves focus and checks the next radio item in the group.
+- `ArrowUp`: Moves focus to the previous radio item in the group.
+- `ArrowLeft`: Moves focus to the previous radio item in the group.

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -53,3 +53,12 @@ This can be useful to trigger the switch to toggle when interacting with outside
 It is then up to you to trigger update to its `checked` state to toggle it.
 
 <Canvas of={stories.ControlledMode} />
+
+## Accessibility
+
+This component adheres to the [`switch` role requirements](https://www.w3.org/WAI/ARIA/apg/patterns/switch).
+
+### Keyboard Interactions
+
+- `Space`: Toggles the component's state.
+- `Enter`: Toggles the component's state.

--- a/packages/components/tabs/src/Tabs.doc.mdx
+++ b/packages/components/tabs/src/Tabs.doc.mdx
@@ -65,3 +65,17 @@ Use `orientation` prop to set `horizontal|vertical` orientation.
 For `horizontal` orientation only, navigation arrows are automatically displayed to help user browse tabs on content overflow. Use then `loop` prop on list to allow navigation loop from last tab to first, and vice versa.
 
 <Canvas of={stories.Overflow} />
+
+## Accessibility
+
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+
+### Keyboard Interactions
+
+- `Tab`: When focus moves onto the tabs, focuses the active trigger. When a trigger is focused, moves focus to the active content.
+- `ArrowDown`: Moves focus to the next trigger depending on `orientation` and activates its associated content.
+- `ArrowRight`: Moves focus to the next trigger depending on `orientation` and activates its associated content.
+- `ArrowUp`: Moves focus to the previous trigger depending on `orientation` and activates its associated content.
+- `ArrowLeft`: Moves focus to the previous trigger depending on `orientation` and activates its associated content.
+- `Home`: Moves focus to the first trigger and activates its associated content.
+- `End`: Moves focus to the last trigger and activates its associated content.

--- a/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
+++ b/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
@@ -27,3 +27,7 @@ import { VisuallyHidden } from "@spark-ui/visually-hidden"
 A button without text can be absolutely mysterious for someone using screen reader. They might be announced simply as "button". We can solve this problem without compromising on our design. A VisuallyHidden component will allow us to place text inside this button that will only be made available to people using screen readers.
 
 <Canvas of={VisuallyHiddenStories.Default} />
+
+## Accessibility
+
+This is useful in certain scenarios as an alternative to traditional labelling with `aria-label` or `aria-labelledby`.


### PR DESCRIPTION
**TASK**: #810

### Description, Motivation and Context
There had been an agreement about accessibility documentation: https://sparkui.vercel.app/?path=/docs/contributing-writing-packages-documentation--docs#6-accessibility But we missed it! So we should add these sections on each story +1

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/f76bddb8-d825-4b5a-bd52-a2cc92c6f4a5)
