### PR TITLE
style(radio-group): resync according to design specs

### DIFF
--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -13,7 +13,7 @@ export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
     const innerId = useId()
     const innerLabelId = useId()
 
-    const { intent, size, disabled } = useRadioGroup()
+    const { intent, disabled } = useRadioGroup()
 
     return (
       <div className={cx('flex items-center gap-md text-body-1', className)}>
@@ -21,7 +21,6 @@ export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
           ref={ref}
           id={id || innerId}
           intent={intent}
-          size={size}
           aria-labelledby={children ? innerLabelId : undefined}
           {...others}
         />

--- a/packages/components/radio-group/src/RadioGroup.doc.mdx
+++ b/packages/components/radio-group/src/RadioGroup.doc.mdx
@@ -55,12 +55,6 @@ Use `intent` prop to set the color of every radio inside the group. Optionally, 
 
 <Canvas of={RadioStories.Intent} />
 
-## Size
-
-Use `size` prop to set the size of every radio inside the group. Optionally, you can set the `size` in each radio component.
-
-<Canvas of={RadioStories.Size} />
-
 ## Orientation
 
 <Canvas of={RadioStories.Orientation} />

--- a/packages/components/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/components/radio-group/src/RadioGroup.stories.tsx
@@ -90,25 +90,6 @@ export const Orientation: StoryFn = _args => {
   )
 }
 
-const sizes: RadioGroupProps['size'][] = ['sm', 'md']
-
-export const Size: StoryFn = _args => {
-  return (
-    <div className="flex gap-xl">
-      {sizes.map(size => (
-        <div key={size}>
-          <StoryLabel>{size}</StoryLabel>
-          <RadioGroup defaultValue="1" size={size}>
-            <RadioGroup.Radio value="1">First</RadioGroup.Radio>
-            <RadioGroup.Radio value="2">Second</RadioGroup.Radio>
-            <RadioGroup.Radio value="3">Third</RadioGroup.Radio>
-          </RadioGroup>
-        </div>
-      ))}
-    </div>
-  )
-}
-
 export const Disabled: StoryFn = _args => (
   <RadioGroup disabled>
     <RadioGroup.Radio value="1">First</RadioGroup.Radio>

--- a/packages/components/radio-group/src/RadioGroup.styles.ts
+++ b/packages/components/radio-group/src/RadioGroup.styles.ts
@@ -1,10 +1,10 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
-export const radioGroupStyles = cva(['flex', 'gap-lg'], {
+export const radioGroupStyles = cva(['flex'], {
   variants: {
     orientation: {
-      horizontal: 'flex-row',
-      vertical: 'flex-col',
+      vertical: ['flex-col', 'gap-lg'],
+      horizontal: ['flex-row', 'gap-xl'],
     },
   },
 })

--- a/packages/components/radio-group/src/RadioGroup.tsx
+++ b/packages/components/radio-group/src/RadioGroup.tsx
@@ -8,7 +8,7 @@ import { RadioInputVariantsProps } from './RadioInput.styles'
 
 export interface RadioGroupProps
   extends RadioGroupVariantsProps,
-    Pick<RadioInputVariantsProps, 'intent' | 'size'>,
+    Pick<RadioInputVariantsProps, 'intent'>,
     Omit<HTMLAttributes<HTMLDivElement>, 'value' | 'defaultValue' | 'dir'> {
   /**
    * Change the component to the HTML tag or custom component of the only child.
@@ -58,7 +58,6 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       orientation = 'vertical',
       loop = true,
       intent,
-      size,
       disabled,
       className,
       required: requiredProp,
@@ -70,7 +69,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
     const required = requiredProp !== undefined ? requiredProp : isRequired
 
     return (
-      <RadioGroupProvider intent={intent} size={size} disabled={disabled}>
+      <RadioGroupProvider intent={intent} disabled={disabled}>
         <RadioGroupPrimitive
           data-spark-component="radio-group"
           className={radioGroupStyles({ orientation, className })}

--- a/packages/components/radio-group/src/RadioGroupContext.tsx
+++ b/packages/components/radio-group/src/RadioGroupContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext } from 'react'
 
-import { RadioInputProps } from './RadioInput'
+import type { RadioInputProps } from './RadioInput'
 
-export type RadioGroupContextState = Pick<RadioInputProps, 'intent' | 'size' | 'disabled'>
+export type RadioGroupContextState = Pick<RadioInputProps, 'intent' | 'disabled'>
 
 export const RadioGroupContext = createContext<RadioGroupContextState | null>(null)
 

--- a/packages/components/radio-group/src/RadioGroupProvider.tsx
+++ b/packages/components/radio-group/src/RadioGroupProvider.tsx
@@ -1,20 +1,14 @@
 import { ReactNode, useMemo } from 'react'
 
 import { RadioGroupContext } from './RadioGroupContext'
-import { RadioInputProps } from './RadioInput'
+import type { RadioInputProps } from './RadioInput'
 
-export interface RadioGroupProviderProps
-  extends Pick<RadioInputProps, 'intent' | 'size' | 'disabled'> {
+export interface RadioGroupProviderProps extends Pick<RadioInputProps, 'intent' | 'disabled'> {
   children: ReactNode
 }
 
-export const RadioGroupProvider = ({
-  intent,
-  size,
-  disabled,
-  children,
-}: RadioGroupProviderProps) => {
-  const value = useMemo(() => ({ intent, size, disabled }), [intent, size, disabled])
+export const RadioGroupProvider = ({ intent, disabled, children }: RadioGroupProviderProps) => {
+  const value = useMemo(() => ({ intent, disabled }), [intent, disabled])
 
   return <RadioGroupContext.Provider value={value}>{children}</RadioGroupContext.Provider>
 }

--- a/packages/components/radio-group/src/RadioIndicator.styles.ts
+++ b/packages/components/radio-group/src/RadioIndicator.styles.ts
@@ -3,10 +3,8 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const radioIndicatorStyles = cva(
   [
-    'block',
-    'relative',
-    'h-full',
-    'w-full',
+    'relative block',
+    'h-4/6 w-4/6',
     'after:absolute',
     'after:left-1/2 after:top-1/2 after:-translate-x-1/2 after:-translate-y-1/2',
     'after:h-none',
@@ -15,6 +13,7 @@ export const radioIndicatorStyles = cva(
     'after:rounded-[50%]',
     "after:content-['']",
     'after:transition-all',
+    'after:spark-state-checked:h-full after:spark-state-checked:w-full',
   ],
   {
     variants: {
@@ -30,14 +29,9 @@ export const radioIndicatorStyles = cva(
         error: ['after:bg-error'],
         info: ['after:bg-info'],
       }),
-      size: makeVariants<'size', ['sm', 'md']>({
-        sm: ['after:spark-state-checked:h-sz-10', 'after:spark-state-checked:w-sz-10'],
-        md: ['after:spark-state-checked:h-sz-16', 'after:spark-state-checked:w-sz-16'],
-      }),
     },
     defaultVariants: {
       intent: 'primary',
-      size: 'sm',
     },
   }
 )

--- a/packages/components/radio-group/src/RadioIndicator.tsx
+++ b/packages/components/radio-group/src/RadioIndicator.tsx
@@ -16,11 +16,11 @@ export interface RadioIndicatorProps extends RadioIndicatorStylesProps {
 }
 
 export const RadioIndicator = forwardRef<HTMLSpanElement, RadioIndicatorProps>(
-  ({ intent, size, className, ...others }, ref) => {
+  ({ intent, className, ...others }, ref) => {
     return (
       <RadioIndicatorPrimitive
         ref={ref}
-        className={radioIndicatorStyles({ intent, size, className })}
+        className={radioIndicatorStyles({ intent, className })}
         {...others}
       />
     )

--- a/packages/components/radio-group/src/RadioInput.styles.ts
+++ b/packages/components/radio-group/src/RadioInput.styles.ts
@@ -1,13 +1,9 @@
 import { makeVariants } from '@spark-ui/internal-utils'
 import { cva, VariantProps } from 'class-variance-authority'
 
-const defaultVariants = {
-  intent: 'primary',
-  size: 'sm',
-} as const
-
 export const radioInputVariants = cva(
   [
+    'flex items-center justify-center',
     'rounded-full',
     'border-md',
     'outline-none',
@@ -15,13 +11,10 @@ export const radioInputVariants = cva(
     'focus-visible:ring-2 focus-visible:ring-on-surface',
     'disabled:cursor-not-allowed disabled:border-outline/dim-2 disabled:hover:ring-transparent',
     'u-shadow-border-transition',
+    'h-sz-24 w-sz-24',
   ],
   {
     variants: {
-      size: makeVariants<'size', ['sm', 'md']>({
-        sm: ['w-sz-20', 'h-sz-20'],
-        md: ['w-sz-28', 'h-sz-28'],
-      }),
       intent: makeVariants<
         'intent',
         ['primary', 'secondary', 'success', 'alert', 'error', 'info', 'neutral']
@@ -47,7 +40,9 @@ export const radioInputVariants = cva(
         error: ['border-error', 'hover:ring-error-container'],
       }),
     },
-    defaultVariants,
+    defaultVariants: {
+      intent: 'primary',
+    },
   }
 )
 

--- a/packages/components/radio-group/src/RadioInput.tsx
+++ b/packages/components/radio-group/src/RadioInput.tsx
@@ -27,18 +27,14 @@ export interface RadioInputProps
 }
 
 export const RadioInput = forwardRef<HTMLButtonElement, RadioInputProps>(
-  ({ intent: intentProp, size, className, ...others }, ref) => {
+  ({ intent: intentProp, className, ...others }, ref) => {
     const { state } = useFormFieldControl()
 
     const intent = state ?? intentProp
 
     return (
-      <RadioPrimitive
-        ref={ref}
-        className={radioInputVariants({ size, intent, className })}
-        {...others}
-      >
-        <RadioIndicator intent={intent} size={size} forceMount />
+      <RadioPrimitive ref={ref} className={radioInputVariants({ intent, className })} {...others}>
+        <RadioIndicator intent={intent} forceMount />
       </RadioPrimitive>
     )
   }


### PR DESCRIPTION
**TASK**: #976 

### Description, Motivation and Context
After reviewing Design specs it appeared that RadioGroup sizes weren't compliant. We want to fix this, and also to remove the prop (as there should be only one size).

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/c2eee35f-1413-4943-951e-a976fa959253)

