### PR TITLE
fix(radio): fix and improve a11y on radio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2618,6 +2618,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -32124,6 +32136,7 @@
       "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-id": "1.0.0",
         "@radix-ui/react-label": "2.0.1",
         "@radix-ui/react-radio-group": "1.1.2",
         "@spark-ui/form-field": "^0.1.4",

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -12,6 +12,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@radix-ui/react-id": "1.0.0",
     "@radix-ui/react-label": "2.0.1",
     "@radix-ui/react-radio-group": "1.1.2",
     "@spark-ui/form-field": "^0.1.4",

--- a/packages/components/radio/src/Radio.doc.mdx
+++ b/packages/components/radio/src/Radio.doc.mdx
@@ -33,9 +33,33 @@ import { RadioGroup } from '@spark-ui/radio'
 
 ## Usage
 
-Compound `RadioGroup` and `Radio` components to create a radio group.
-
 <Canvas of={RadioStories.Default} />
+
+## Using a FormField
+
+If you need to provide more context about the Radio group (for example, a helper message or an error message) the FormField component could be used. See [documentation](./?path=/docs/experimental-formfield--docs) for more details.
+
+<Canvas of={RadioStories.WithFormField} />
+
+## Disabled
+
+<Canvas of={RadioStories.Disabled} />
+
+## Intent
+
+Use `intent` prop to set the color of every radio inside the group. Optionally, you can set the `intent` in each radio component.
+
+<Canvas of={RadioStories.Intent} />
+
+## Size
+
+Use `size` prop to set the size of every radio inside the group. Optionally, you can set the `size` in each radio component.
+
+<Canvas of={RadioStories.Size} />
+
+## Orientation
+
+<Canvas of={RadioStories.Orientation} />
 
 ## Uncontrolled
 
@@ -49,57 +73,9 @@ Use `value` and `onValueChange` props to make the radio group controlled.
 
 <Canvas of={RadioStories.Controlled} />
 
-## Disabled
-
-Use `disable` prop to disable all radios inside the group.
-
-<Canvas of={RadioStories.Disabled} />
-
-## Intent
-
-Use `intent` prop to set the color of every radio inside the group. Optionally, you can set the `intent` in each radio component.
-
-<Canvas of={RadioStories.Intent} />
-
-## Orientation
-
-Use `orientation` prop to set the orientation of the component which could be `vertical` or `horizontal`.
-
-<Canvas of={RadioStories.Orientation} />
-
-## Size
-
-Use `size` prop to set the size of every radio inside the group. Optionally, you can set the `size` in each radio component.
-
-<Canvas of={RadioStories.Size} />
-
-## Form field
-
-### Usage
-
-Use `FormField`, `FormField.Label`, `FormField.HelperMessage` and `FormField.ErrorMessage` to provide context to the radio group.
-
-<Canvas of={RadioStories.Control} />
-
-### Hidden label
-
-Use `VisuallyHidden` component to hide the label of the radio group.
-
-<Canvas of={RadioStories.HiddenLabel} />
-
-### Required
-
-Use the `isRequired` prop to indicate that the radio group is required.
-
-<Canvas of={RadioStories.Required} />
-
-### Invalid
-
-Use the `isInvalid` prop to indicate that the radio group is invalid and show the error message.
-
-<Canvas of={RadioStories.Invalid} />
-
 ## Accessibility
+
+This component should always have a label, directly declared through the `children` prop or inherited from the `FormField` wrapper. If none of those are available it is strongly recommended to define an `aria-label` attribute, to comply to accessibility requirements.
 
 Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
 

--- a/packages/components/radio/src/Radio.stories.tsx
+++ b/packages/components/radio/src/Radio.stories.tsx
@@ -76,7 +76,7 @@ const orientations: RadioGroupProps['orientation'][] = ['horizontal', 'vertical'
 
 export const Orientation: StoryFn = _args => {
   return (
-    <div className="gap-xl flex flex-col">
+    <div className="gap-xl flex">
       {orientations.map(orientation => (
         <div key={orientation}>
           <StoryLabel>{orientation}</StoryLabel>
@@ -118,72 +118,27 @@ export const Disabled: StoryFn = _args => (
   </RadioGroup>
 )
 
-export const Control: StoryFn = _args => (
-  <FormField name="condition">
-    <FormField.Label asChild>
-      <p>Apparel condition</p>
-    </FormField.Label>
+export const WithFormField: StoryFn = _args => {
+  const [value, setValue] = useState<string>()
 
-    <RadioGroup>
-      <RadioGroup.Radio value="1">New</RadioGroup.Radio>
-      <RadioGroup.Radio value="2">Very good</RadioGroup.Radio>
-      <RadioGroup.Radio value="3">Good</RadioGroup.Radio>
-      <RadioGroup.Radio value="4">Satisfactory</RadioGroup.Radio>
-    </RadioGroup>
+  const handleValueChange = (current: string) => {
+    setValue(current)
+  }
 
-    <FormField.HelperMessage>The condition that best matches your product</FormField.HelperMessage>
-
-    <FormField.ErrorMessage>The condition is required</FormField.ErrorMessage>
-  </FormField>
-)
-
-export const HiddenLabel: StoryFn = _args => (
-  <FormField name="condition">
-    <VisuallyHidden>
+  return (
+    <FormField name="condition" isRequired isInvalid={!value}>
       <FormField.Label asChild>
         <p>Apparel condition</p>
       </FormField.Label>
-    </VisuallyHidden>
 
-    <RadioGroup>
-      <RadioGroup.Radio value="1">New</RadioGroup.Radio>
-      <RadioGroup.Radio value="2">Very good</RadioGroup.Radio>
-      <RadioGroup.Radio value="3">Good</RadioGroup.Radio>
-      <RadioGroup.Radio value="4">Satisfactory</RadioGroup.Radio>
-    </RadioGroup>
-  </FormField>
-)
+      <RadioGroup value={value} onValueChange={handleValueChange}>
+        <RadioGroup.Radio value="1">New</RadioGroup.Radio>
+        <RadioGroup.Radio value="2">Very good</RadioGroup.Radio>
+        <RadioGroup.Radio value="3">Good</RadioGroup.Radio>
+        <RadioGroup.Radio value="4">Satisfactory</RadioGroup.Radio>
+      </RadioGroup>
 
-export const Required: StoryFn = _args => (
-  <FormField name="condition" isRequired>
-    <FormField.Label asChild>
-      <p>Apparel condition</p>
-    </FormField.Label>
-
-    <RadioGroup>
-      <RadioGroup.Radio value="1">New</RadioGroup.Radio>
-      <RadioGroup.Radio value="2">Very good</RadioGroup.Radio>
-      <RadioGroup.Radio value="3">Good</RadioGroup.Radio>
-      <RadioGroup.Radio value="4">Satisfactory</RadioGroup.Radio>
-    </RadioGroup>
-
-    <FormField.ErrorMessage>The condition is required</FormField.ErrorMessage>
-  </FormField>
-)
-
-export const Invalid: StoryFn = _args => (
-  <FormField name="condition" isRequired isInvalid>
-    <FormField.Label asChild>
-      <p>Apparel condition</p>
-    </FormField.Label>
-
-    <RadioGroup>
-      <RadioGroup.Radio value="1">New</RadioGroup.Radio>
-      <RadioGroup.Radio value="2">Very good</RadioGroup.Radio>
-      <RadioGroup.Radio value="3">Good</RadioGroup.Radio>
-      <RadioGroup.Radio value="4">Satisfactory</RadioGroup.Radio>
-    </RadioGroup>
-
-    <FormField.ErrorMessage>The condition is required</FormField.ErrorMessage>
-  </FormField>
-)
+      <FormField.ErrorMessage>The condition is required</FormField.ErrorMessage>
+    </FormField>
+  )
+}

--- a/packages/components/radio/src/Radio.stories.tsx
+++ b/packages/components/radio/src/Radio.stories.tsx
@@ -1,6 +1,5 @@
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { FormField } from '@spark-ui/form-field'
-import { VisuallyHidden } from '@spark-ui/visually-hidden'
 import { Meta, StoryFn } from '@storybook/react'
 import { useState } from 'react'
 

--- a/packages/components/radio/src/Radio.tsx
+++ b/packages/components/radio/src/Radio.tsx
@@ -1,3 +1,5 @@
+import { useId } from '@radix-ui/react-id'
+import { cx } from 'class-variance-authority'
 import { forwardRef } from 'react'
 
 import { useRadioGroup } from './RadioGroupContext'
@@ -7,17 +9,29 @@ import { RadioLabel } from './RadioLabel'
 export type RadioProps = RadioInputProps
 
 export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
-  ({ className, children, disabled: disabledProp, ...others }, ref) => {
-    const context = useRadioGroup()
+  ({ className, children, id, disabled: disabledProp, ...others }, ref) => {
+    const innerId = useId()
+    const innerLabelId = useId()
 
-    const { intent, size } = context
-    const disabled = disabledProp || context.disabled
+    const { intent, size, disabled } = useRadioGroup()
 
     return (
-      <RadioLabel className={className} disabled={disabled}>
-        <RadioInput ref={ref} intent={intent} size={size} {...others} />
-        {children}
-      </RadioLabel>
+      <div className={cx('flex items-center gap-md text-body-1', className)}>
+        <RadioInput
+          ref={ref}
+          id={id || innerId}
+          intent={intent}
+          size={size}
+          aria-labelledby={children ? innerLabelId : undefined}
+          {...others}
+        />
+
+        {children && (
+          <RadioLabel disabled={disabledProp || disabled} htmlFor={id || innerId} id={innerLabelId}>
+            {children}
+          </RadioLabel>
+        )}
+      </div>
     )
   }
 )

--- a/packages/components/radio/src/RadioLabel.styles.tsx
+++ b/packages/components/radio/src/RadioLabel.styles.tsx
@@ -1,17 +1,15 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
-const defaultVariants = {
-  disabled: false,
-}
-
-export const radioLabelStyles = cva(['flex', 'items-center', 'gap-md', 'text-body-1'], {
+export const radioLabelStyles = cva('', {
   variants: {
     disabled: {
       true: ['text-neutral/dim-2', 'cursor-not-allowed'],
       false: ['cursor-pointer'],
     },
   },
-  defaultVariants,
+  defaultVariants: {
+    disabled: false,
+  },
 })
 
 export type RadioLabelStylesProps = VariantProps<typeof radioLabelStyles>

--- a/packages/components/radio/src/RadioLabel.tsx
+++ b/packages/components/radio/src/RadioLabel.tsx
@@ -1,5 +1,5 @@
 import { Label } from '@radix-ui/react-label'
-import { PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 
 import { radioLabelStyles, RadioLabelStylesProps } from './RadioLabel.styles'
 
@@ -20,8 +20,8 @@ export interface RadioLabelProps
   disabled?: boolean
 }
 
-export const RadioLabel = ({ className, disabled, ...others }: RadioLabelProps) => {
-  return <Label className={radioLabelStyles({ className, disabled })} {...others} />
+export const RadioLabel = ({ disabled, ...others }: RadioLabelProps) => {
+  return <Label className={radioLabelStyles({ disabled })} {...others} />
 }
 
 RadioLabel.displayName = 'RadioGroup.RadioLabel'


### PR DESCRIPTION
**TASK**: #798 

### Description, Motivation and Context
With current DOM structure (label tag wrapping the whole content) we recently noticed a small accessibility concern, about accessible name.

Indeed, the component itself doesn't have any accessible name. This is due to component text (aka children) added as a sibling DOM node, and so not directly related. This can be confirmed using the "Axe" Chrome accessibility extension, and testing the component.

After discussions with @andresz1, @acd02 and @Powerplex we agreed:
- changing the DOM structure, to match the Radix pattern: having the label as a sibling, linked through an `htmlFor` attribute. The whole content wrapped within a neutral div, for ex.
- using `aria-label` or `aria-labelledby` based on use case

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧾 Documentation
- [x] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
**Before:**
![Capture d’écran du 2023-06-01 10-24-37](https://github.com/adevinta/spark/assets/66770550/06aafb61-4e71-4e0d-9fc7-e452329722dd)

**After:**
![Capture d’écran du 2023-06-01 10-24-06](https://github.com/adevinta/spark/assets/66770550/b97826d4-5be1-45e3-ace0-00d60d58985f)
