### PR TITLE
remove eslint ignore comments

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,12 @@ module.exports = {
         'max-nested-callbacks': [1, 4],
       },
     },
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        'max-lines-per-function': [1, { max: 150, skipBlankLines: true, skipComments: true }],
+      },
+    },
   ],
   settings: {
     react: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,13 @@
 module.exports = {
+  overrides: [
+    {
+      files: ['**/*.test.ts', '**/*.test.tsx'],
+      rules: {
+        'max-lines-per-function': [1, { max: 300, skipBlankLines: true, skipComments: true }],
+        'max-nested-callbacks': [1, 4],
+      },
+    },
+  ],
   settings: {
     react: {
       version: 'detect',

--- a/packages/components/checkbox/src/Checkbox.test.tsx
+++ b/packages/components/checkbox/src/Checkbox.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { FormField } from '@spark-ui/form-field'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -117,7 +116,9 @@ describe('Checkbox', () => {
     expect(checkboxEl).not.toBeChecked()
     expect(onCheckedChange).toHaveBeenCalledTimes(0)
   })
+})
 
+describe('CheckboxGroup', () => {
   it('should render group', () => {
     render(
       <FormField name="sports">

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -23,24 +23,25 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     forwardedRef
   ) => {
     const field = useFormFieldState()
-    const {
-      name = field.name,
-      isRequired = field.isRequired,
-      isInvalid = field.isInvalid,
-
-      id: groupId,
-      intent: groupIntent,
-      value: groupValue,
-      onCheckedChange: groupOnCheckedChange,
-    } = useCheckboxGroup()
+    const group = useCheckboxGroup()
     const rootRef = useRef<HTMLButtonElement | undefined>()
     const ref = useMergeRefs(forwardedRef, rootRef)
 
-    const isFieldEnclosed = field.id !== groupId
+    const name = field.name ?? group.name
+    const isRequired = field.isRequired ?? group.isRequired
+    const isInvalid = field.isInvalid ?? group.isInvalid
+    const isFieldEnclosed = field.id !== group.id
     const id = isFieldEnclosed ? field.id : undefined
     const description = isFieldEnclosed ? field.description : undefined
-    const intent = isInvalid ? 'error' : intentProp ?? groupIntent
-    const checked = groupValue && value ? groupValue.includes(value) : checkedProp
+    const intent = (() => {
+      if (isInvalid) {
+        return 'error'
+      }
+
+      return intentProp ?? group.intent
+    })()
+
+    const checked = group.value && value ? group.value.includes(value) : checkedProp
 
     const handleCheckedChange = (checked: boolean) => {
       if (onCheckedChange) {
@@ -49,8 +50,8 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
 
       const element = rootRef.current
 
-      if (groupOnCheckedChange && element?.value) {
-        groupOnCheckedChange(checked, element.value)
+      if (group.onCheckedChange && element?.value) {
+        group.onCheckedChange(checked, element.value)
       }
     }
 

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable complexity */
-
 import { useFormFieldState } from '@spark-ui/form-field'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { forwardRef, useRef } from 'react'
@@ -25,18 +23,24 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     forwardedRef
   ) => {
     const field = useFormFieldState()
-    const group = useCheckboxGroup()
+    const {
+      name = field.name,
+      isRequired = field.isRequired,
+      isInvalid = field.isInvalid,
+
+      id: groupId,
+      intent: groupIntent,
+      value: groupValue,
+      onCheckedChange: groupOnCheckedChange,
+    } = useCheckboxGroup()
     const rootRef = useRef<HTMLButtonElement | undefined>()
     const ref = useMergeRefs(forwardedRef, rootRef)
 
-    const name = field.name ?? group.name
-    const isRequired = field.isRequired ?? group.isRequired
-    const isInvalid = field.isInvalid ?? group.isInvalid
-    const isFieldEnclosed = field.id !== group.id
+    const isFieldEnclosed = field.id !== groupId
     const id = isFieldEnclosed ? field.id : undefined
     const description = isFieldEnclosed ? field.description : undefined
-    const intent = isInvalid ? 'error' : intentProp ?? group.intent
-    const checked = group.value && value ? group.value.includes(value) : checkedProp
+    const intent = isInvalid ? 'error' : intentProp ?? groupIntent
+    const checked = groupValue && value ? groupValue.includes(value) : checkedProp
 
     const handleCheckedChange = (checked: boolean) => {
       if (onCheckedChange) {
@@ -45,8 +49,8 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
 
       const element = rootRef.current
 
-      if (group.onCheckedChange && element?.value) {
-        group.onCheckedChange(checked, element.value)
+      if (groupOnCheckedChange && element?.value) {
+        groupOnCheckedChange(checked, element.value)
       }
     }
 

--- a/packages/components/form-field/src/FormField.test.tsx
+++ b/packages/components/form-field/src/FormField.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/components/icons/src/index.test.tsx
+++ b/packages/components/icons/src/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/components/input/src/Input.test.tsx
+++ b/packages/components/input/src/Input.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 import { FormField } from '@spark-ui/form-field'
 import { Icon } from '@spark-ui/icon'
 import { Check } from '@spark-ui/icons/dist/icons/Check'

--- a/packages/components/popover/src/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent.styles.ts
@@ -1,6 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 
-// eslint-disable-next-line tailwindcss/no-custom-classname
 export const styles = cva(
   [
     'rounded-md',

--- a/packages/components/radio/src/Radio.test.tsx
+++ b/packages/components/radio/src/Radio.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 import { FormField } from '@spark-ui/form-field'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/packages/components/slot/src/Slot.stories.tsx
+++ b/packages/components/slot/src/Slot.stories.tsx
@@ -46,13 +46,15 @@ export const Handlers: StoryFn = _args => {
     </Slot>
   )
 }
-/* eslint-disable tailwindcss/no-custom-classname */
+
 export const ClassNames: StoryFn = _args => {
   const [element, ref] = useDOMElementString<HTMLAnchorElement>()
 
   return (
     <div className="flex flex-col">
+      {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
       <Slot className="slotClassName">
+        {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
         <a href="/" className="childrenClassName" ref={ref}>
           Link
         </a>
@@ -61,7 +63,6 @@ export const ClassNames: StoryFn = _args => {
     </div>
   )
 }
-/* eslint-enable */
 
 export const Style: StoryFn = _args => {
   const [element, ref] = useDOMElementString<HTMLDivElement>()

--- a/packages/components/switch/src/Switch.test.tsx
+++ b/packages/components/switch/src/Switch.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-/* eslint-disable max-nested-callbacks */
 import { FormField } from '@spark-ui/form-field'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import * as SwitchPrimitive from '@radix-ui/react-switch'
 import { useFormFieldState } from '@spark-ui/form-field'
 import { Check } from '@spark-ui/icons/dist/icons/Check'

--- a/packages/components/tabs/src/Tabs.test.tsx
+++ b/packages/components/tabs/src/Tabs.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-/* eslint-disable max-nested-callbacks */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { mockResizeObserver } from 'jsdom-testing-mocks'

--- a/packages/components/tabs/src/TabsList.tsx
+++ b/packages/components/tabs/src/TabsList.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import * as RadixTabs from '@radix-ui/react-tabs'
 import { Button } from '@spark-ui/button'
 import { Icon } from '@spark-ui/icon'
@@ -134,19 +133,7 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
     return (
       <div className={wrapperStyles({ className })} ref={wrapperRef}>
         {arrows.prev !== 'hidden' && (
-          <Button
-            shape="square"
-            intent="surface"
-            size="sm"
-            className={navigationArrowStyles()}
-            onClick={handlePrevClick}
-            disabled={arrows.prev === 'disabled'}
-            aria-label="Scroll left"
-          >
-            <Icon>
-              <ArrowVerticalLeft />
-            </Icon>
-          </Button>
+          <Components.Prev handleClick={handlePrevClick} disabled={arrows.prev === 'disabled'} />
         )}
 
         <RadixTabs.List
@@ -160,23 +147,55 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
         </RadixTabs.List>
 
         {arrows.next !== 'hidden' && (
-          <Button
-            shape="square"
-            intent="surface"
-            size="sm"
-            className={navigationArrowStyles()}
-            onClick={handleNextClick}
-            disabled={arrows.next === 'disabled'}
-            aria-label="Scroll right"
-          >
-            <Icon>
-              <ArrowVerticalRight />
-            </Icon>
-          </Button>
+          <Components.Next handleClick={handleNextClick} disabled={arrows.prev === 'disabled'} />
         )}
       </div>
     )
   }
 )
+
+interface ComponentsProps {
+  NavigationBtn: {
+    handleClick: () => void
+    disabled?: boolean
+  }
+}
+
+const Components = {
+  Prev: ({ handleClick, disabled }: ComponentsProps['NavigationBtn']) => {
+    return (
+      <Button
+        shape="square"
+        intent="surface"
+        size="sm"
+        className={navigationArrowStyles()}
+        onClick={handleClick}
+        disabled={disabled}
+        aria-label="Scroll left"
+      >
+        <Icon>
+          <ArrowVerticalLeft />
+        </Icon>
+      </Button>
+    )
+  },
+  Next: ({ handleClick, disabled }: ComponentsProps['NavigationBtn']) => {
+    return (
+      <Button
+        shape="square"
+        intent="surface"
+        size="sm"
+        className={navigationArrowStyles()}
+        onClick={handleClick}
+        disabled={disabled}
+        aria-label="Scroll right"
+      >
+        <Icon>
+          <ArrowVerticalRight />
+        </Icon>
+      </Button>
+    )
+  },
+}
 
 TabsList.displayName = 'Tabs.List'

--- a/packages/components/tabs/src/TabsList.tsx
+++ b/packages/components/tabs/src/TabsList.tsx
@@ -133,7 +133,19 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
     return (
       <div className={wrapperStyles({ className })} ref={wrapperRef}>
         {arrows.prev !== 'hidden' && (
-          <Components.Prev handleClick={handlePrevClick} disabled={arrows.prev === 'disabled'} />
+          <Button
+            shape="square"
+            intent="surface"
+            size="sm"
+            className={navigationArrowStyles()}
+            onClick={handlePrevClick}
+            disabled={arrows.prev === 'disabled'}
+            aria-label="Scroll left"
+          >
+            <Icon>
+              <ArrowVerticalLeft />
+            </Icon>
+          </Button>
         )}
 
         <RadixTabs.List
@@ -147,55 +159,23 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
         </RadixTabs.List>
 
         {arrows.next !== 'hidden' && (
-          <Components.Next handleClick={handleNextClick} disabled={arrows.prev === 'disabled'} />
+          <Button
+            shape="square"
+            intent="surface"
+            size="sm"
+            className={navigationArrowStyles()}
+            onClick={handleNextClick}
+            disabled={arrows.next === 'disabled'}
+            aria-label="Scroll right"
+          >
+            <Icon>
+              <ArrowVerticalRight />
+            </Icon>
+          </Button>
         )}
       </div>
     )
   }
 )
-
-interface ComponentsProps {
-  NavigationBtn: {
-    handleClick: () => void
-    disabled?: boolean
-  }
-}
-
-const Components = {
-  Prev: ({ handleClick, disabled }: ComponentsProps['NavigationBtn']) => {
-    return (
-      <Button
-        shape="square"
-        intent="surface"
-        size="sm"
-        className={navigationArrowStyles()}
-        onClick={handleClick}
-        disabled={disabled}
-        aria-label="Scroll left"
-      >
-        <Icon>
-          <ArrowVerticalLeft />
-        </Icon>
-      </Button>
-    )
-  },
-  Next: ({ handleClick, disabled }: ComponentsProps['NavigationBtn']) => {
-    return (
-      <Button
-        shape="square"
-        intent="surface"
-        size="sm"
-        className={navigationArrowStyles()}
-        onClick={handleClick}
-        disabled={disabled}
-        aria-label="Scroll right"
-      >
-        <Icon>
-          <ArrowVerticalRight />
-        </Icon>
-      </Button>
-    )
-  },
-}
 
 TabsList.displayName = 'Tabs.List'

--- a/packages/components/tabs/src/useResizeObserver.test.ts
+++ b/packages/components/tabs/src/useResizeObserver.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 import { act, renderHook } from '@testing-library/react'
 import { mockResizeObserver } from 'jsdom-testing-mocks'
 import { describe, expect, it, vi } from 'vitest'

--- a/packages/utils/internal-utils/src/variants/index.ts
+++ b/packages/utils/internal-utils/src/variants/index.ts
@@ -1,8 +1,8 @@
 import { Picks, VariantLookup } from './types'
 
-/* eslint-disable space-before-function-paren */
 function makeVariants<
   Variant extends 'design' | 'intent' | 'shape' | 'size',
+  /* eslint-disable-next-line space-before-function-paren */
   P extends (keyof VariantLookup[Variant])[] = []
 >(
   variants: P extends [] ? VariantLookup[Variant] : Picks<VariantLookup[Variant], P>

--- a/packages/utils/tailwind-plugins/spark-theme/getCSSVariableReferences.js
+++ b/packages/utils/tailwind-plugins/spark-theme/getCSSVariableReferences.js
@@ -22,8 +22,8 @@ function getCSSVariableReferences(_theme) {
 
   const { fontSize, colors, screens } = tailwindCategoryKeys
 
-  /* eslint-disable complexity */
   function traverse(theme, paths = []) {
+    /* eslint-disable-next-line complexity */
     Object.entries(theme).forEach(([key, value]) => {
       // 👀 see: https://tailwindcss.com/docs/font-size#providing-a-default-line-height
       if (isObject(value) && !paths.length && key === fontSize) {

--- a/packages/utils/tailwind-plugins/spark-theme/hexRgb.js
+++ b/packages/utils/tailwind-plugins/spark-theme/hexRgb.js
@@ -6,7 +6,7 @@ const match6or8Hex = `#?[${hexCharacters}]{6}([${hexCharacters}]{2})?`
 const nonHexChars = new RegExp(`[^#${hexCharacters}]`, 'gi')
 const validHexSize = new RegExp(`^${match3or4Hex}$|^${match6or8Hex}$`, 'i')
 
-/* eslint-disable complexity */
+/* eslint-disable-next-line complexity */
 function hexRgb(hex, options = {}) {
   if (typeof hex !== 'string' || nonHexChars.test(hex) || !validHexSize.test(hex)) {
     throw new TypeError('Expected a valid hex string')


### PR DESCRIPTION
**TASK**: #844

### Description, Motivation and Context
In our codebase, there are several ESLint ignore comments that have been added to disable specific rules or warnings. These comments can make it harder to maintain and understand the codebase over time.

This PR remove these comments and instead address the underlying issues they are suppressing.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [ ] 💄 Styles
