### PR TITLE
feat: add height transition to FAQ component

### DIFF
--- a/documentation/helpers/FAQ/Answer.tsx
+++ b/documentation/helpers/FAQ/Answer.tsx
@@ -1,3 +1,4 @@
+import { cx } from 'class-variance-authority'
 import { PropsWithChildren } from 'react'
 
 import { useFAQItemContext } from './context'
@@ -5,5 +6,16 @@ import { useFAQItemContext } from './context'
 export function Answer({ children }: PropsWithChildren<unknown>) {
   const { state } = useFAQItemContext()
 
-  return <dd className={`${state.isOpen ? 'block' : 'hidden'} mb-lg`}>{children}</dd>
+  return (
+    <dd
+      aria-hidden={!state.isOpen}
+      className={cx(
+        'overflow-hidden',
+        state.isOpen ? 'mb-lg' : '',
+        state.isOpen ? '' : 'invisible'
+      )}
+    >
+      {children}
+    </dd>
+  )
 }

--- a/documentation/helpers/FAQ/Answer.tsx
+++ b/documentation/helpers/FAQ/Answer.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'class-variance-authority'
-import { PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 
 import { useFAQItemContext } from './context'
 
@@ -9,11 +9,7 @@ export function Answer({ children }: PropsWithChildren<unknown>) {
   return (
     <dd
       aria-hidden={!state.isOpen}
-      className={cx(
-        'overflow-hidden',
-        state.isOpen ? 'mb-lg' : '',
-        state.isOpen ? '' : 'invisible'
-      )}
+      className={cx('overflow-hidden', state.isOpen ? 'mb-lg' : 'invisible')}
     >
       {children}
     </dd>

--- a/documentation/helpers/FAQ/Item.tsx
+++ b/documentation/helpers/FAQ/Item.tsx
@@ -1,3 +1,4 @@
+import { cx } from 'class-variance-authority'
 import { PropsWithChildren } from 'react'
 
 import { ItemProvider } from './context'
@@ -5,7 +6,17 @@ import { ItemProvider } from './context'
 export function Item({ children }: PropsWithChildren<unknown>) {
   return (
     <ItemProvider>
-      <div className="border-t-outline [&:not(:first-child)]:border-t-sm">{children}</div>
+      {isOpen => (
+        <div
+          className={cx(
+            isOpen ? '[grid-template-rows:auto_1fr]' : '[grid-template-rows:auto_0fr]',
+            'grid border-t-outline ease-in duration-250 transition-all',
+            '[&:not(:first-child)]:border-t-sm'
+          )}
+        >
+          {children}
+        </div>
+      )}
     </ItemProvider>
   )
 }

--- a/documentation/helpers/FAQ/Item.tsx
+++ b/documentation/helpers/FAQ/Item.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'class-variance-authority'
-import { PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 
 import { ItemProvider } from './context'
 

--- a/documentation/helpers/FAQ/Question.tsx
+++ b/documentation/helpers/FAQ/Question.tsx
@@ -24,7 +24,7 @@ export function Question({ label }: Props) {
 
     dispatch({ type: 'TOGGLE_OPEN' })
     btnRef.current.scrollIntoView({ behavior: 'smooth' })
-  }, [])
+  }, [dispatch, slugifiedLabel])
 
   return (
     <dt className="py-lg">

--- a/documentation/helpers/FAQ/context.tsx
+++ b/documentation/helpers/FAQ/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, type Dispatch, PropsWithChildren, useContext, useReducer } from 'react'
+import { createContext, type Dispatch, ReactNode, useContext, useReducer } from 'react'
 
 interface Action {
   type: 'TOGGLE_OPEN'
@@ -40,10 +40,15 @@ function useFAQItemContext() {
   return ctx
 }
 
-function ItemProvider({ children }: PropsWithChildren<unknown>) {
-  const [state, dispatch] = useReducer(reducer, initialState)
+interface ItemProviderProps {
+  children: ReactNode | ((value: boolean) => ReactNode)
+}
 
-  return <FAQItemContext.Provider value={{ state, dispatch }}>{children}</FAQItemContext.Provider>
+function ItemProvider({ children }: ItemProviderProps) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const content = typeof children === 'function' ? children(state.isOpen) : children
+
+  return <FAQItemContext.Provider value={{ state, dispatch }}>{content}</FAQItemContext.Provider>
 }
 
 export { useFAQItemContext, ItemProvider }


### PR DESCRIPTION
**TASK**: #1018

### Description, Motivation and Context
Update the FAQ component to include a height transition when opening and closing items, to provide a smoother user experience

### Types of changes
- [x] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
