### PR TITLE
1036 components input clear button styles update

### DIFF
--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@spark-ui/form-field": "^0.6.4",
     "@spark-ui/icon": "^1.7.7",
-    "@spark-ui/icon-button": "^1.3.9",
     "@spark-ui/icons": "^1.19.2",
     "@spark-ui/slot": "^1.6.1",
     "@spark-ui/use-combined-state": "^0.5.0",

--- a/packages/components/input/src/InputClearButton.tsx
+++ b/packages/components/input/src/InputClearButton.tsx
@@ -1,26 +1,14 @@
 import { Icon } from '@spark-ui/icon'
-import { IconButton, IconButtonProps } from '@spark-ui/icon-button'
 import { DeleteFill } from '@spark-ui/icons/dist/icons/DeleteFill'
 import { cx } from 'class-variance-authority'
-import { forwardRef, MouseEventHandler } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, MouseEventHandler } from 'react'
 
 import { useInputGroup } from './InputGroupContext'
 
-export type InputClearButtonProps = IconButtonProps
+export type InputClearButtonProps = ComponentPropsWithoutRef<'button'>
 
 export const InputClearButton = forwardRef<HTMLButtonElement, InputClearButtonProps>(
-  (
-    {
-      className,
-      intent = 'neutral',
-      design = 'ghost',
-      size = 'sm',
-      tabIndex = -1,
-      onClick,
-      ...others
-    },
-    ref
-  ) => {
+  ({ className, tabIndex = -1, onClick, ...others }, ref) => {
     const { onClear, hasTrailingIcon } = useInputGroup()
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = event => {
@@ -34,24 +22,23 @@ export const InputClearButton = forwardRef<HTMLButtonElement, InputClearButtonPr
     }
 
     return (
-      <IconButton
+      <button
         ref={ref}
         className={cx(
           className,
           'absolute top-1/2 -translate-y-1/2 pointer-events-auto',
-          hasTrailingIcon ? 'right-3xl' : 'right-sm'
+          'inline-flex items-center justify-center h-full outline-none',
+          'text-neutral hover:text-neutral-hovered',
+          hasTrailingIcon ? 'right-3xl px-[var(--sz-12)]' : 'right-none pr-lg pl-md'
         )}
         tabIndex={tabIndex}
-        intent={intent}
-        design={design}
-        size={size}
         onClick={handleClick}
         {...others}
       >
         <Icon size="sm">
           <DeleteFill />
         </Icon>
-      </IconButton>
+      </button>
     )
   }
 )

--- a/packages/components/input/src/InputClearButton.tsx
+++ b/packages/components/input/src/InputClearButton.tsx
@@ -5,7 +5,9 @@ import { ComponentPropsWithoutRef, forwardRef, MouseEventHandler } from 'react'
 
 import { useInputGroup } from './InputGroupContext'
 
-export type InputClearButtonProps = ComponentPropsWithoutRef<'button'>
+export interface InputClearButtonProps extends ComponentPropsWithoutRef<'button'> {
+  'aria-label': string
+}
 
 export const InputClearButton = forwardRef<HTMLButtonElement, InputClearButtonProps>(
   ({ className, tabIndex = -1, onClick, ...others }, ref) => {


### PR DESCRIPTION
## Input clear button styles

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1036 

### Description, Motivation and Context
This PR:
- Change `InputGroup.ClearButton` to be a custom one
- Clickable area improvement (smaller in mobile but it takes full height)

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations

![Screen Shot 2023-07-18 at 13 17 10](https://github.com/adevinta/spark/assets/6877967/e60dc7c3-1c10-4c2b-ab8d-acd105afa282)

![Screen Shot 2023-07-18 at 13 16 14](https://github.com/adevinta/spark/assets/6877967/544107d0-1c58-4541-8a39-af3854935079)

