### PR TITLE
refactor(button): upd outlined variant border size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2618,6 +2618,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",

--- a/packages/components/button/src/Button.styles.tsx
+++ b/packages/components/button/src/Button.styles.tsx
@@ -35,7 +35,7 @@ export const buttonStyles = cva(
        */
       design: makeVariants<'design'>({
         filled: [],
-        outlined: ['bg-transparent', 'ring-2', 'ring-current'],
+        outlined: ['bg-transparent', 'ring-1', 'ring-current'],
         tinted: [],
         ghost: [],
         contrast: ['bg-surface'],


### PR DESCRIPTION
**TASK**: #830 

### Description, Motivation and Context
To improve our DS consistency, we want to harmonize border sizes. As visible in [Figma specs](https://www.figma.com/file/0QchRdipAVuvVoDfTjLrgQ/Spark-Specs-and-Handoff?type=design&node-id=2340-22556&t=xkErzPSGZ3TXhuHG-0), we now want Button and IconButton components to have a 1px border size.

### Types of changes
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/f20a493c-5ef3-4438-b24f-560ff4bc8f96)
![image](https://github.com/adevinta/spark/assets/66770550/f114612f-f1b5-401c-9087-a71442f10f26)
