### PR TITLE
docs: enable description for subComponents tables

### DIFF
--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -1,33 +1,55 @@
 import { Tabs } from '@spark-ui/tabs'
 import { ArgTypes as StorybookArgTypes } from '@storybook/blocks'
-import type { FC } from 'react'
+import { type FC, type ReactNode } from 'react'
 
 interface Props<T> {
-  of?: T
-  subcomponents?: Record<string, T>
+  of: T
+  description?: string
+  subcomponents?: Record<string, any> | null
 }
 
-export const ArgTypes = <T extends FC>({ of, subcomponents = {} }: Props<T>) => {
-  const components = {
-    [of?.displayName as string]: of,
-    ...subcomponents,
-  }
+const ComponentDescription = ({ children }: { children: ReactNode }) => {
+  return (
+    <p className="rounded-md bg-primary-container px-lg py-md text-body-2 text-on-primary-container">
+      {children}
+    </p>
+  )
+}
+
+export const ArgTypes = <T extends FC>({ of, description, subcomponents = null }: Props<T>) => {
+  if (!subcomponents) return <StorybookArgTypes of={of} />
+
+  const { displayName: name = 'Root' } = of // "Root" in case the root component is missing a displayName
+  const subComponentsList = Object.entries(subcomponents)
 
   return (
-    <Tabs defaultValue={of?.displayName} orientation="vertical" className="sb-unstyled mt-xl">
+    <Tabs defaultValue={name} orientation="vertical" className="sb-unstyled mt-xl">
       <Tabs.List>
-        {Object.keys(components).map(name => (
-          <Tabs.Trigger key={name} value={name}>
-            {name}
-          </Tabs.Trigger>
-        ))}
+        <Tabs.Trigger key={name} value={name}>
+          {name}
+        </Tabs.Trigger>
+        <>
+          {subComponentsList.map(([name]) => (
+            <Tabs.Trigger key={name} value={name}>
+              {name}
+            </Tabs.Trigger>
+          ))}
+        </>
       </Tabs.List>
 
-      {Object.entries(components).map(([name, component]) => (
-        <Tabs.Content key={name} value={name} className="py-none">
-          <StorybookArgTypes of={component} />
-        </Tabs.Content>
-      ))}
+      <Tabs.Content key={name} value={name} className="py-none">
+        {description && <ComponentDescription>{description}</ComponentDescription>}
+        <StorybookArgTypes of={of} />
+      </Tabs.Content>
+
+      {subComponentsList.map(([name, { of, description }]) => {
+        return (
+          <Tabs.Content key={name} value={name} className="py-none">
+            {description && <ComponentDescription>{description}</ComponentDescription>}
+            <StorybookArgTypes of={of} />
+          </Tabs.Content>
+        )
+      })}
     </Tabs>
   )
 }

--- a/packages/components/form-field/src/FormField.doc.mdx
+++ b/packages/components/form-field/src/FormField.doc.mdx
@@ -28,13 +28,13 @@ import { FormField } from '@spark-ui/form-control'
 <ArgTypes
   of={FormField}
   subcomponents={{
-    'FormField.Label': FormField.Label,
-    'FormField.HelperMessage': FormField.HelperMessage,
-    'FormField.SuccessMessage': FormField.SuccessMessage,
-    'FormField.AlertMessage': FormField.AlertMessage,
-    'FormField.ErrorMessage': FormField.ErrorMessage,
-    'FormField.Control': FormField.Control,
-    'FormField.RequiredIndicator': FormField.RequiredIndicator,
+    'FormField.Label': { of: FormField.Label },
+    'FormField.HelperMessage': { of: FormField.HelperMessage },
+    'FormField.SuccessMessage': { of: FormField.SuccessMessage },
+    'FormField.AlertMessage': { of: FormField.AlertMessage },
+    'FormField.ErrorMessage': { of: FormField.ErrorMessage },
+    'FormField.Control': { of: FormField.Control },
+    'FormField.RequiredIndicator': { of: FormField.RequiredIndicator },
   }}
 />
 

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -65,10 +65,10 @@ Use `InputGroup` component to group your input with addons and elements like ico
 <ExtendedArgTypes
   of={InputGroup}
   subcomponents={{
-    'InputGroup.LeftAddon': InputGroup.LeftAddon,
-    'InputGroup.LeftElement': InputGroup.LeftElement,
-    'InputGroup.RightAddon': InputGroup.RightAddon,
-    'InputGroup.RightElement': InputGroup.RightElement,
+    'InputGroup.LeftAddon': { of: InputGroup.LeftAddon },
+    'InputGroup.LeftElement': { of: InputGroup.LeftElement },
+    'InputGroup.RightAddon': { of: InputGroup.RightAddon },
+    'InputGroup.RightElement': { of: InputGroup.RightElement },
   }}
 />
 

--- a/packages/components/label/src/Label.doc.mdx
+++ b/packages/components/label/src/Label.doc.mdx
@@ -25,8 +25,13 @@ import { Label } from '@spark-ui/label'
 
 <ArgTypes
   of={Label}
+  description="A label that can be used to describe a field"
   subcomponents={{
-    'Label.RequiredIndicator': Label.RequiredIndicator,
+    'Label.RequiredIndicator': {
+      of: Label.RequiredIndicator,
+      description:
+        'An optional indicator to display a field as required. Must be rendered inside Label.',
+    },
   }}
 />
 

--- a/packages/components/popover/src/Popover.doc.mdx
+++ b/packages/components/popover/src/Popover.doc.mdx
@@ -27,14 +27,40 @@ import { Popover } from '@spark-ui/popover'
 
 <ArgTypes
   of={Popover}
+  description="Contains all the parts of a popover."
   subcomponents={{
-    'Popover.Trigger': Popover.Trigger,
-    'Popover.Anchor': Popover.Anchor,
-    'Popover.Portal': Popover.Portal,
-    'Popover.Content': Popover.Content,
-    'Popover.Header': Popover.Header,
-    'Popover.CloseButton': Popover.CloseButton,
-    'Popover.Arrow': Popover.Arrow,
+    'Popover.Trigger': {
+      of: Popover.Trigger,
+      description:
+        'The button that toggles the popover. By default, the Popover.Content will position itself against the trigger.',
+    },
+    'Popover.Anchor': {
+      of: Popover.Anchor,
+      description:
+        'An optional element to position the Popover.Content against. If this part is not used, the content will position alongside the Popover.Trigger.',
+    },
+    'Popover.Portal': {
+      of: Popover.Portal,
+      description: 'When used, portals the content part into the body.',
+    },
+    'Popover.Content': {
+      of: Popover.Content,
+      description: 'The component that pops out when the popover is open.',
+    },
+    'Popover.Header': {
+      of: Popover.Header,
+      description:
+        'Header for the popover content. Also serve as an accessible name for the Popover. Must be rendered inside Popover.Content.',
+    },
+    'Popover.CloseButton': {
+      of: Popover.CloseButton,
+      description: 'The button that closes an open popover.',
+    },
+    'Popover.Arrow': {
+      of: Popover.Arrow,
+      description:
+        'An optional arrow element to render alongside the popover. This can be used to help visually link the anchor with the Popover.Content. Must be rendered inside Popover.Content.',
+    },
   }}
 />
 

--- a/packages/components/radio-group/src/RadioGroup.doc.mdx
+++ b/packages/components/radio-group/src/RadioGroup.doc.mdx
@@ -26,8 +26,12 @@ import { RadioGroup } from '@spark-ui/radio-group'
 
 <ArgTypes
   of={RadioGroup}
+  description="Contains all the parts of a radio group."
   subcomponents={{
-    'RadioGroup.Radio': RadioGroup.Radio,
+    'RadioGroup.Radio': {
+      of: RadioGroup.Radio,
+      description: 'An item in the group that can be checked.',
+    },
   }}
 />
 

--- a/packages/components/tabs/src/Tabs.doc.mdx
+++ b/packages/components/tabs/src/Tabs.doc.mdx
@@ -25,10 +25,20 @@ import { Tabs } from "@spark-ui/tabs"
 
 <ArgTypes
   of={Tabs}
+  description="Contains all the tabs component parts."
   subcomponents={{
-    'Tabs.List': Tabs.List,
-    'Tabs.Trigger': Tabs.Trigger,
-    'Tabs.Content': Tabs.Content,
+    'Tabs.List': {
+      of: Tabs.List,
+      description: 'Contains the triggers that are aligned along the edge of the active content.',
+    },
+    'Tabs.Trigger': {
+      of: Tabs.Trigger,
+      description: 'The button that activates its associated content.',
+    },
+    'Tabs.Content': {
+      of: Tabs.Content,
+      description: 'Contains the content associated with each trigger.',
+    },
   }}
 />
 


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #941 

### Description, Motivation and Context

Feedback from a feature team trying to use Form components (TextField, etc) is that it's not clear what is the role of each subComponent. I was thinking we could start by adding description in the argTypes table for each subComponent to make it more clear.

### Types of changes
- [x] 🧾 Documentation


### Screenshots - Animations
![Capture d’écran 2023-06-23 à 16 09 22](https://github.com/adevinta/spark/assets/2033710/488c6ec4-454b-43fb-b759-50db848bc9ec)

