### PR TITLE
refactor: widen the Tailwind peerDep for utils

### DIFF
--- a/packages/utils/tailwind-plugins/package.json
+++ b/packages/utils/tailwind-plugins/package.json
@@ -11,7 +11,7 @@
     "tailwindcss-radix": "2.8.0"
   },
   "peerDependencies": {
-    "tailwindcss": "3.0.0"
+    "tailwindcss": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## refactor(Tailwind Utils): Widen the TailwindCSS peerDep

### Description, Motivation and Context

The Utility package for Tailwind has a pinned dependency on the exact major of TailwindCSS, which is restrictive for a consumer. If there is no limiting issue, and given how liberally SemVer is used in the JS world, I propose to pin only to the major and allow consumers to upgrade.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
<!---
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
 -->

