### PR TITLE
docs: add ids to faq helper items for easier url sharing and navigation

### DIFF
--- a/documentation/helpers/FAQ/Question.tsx
+++ b/documentation/helpers/FAQ/Question.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+
 import { useFAQItemContext } from './context'
 
 interface Props {
@@ -6,12 +8,31 @@ interface Props {
 
 export function Question({ label }: Props) {
   const { state, dispatch } = useFAQItemContext()
+  const btnRef = useRef<HTMLButtonElement>(null)
+
+  const slugifiedLabel = utils.slugify(label)
+
+  function handleClick() {
+    dispatch({ type: 'TOGGLE_OPEN' })
+
+    if (!window.top) return
+    window.top.location.hash = slugifiedLabel
+  }
+
+  useEffect(() => {
+    if (!btnRef.current || window.top?.location.hash !== `#${slugifiedLabel}`) return
+
+    dispatch({ type: 'TOGGLE_OPEN' })
+    btnRef.current.scrollIntoView({ behavior: 'smooth' })
+  }, [])
 
   return (
     <dt className="py-lg">
       <button
-        className="flex w-full items-start justify-between"
-        onClick={() => dispatch({ type: 'TOGGLE_OPEN' })}
+        ref={btnRef}
+        id={slugifiedLabel}
+        className="flex w-full scroll-mt-lg items-start justify-between"
+        onClick={handleClick}
       >
         <span className="flex basis-11/12 font-bold">{label}</span>
         <span className="h-sz-20 w-sz-20">
@@ -20,6 +41,15 @@ export function Question({ label }: Props) {
       </button>
     </dt>
   )
+}
+
+const utils = {
+  slugify(str: string) {
+    return str
+      .replace(/[^a-z0-9 ]/gi, '')
+      .toLowerCase()
+      .replace(/ /g, '-')
+  },
 }
 
 const Components = {


### PR DESCRIPTION
Add IDs to FAQ helper items for easier URL sharing and navigation

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #964

### Description, Motivation and Context
improve the FAQ helper component by adding an ID to each item. This will allow users to share a URL and go (scroll) straight to the desired question.

### Types of changes
- [x] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
