### PR TITLE
fix(tag): remove shape prop from tag (design resync)

### DIFF
--- a/packages/components/tag/src/Tag.doc.mdx
+++ b/packages/components/tag/src/Tag.doc.mdx
@@ -41,12 +41,6 @@ Use `intent` prop to set the color intent of a tag.
 
 <Canvas of={TagStories.Intent} />
 
-## Shapes
-
-Use `shape` prop to set the shape of a tag.
-
-<Canvas of={TagStories.Shapes} />
-
 ## Icons
 
 Compose the content of the tag using the `Icon` component to add an icon to the left or right.

--- a/packages/components/tag/src/Tag.stories.tsx
+++ b/packages/components/tag/src/Tag.stories.tsx
@@ -24,7 +24,6 @@ const intents: TagProps['intent'][] = [
   'neutral',
 ]
 const designs: TagProps['design'][] = ['filled', 'outlined', 'tinted']
-const shapes: TagProps['shape'][] = ['rounded', 'square', 'pill']
 
 export const Default: StoryFn = _args => <Tag>Default tag</Tag>
 
@@ -45,18 +44,6 @@ export const Intent: StoryFn = _args => (
         {intent} tag
       </Tag>
     ))}
-  </div>
-)
-
-export const Shapes: StoryFn = _args => (
-  <div className="flex items-center gap-md">
-    {shapes.map(shape => {
-      return (
-        <Tag key={shape} shape={shape}>
-          {shape} tag
-        </Tag>
-      )
-    })}
   </div>
 )
 

--- a/packages/components/tag/src/Tag.styles.tsx
+++ b/packages/components/tag/src/Tag.styles.tsx
@@ -9,18 +9,15 @@ export const tagStyles = cva(
     'text-caption font-bold',
     'h-sz-20 px-md',
     'ring-inset',
+    'rounded-full',
   ],
   {
     variants: {
       /**
        * Main style of the tag.
-       *
        * - `filled`: Tag will be plain.
-       *
        * - `outlined`: Tag will have a surface background with an colored outline/text.
-       *
        * - `tinted`: Tag will be filled but using a lighter color scheme.
-       *
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted']>({
         filled: [],
@@ -42,17 +39,11 @@ export const tagStyles = cva(
         info: [],
         neutral: [],
       }),
-      shape: makeVariants<'shape'>({
-        rounded: ['rounded-lg'],
-        square: ['rounded-none'],
-        pill: ['rounded-full'],
-      }),
     },
     compoundVariants: [...filledVariants, ...outlinedVariants, ...tintedVariants],
     defaultVariants: {
       design: 'filled',
       intent: 'primary',
-      shape: 'rounded',
     },
   }
 )

--- a/packages/components/tag/src/Tag.tsx
+++ b/packages/components/tag/src/Tag.tsx
@@ -1,5 +1,5 @@
 import { Slot } from '@spark-ui/slot'
-import React, { PropsWithChildren } from 'react'
+import { forwardRef, type PropsWithChildren } from 'react'
 
 import { tagStyles, type TagStylesProps } from './Tag.styles'
 
@@ -12,11 +12,8 @@ export interface TagProps
   asChild?: boolean
 }
 
-export const Tag = React.forwardRef<HTMLButtonElement, TagProps>(
-  (
-    { design = 'filled', intent = 'primary', shape = 'rounded', asChild, className, ...others },
-    ref
-  ) => {
+export const Tag = forwardRef<HTMLButtonElement, TagProps>(
+  ({ design = 'filled', intent = 'primary', asChild, className, ...others }, ref) => {
     const Component = asChild ? Slot : 'span'
 
     return (
@@ -27,7 +24,6 @@ export const Tag = React.forwardRef<HTMLButtonElement, TagProps>(
           className,
           design,
           intent,
-          shape,
         })}
         {...others}
       />


### PR DESCRIPTION
**TASK**: #978 

### Description, Motivation and Context
After reviewing Design specs it appeared that Tag shape property shouldn't be there. The only defined shape should be "fully rounded".

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/3b959209-c9f3-41ab-86de-ef0020a73aad)
