### PR TITLE
feat(internal-utils): add dashed design to internal utils constants

### DIFF
--- a/packages/components/button/src/Button.styles.tsx
+++ b/packages/components/button/src/Button.styles.tsx
@@ -33,7 +33,7 @@ export const buttonStyles = cva(
        * - `contrast`: Button will be surface filled. No borders, plain text.
        *
        */
-      design: makeVariants<'design'>({
+      design: makeVariants<'design', ['filled', 'outlined', 'tinted', 'ghost', 'contrast']>({
         filled: [],
         outlined: ['bg-transparent', 'ring-1', 'ring-current'],
         tinted: [],

--- a/packages/utils/internal-utils/src/variants/constants.ts
+++ b/packages/utils/internal-utils/src/variants/constants.ts
@@ -13,7 +13,7 @@ const intents = [
   'surface',
 ] as const
 
-const designs = ['filled', 'outlined', 'tinted', 'ghost', 'contrast'] as const
+const designs = ['filled', 'outlined', 'tinted', 'ghost', 'contrast', 'dashed'] as const
 
 const shapes = ['rounded', 'square', 'pill'] as const
 


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
The chip designs add a new one not included in out internal-util constants. I added that NEW 'dashed' design and pick the right values in the button to filter that undesired design value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->

- [x] 🛠️ Tool


### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
