### PR TITLE
style(checkbox): resync sizing according to design specs

### DIFF
--- a/packages/components/checkbox/src/CheckboxGroup.styles.ts
+++ b/packages/components/checkbox/src/CheckboxGroup.styles.ts
@@ -1,10 +1,10 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
-export const checkboxGroupStyles = cva(['flex', 'gap-lg'], {
+export const checkboxGroupStyles = cva(['flex'], {
   variants: {
     orientation: {
-      vertical: ['flex-col'],
-      horizontal: [],
+      vertical: ['flex-col', 'gap-lg'],
+      horizontal: ['gap-xl'],
     },
   },
 })

--- a/packages/components/checkbox/src/CheckboxInput.styles.ts
+++ b/packages/components/checkbox/src/CheckboxInput.styles.ts
@@ -3,7 +3,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const checkboxInputStyles = cva(
   [
-    'box-content h-sz-16 w-sz-16 items-center justify-center rounded-sm border-md bg-transparent outline-none',
+    'h-sz-24 w-sz-24 items-center justify-center rounded-sm border-md bg-transparent outline-none',
     'spark-disabled:cursor-not-allowed spark-disabled:opacity-dim-3 spark-disabled:hover:ring-0',
     'focus-visible:ring-2 focus-visible:ring-outline-high',
     'hover:border-primary-container hover:ring-2',


### PR DESCRIPTION
**TASK**: #975 

### Description, Motivation and Context
After reviewing Design specs it appeared that Checkbox size wasn't compliant. We want to fix this.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/9a24e873-5a06-4725-8ade-e256719caf61)

