### PR TITLE
feat(input): add read only styles

### DIFF
--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -50,6 +50,12 @@ Use `disabled` prop to indicate the input is disabled.
 
 <Canvas of={stories.Disabled} />
 
+## Read Only
+
+Use `readOnly` prop to indicate the input is only readable.
+
+<Canvas of={stories.ReadOnly} />
+
 ## Intent
 
 Use `intent` prop to change the color of the input.

--- a/packages/components/input/src/Input.stories.tsx
+++ b/packages/components/input/src/Input.stories.tsx
@@ -20,11 +20,11 @@ export const Default: StoryFn = _args => (
 )
 
 export const Uncontrolled: StoryFn = _args => (
-  <Input defaultValue="IPhone 12" aria-label="Phone type" />
+  <Input defaultValue="iPhone 12" aria-label="Phone type" />
 )
 
 export const Controlled: StoryFn = () => {
-  const [value, setValue] = useState('IPhone 13')
+  const [value, setValue] = useState('iPhone 13')
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value)
@@ -34,7 +34,11 @@ export const Controlled: StoryFn = () => {
 }
 
 export const Disabled: StoryFn = _args => (
-  <Input defaultValue="IPhone" disabled aria-label="Phone type" />
+  <Input defaultValue="iPhone" disabled aria-label="Phone type" />
+)
+
+export const ReadOnly: StoryFn = _args => (
+  <Input defaultValue="iPhone" readOnly aria-label="Phone type" />
 )
 
 const intents: InputProps['intent'][] = ['neutral', 'success', 'alert', 'error']

--- a/packages/components/input/src/Input.styles.tsx
+++ b/packages/components/input/src/Input.styles.tsx
@@ -22,13 +22,17 @@ export const inputStyles = cva(
         alert: ['border-alert', 'ring-alert'],
         error: ['border-error', 'ring-error'],
       },
+      isDisabled: {
+        true: ['bg-on-surface/dim-5', 'text-on-surface/dim-3', 'cursor-not-allowed'],
+        false: [],
+      },
+      isReadOnly: {
+        true: ['bg-on-surface/dim-5', 'cursor-text'],
+        false: [],
+      },
       isHovered: {
         true: [],
         false: [],
-      },
-      isDisabled: {
-        true: ['bg-on-surface/dim-5', 'text-on-surface/dim-3', 'cursor-not-allowed'],
-        false: ['bg-surface', 'text-on-surface'],
       },
       isLeftElementVisible: {
         true: [],
@@ -48,6 +52,11 @@ export const inputStyles = cva(
       },
     },
     compoundVariants: [
+      {
+        isDisabled: false,
+        isReadOnly: false,
+        class: ['bg-surface', 'text-on-surface'],
+      },
       {
         intent: 'neutral',
         isDisabled: true,

--- a/packages/components/input/src/Input.test.tsx
+++ b/packages/components/input/src/Input.test.tsx
@@ -24,7 +24,7 @@ describe('Input', () => {
 
     const inputEl = screen.getByDisplayValue(defaultValue)
 
-    const value = 'Iphone 12'
+    const value = 'iPhone 12'
 
     await userEvent.clear(inputEl)
     await userEvent.type(inputEl, value)
@@ -41,7 +41,7 @@ describe('Input', () => {
 
     const inputEl = screen.getByDisplayValue(value)
 
-    const current = 'Iphone 12'
+    const current = 'iPhone 12'
 
     await userEvent.clear(inputEl)
     await userEvent.type(inputEl, current)
@@ -56,10 +56,23 @@ describe('Input', () => {
 
     const inputEl = screen.getByPlaceholderText(placeholder)
 
-    await userEvent.type(inputEl, 'Iphone 12')
+    await userEvent.type(inputEl, 'iPhone 12')
 
     expect(inputEl).not.toHaveValue()
     expect(inputEl).toBeDisabled()
+  })
+
+  it('should not change value when is read only', async () => {
+    const placeholder = 'Smartphone'
+
+    render(<Input placeholder={placeholder} readOnly />)
+
+    const inputEl = screen.getByPlaceholderText(placeholder)
+
+    await userEvent.type(inputEl, 'iPhone 12')
+
+    expect(inputEl).not.toHaveValue()
+    expect(inputEl).toHaveAttribute('readonly')
   })
 
   it('should render addons within group', () => {

--- a/packages/components/input/src/Input.tsx
+++ b/packages/components/input/src/Input.tsx
@@ -16,6 +16,7 @@ export interface InputProps
     Omit<
       InputStylesProps,
       | 'isDisabled'
+      | 'isReadOnly'
       | 'isLeftAddonVisible'
       | 'isRightAddonVisible'
       | 'isLeftElementVisible'
@@ -30,6 +31,7 @@ export const Input = forwardRef<HTMLInputElement, PropsWithChildren<InputProps>>
       className,
       intent: intentProp = 'neutral',
       disabled: disabledProp = false,
+      readOnly = false,
       asChild,
       onFocus,
       onBlur,
@@ -104,12 +106,14 @@ export const Input = forwardRef<HTMLInputElement, PropsWithChildren<InputProps>>
           intent,
           isHovered: !!isHovered,
           isDisabled: !!isDisabled,
+          isReadOnly: !!readOnly,
           isLeftAddonVisible: !!isLeftAddonVisible,
           isRightAddonVisible: !!isRightAddonVisible,
           isLeftElementVisible: !!isLeftElementVisible,
           isRightElementVisible: !!isRightElementVisible,
         })}
         disabled={isDisabled}
+        readOnly={readOnly}
         required={isRequired}
         aria-describedby={description}
         aria-invalid={isInvalid}


### PR DESCRIPTION
## feat(inout): add read only styles

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #886

### Description, Motivation and Context
Add read only styles to the current `Input` component (not for the `TextField` yet).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Screenshots - Animations
<img width="1072" alt="read only" src="https://github.com/adevinta/spark/assets/2622119/a5bd122f-a060-425d-8e12-f55999429d8b">
