### PR TITLE
style(tag): synced styles with figma for outlined design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2483,6 +2483,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,

--- a/packages/components/tag/src/Tag.doc.mdx
+++ b/packages/components/tag/src/Tag.doc.mdx
@@ -46,3 +46,9 @@ Use `intent` prop to set the color intent of a tag.
 Use `shape` prop to set the shape of a tag.
 
 <Canvas of={TagStories.Shapes} />
+
+## Icons
+
+Compose the content of the tag using the `Icon` component to add an icon to the left or right.
+
+<Canvas of={TagStories.Icons} />

--- a/packages/components/tag/src/Tag.stories.tsx
+++ b/packages/components/tag/src/Tag.stories.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@spark-ui/icon'
+import { Check } from '@spark-ui/icons/dist/icons/Check'
 import { Meta, StoryFn } from '@storybook/react'
 import { type ComponentProps } from 'react'
 
@@ -27,7 +29,7 @@ const shapes: TagProps['shape'][] = ['rounded', 'square', 'pill']
 export const Default: StoryFn = _args => <Tag>Default tag</Tag>
 
 export const Design: StoryFn = _args => (
-  <div className="gap-md flex flex-row">
+  <div className="flex flex-row gap-md">
     {designs.map(design => (
       <Tag key={design} design={design}>
         {design} tag
@@ -37,7 +39,7 @@ export const Design: StoryFn = _args => (
 )
 
 export const Intent: StoryFn = _args => (
-  <div className="gap-md flex flex-row">
+  <div className="flex flex-row gap-md">
     {intents.map(intent => (
       <Tag key={intent} intent={intent}>
         {intent} tag
@@ -47,7 +49,7 @@ export const Intent: StoryFn = _args => (
 )
 
 export const Shapes: StoryFn = _args => (
-  <div className="gap-md flex items-center">
+  <div className="flex items-center gap-md">
     {shapes.map(shape => {
       return (
         <Tag key={shape} shape={shape}>
@@ -55,5 +57,22 @@ export const Shapes: StoryFn = _args => (
         </Tag>
       )
     })}
+  </div>
+)
+
+export const Icons: StoryFn = _args => (
+  <div className="flex flex-wrap gap-md">
+    <Tag>
+      Button
+      <Icon>
+        <Check />
+      </Icon>
+    </Tag>
+    <Tag>
+      <Icon>
+        <Check />
+      </Icon>
+      Button
+    </Tag>
   </div>
 )

--- a/packages/components/tag/src/Tag.styles.tsx
+++ b/packages/components/tag/src/Tag.styles.tsx
@@ -5,7 +5,7 @@ import { filledVariants, outlinedVariants, tintedVariants } from './variants'
 
 export const tagStyles = cva(
   [
-    'gap-md box-border inline-flex items-center justify-center whitespace-nowrap',
+    'box-border inline-flex items-center justify-center gap-sm whitespace-nowrap',
     'text-caption font-bold',
     'h-sz-20 px-md',
     'ring-inset',
@@ -17,14 +17,14 @@ export const tagStyles = cva(
        *
        * - `filled`: Tag will be plain.
        *
-       * - `outlined`: Tag will be transparent with an outline.
+       * - `outlined`: Tag will have a surface background with an colored outline/text.
        *
        * - `tinted`: Tag will be filled but using a lighter color scheme.
        *
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted']>({
         filled: [],
-        outlined: ['bg-transparent', 'ring-2', 'ring-current'],
+        outlined: ['bg-surface', 'ring-1', 'ring-current'],
         tinted: [],
       }),
       /**


### PR DESCRIPTION
### Task
#913 

### Description, Motivation and Context

Design updates to be synced with Figma: https://www.figma.com/file/NsGfE3UnbhEyAPpVf3B60P/Spark-Components?type=design&node-id=14-3762&t=yL9keRLExfQd0LlZ-4

- outline border goes from 2px to 1px width.
- outline background color goes from `transparent` to `surface`

### Types of changes
- [x] 💄 Styles
