### PR TITLE
fix(button): fix hover styles not being applied correctly when using the 'asChild' prop on button

### DIFF
--- a/packages/components/button/src/variants/contrast.ts
+++ b/packages/components/button/src/variants/contrast.ts
@@ -6,7 +6,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-primary',
-      'enabled:hover:bg-primary-container-hovered',
+      'hover:bg-primary-container-hovered',
       'enabled:active:bg-primary-container-pressed',
       'focus-visible:bg-primary-container-focused',
     ]),
@@ -16,7 +16,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-secondary',
-      'enabled:hover:bg-secondary-container-hovered',
+      'hover:bg-secondary-container-hovered',
       'enabled:active:bg-secondary-container-pressed',
       'focus-visible:bg-secondary-container-focused',
     ]),
@@ -26,7 +26,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-success',
-      'enabled:hover:bg-success-container-hovered',
+      'hover:bg-success-container-hovered',
       'enabled:active:bg-success-container-pressed',
       'focus-visible:bg-success-container-focused',
     ]),
@@ -36,7 +36,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-alert',
-      'enabled:hover:bg-alert-container-hovered',
+      'hover:bg-alert-container-hovered',
       'enabled:active:bg-alert-container-pressed',
       'focus-visible:bg-alert-container-focused',
     ]),
@@ -46,7 +46,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-error',
-      'enabled:hover:bg-error-container-hovered',
+      'hover:bg-error-container-hovered',
       'enabled:active:bg-error-container-pressed',
       'focus-visible:bg-error-container-focused',
     ]),
@@ -56,7 +56,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-info',
-      'enabled:hover:bg-info-container-hovered',
+      'hover:bg-info-container-hovered',
       'enabled:active:bg-info-container-pressed',
       'focus-visible:bg-info-container-focused',
     ]),
@@ -66,7 +66,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-neutral',
-      'enabled:hover:bg-neutral-container-hovered',
+      'hover:bg-neutral-container-hovered',
       'enabled:active:bg-neutral-container-pressed',
       'focus-visible:bg-neutral-container-focused',
     ]),
@@ -76,7 +76,7 @@ export const contrastVariants = [
     design: 'contrast',
     class: tw([
       'text-on-surface',
-      'enabled:hover:bg-surface-hovered',
+      'hover:bg-surface-hovered',
       'enabled:active:bg-surface-pressed',
       'focus-visible:bg-surface-focused',
     ]),

--- a/packages/components/button/src/variants/filled.ts
+++ b/packages/components/button/src/variants/filled.ts
@@ -8,7 +8,7 @@ export const filledVariants = [
     class: tw([
       'bg-primary',
       'text-on-primary',
-      'enabled:hover:bg-primary-hovered',
+      'hover:bg-primary-hovered',
       'enabled:active:bg-primary-pressed',
       'focus-visible:bg-primary-focused',
     ]),
@@ -20,7 +20,7 @@ export const filledVariants = [
     class: tw([
       'bg-secondary',
       'text-on-secondary',
-      'enabled:hover:bg-secondary-hovered',
+      'hover:bg-secondary-hovered',
       'enabled:active:bg-secondary-pressed',
       'focus-visible:bg-secondary-focused',
     ]),
@@ -32,7 +32,7 @@ export const filledVariants = [
     class: tw([
       'bg-success',
       'text-on-success',
-      'enabled:hover:bg-success-hovered',
+      'hover:bg-success-hovered',
       'enabled:active:bg-success-pressed',
       'focus-visible:bg-success-focused',
     ]),
@@ -44,7 +44,7 @@ export const filledVariants = [
     class: tw([
       'bg-alert',
       'text-on-alert',
-      'enabled:hover:bg-alert-hovered',
+      'hover:bg-alert-hovered',
       'enabled:active:bg-alert-pressed',
       'focus-visible:bg-alert-focused',
     ]),
@@ -55,7 +55,7 @@ export const filledVariants = [
     design: 'filled',
     class: tw([
       'text-on-error bg-error',
-      'enabled:hover:bg-error-hovered enabled:active:bg-error-pressed',
+      'hover:bg-error-hovered enabled:active:bg-error-pressed',
       'focus-visible:bg-error-focused',
     ]),
   },
@@ -65,7 +65,7 @@ export const filledVariants = [
     design: 'filled',
     class: tw([
       'text-on-error bg-info',
-      'enabled:hover:bg-info-hovered enabled:active:bg-info-pressed',
+      'hover:bg-info-hovered enabled:active:bg-info-pressed',
       'focus-visible:bg-info-focused',
     ]),
   },
@@ -76,7 +76,7 @@ export const filledVariants = [
     class: tw([
       'bg-neutral',
       'text-on-neutral',
-      'enabled:hover:bg-neutral-hovered',
+      'hover:bg-neutral-hovered',
       'enabled:active:bg-neutral-pressed',
       'focus-visible:bg-neutral-focused',
     ]),
@@ -88,7 +88,7 @@ export const filledVariants = [
     class: tw([
       'bg-surface',
       'text-on-surface',
-      'enabled:hover:bg-surface-hovered',
+      'hover:bg-surface-hovered',
       'enabled:active:bg-surface-pressed',
       'focus-visible:bg-surface-focused',
     ]),

--- a/packages/components/button/src/variants/ghost.ts
+++ b/packages/components/button/src/variants/ghost.ts
@@ -6,7 +6,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-primary',
-      'enabled:hover:bg-primary/dim-5',
+      'hover:bg-primary/dim-5',
       'enabled:active:bg-primary/dim-5',
       'focus-visible:bg-primary/dim-5',
     ]),
@@ -16,7 +16,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-secondary',
-      'enabled:hover:bg-secondary/dim-5',
+      'hover:bg-secondary/dim-5',
       'enabled:active:bg-secondary/dim-5',
       'focus-visible:bg-secondary/dim-5',
     ]),
@@ -26,7 +26,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-success',
-      'enabled:hover:bg-success/dim-5',
+      'hover:bg-success/dim-5',
       'enabled:active:bg-success/dim-5',
       'focus-visible:bg-success/dim-5',
     ]),
@@ -36,7 +36,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-alert',
-      'enabled:hover:bg-alert/dim-5',
+      'hover:bg-alert/dim-5',
       'enabled:active:bg-alert/dim-5',
       'focus-visible:bg-alert/dim-5',
     ]),
@@ -46,7 +46,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-error',
-      'enabled:hover:bg-error/dim-5',
+      'hover:bg-error/dim-5',
       'enabled:active:bg-error/dim-5',
       'focus-visible:bg-error/dim-5',
     ]),
@@ -56,7 +56,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-info',
-      'enabled:hover:bg-info/dim-5',
+      'hover:bg-info/dim-5',
       'enabled:active:bg-info/dim-5',
       'focus-visible:bg-info/dim-5',
     ]),
@@ -66,7 +66,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-neutral',
-      'enabled:hover:bg-neutral/dim-5',
+      'hover:bg-neutral/dim-5',
       'enabled:active:bg-neutral/dim-5',
       'focus-visible:bg-neutral/dim-5',
     ]),
@@ -76,7 +76,7 @@ export const ghostVariants = [
     design: 'ghost',
     class: tw([
       'text-surface',
-      'enabled:hover:bg-surface/dim-5',
+      'hover:bg-surface/dim-5',
       'enabled:active:bg-surface/dim-5',
       'focus-visible:bg-surface/dim-5',
     ]),

--- a/packages/components/button/src/variants/outlined.ts
+++ b/packages/components/button/src/variants/outlined.ts
@@ -5,7 +5,7 @@ export const outlinedVariants = [
     intent: 'primary',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-primary/dim-5',
+      'hover:bg-primary/dim-5',
       'enabled:active:bg-primary/dim-5',
       'focus-visible:bg-primary/dim-5',
       'text-primary',
@@ -15,7 +15,7 @@ export const outlinedVariants = [
     intent: 'secondary',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-secondary/dim-5',
+      'hover:bg-secondary/dim-5',
       'enabled:active:bg-secondary/dim-5',
       'focus-visible:bg-secondary/dim-5',
       'text-secondary',
@@ -25,7 +25,7 @@ export const outlinedVariants = [
     intent: 'success',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-success/dim-5',
+      'hover:bg-success/dim-5',
       'enabled:active:bg-success/dim-5',
       'focus-visible:bg-success/dim-5',
       'text-success',
@@ -35,7 +35,7 @@ export const outlinedVariants = [
     intent: 'alert',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-alert/dim-5',
+      'hover:bg-alert/dim-5',
       'enabled:active:bg-alert/dim-5',
       'focus-visible:bg-alert/dim-5',
       'text-alert',
@@ -45,7 +45,7 @@ export const outlinedVariants = [
     intent: 'danger',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-error/dim-5',
+      'hover:bg-error/dim-5',
       'enabled:active:bg-error/dim-5',
       'focus-visible:bg-error/dim-5',
       'text-error',
@@ -55,7 +55,7 @@ export const outlinedVariants = [
     intent: 'info',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-info/dim-5',
+      'hover:bg-info/dim-5',
       'enabled:active:bg-info/dim-5',
       'focus-visible:bg-info/dim-5',
       'text-info',
@@ -65,7 +65,7 @@ export const outlinedVariants = [
     intent: 'neutral',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-neutral/dim-5',
+      'hover:bg-neutral/dim-5',
       'enabled:active:bg-neutral/dim-5',
       'focus-visible:bg-neutral/dim-5',
       'text-neutral',
@@ -75,7 +75,7 @@ export const outlinedVariants = [
     intent: 'surface',
     design: 'outlined',
     class: tw([
-      'enabled:hover:bg-surface/dim-5',
+      'hover:bg-surface/dim-5',
       'enabled:active:bg-surface/dim-5',
       'focus-visible:bg-surface/dim-5',
       'text-surface',

--- a/packages/components/button/src/variants/tinted.ts
+++ b/packages/components/button/src/variants/tinted.ts
@@ -7,7 +7,7 @@ export const tintedVariants = [
     class: tw([
       'bg-primary-container',
       'text-on-primary-container',
-      'enabled:hover:bg-primary-container-hovered',
+      'hover:bg-primary-container-hovered',
       'enabled:active:bg-primary-container-pressed',
       'focus-visible:bg-primary-container-focused',
     ]),
@@ -18,7 +18,7 @@ export const tintedVariants = [
     class: tw([
       'bg-secondary-container',
       'text-on-secondary-container',
-      'enabled:hover:bg-secondary-container-hovered',
+      'hover:bg-secondary-container-hovered',
       'enabled:active:bg-secondary-container-pressed',
       'focus-visible:bg-secondary-container-focused',
     ]),
@@ -29,7 +29,7 @@ export const tintedVariants = [
     class: tw([
       'bg-success-container',
       'text-on-success-container',
-      'enabled:hover:bg-success-container-hovered',
+      'hover:bg-success-container-hovered',
       'enabled:active:bg-success-container-pressed',
       'focus-visible:bg-success-container-focused',
     ]),
@@ -40,7 +40,7 @@ export const tintedVariants = [
     class: tw([
       'bg-alert-container',
       'text-on-alert-container',
-      'enabled:hover:bg-alert-container-hovered',
+      'hover:bg-alert-container-hovered',
       'enabled:active:bg-alert-container-pressed',
       'focus-visible:bg-alert-container-focused',
     ]),
@@ -51,7 +51,7 @@ export const tintedVariants = [
     class: tw([
       'bg-error-container',
       'text-on-error-container',
-      'enabled:hover:bg-error-container-hovered',
+      'hover:bg-error-container-hovered',
       'enabled:active:bg-error-container-pressed',
       'focus-visible:bg-error-container-focused',
     ]),
@@ -62,7 +62,7 @@ export const tintedVariants = [
     class: tw([
       'bg-info-container',
       'text-on-info-container',
-      'enabled:hover:bg-info-container-hovered',
+      'hover:bg-info-container-hovered',
       'enabled:active:bg-info-container-pressed',
       'focus-visible:bg-info-container-focused',
     ]),
@@ -73,7 +73,7 @@ export const tintedVariants = [
     class: tw([
       'bg-neutral-container',
       'text-on-neutral-container',
-      'enabled:hover:bg-neutral-container-hovered',
+      'hover:bg-neutral-container-hovered',
       'enabled:active:bg-neutral-container-pressed',
       'focus-visible:bg-neutral-container-focused',
     ]),
@@ -84,7 +84,7 @@ export const tintedVariants = [
     class: tw([
       'bg-surface',
       'text-on-surface',
-      'enabled:hover:bg-surface-hovered',
+      'hover:bg-surface-hovered',
       'enabled:active:bg-surface-pressed',
       'focus-visible:bg-surface-focused',
     ]),


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #950

### Description, Motivation and Context
Fix hover styles not being applied correctly when using the 'asChild' prop on Button due to ":enabled" [pseudo-class](https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled) not working with child divs or "a" tags

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
