### PR TITLE
Fix formfield doc typo

### DIFF
--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -9,11 +9,14 @@ interface Props<T> {
   subcomponents?: Record<string, any> | null
 }
 
-const ComponentDescription = ({ children }: { children: ReactNode }) => {
+const ComponentDescription = ({ name, children }: { name: string; children: ReactNode }) => {
   return (
-    <p className="rounded-md bg-primary-container px-lg py-md text-body-2 text-on-primary-container">
-      {children}
-    </p>
+    <div className="rounded-t-lg bg-surface bg-gradient-to-b from-info via-transparent via-80% to-transparent p-[16px] pb-none text-on-surface">
+      <div className="rounded-lg bg-surface px-lg py-md shadow-sm">
+        <p className="mb-md text-body-1 font-bold">{`<${name} />`}</p>
+        <p className="text-body-2 italic">{children}</p>
+      </div>
+    </div>
   )
 }
 
@@ -39,14 +42,14 @@ export const ArgTypes = <T extends FC>({ of, description, subcomponents = null }
       </Tabs.List>
 
       <Tabs.Content key={name} value={name} className="py-none">
-        {description && <ComponentDescription>{description}</ComponentDescription>}
+        {description && <ComponentDescription name={name}>{description}</ComponentDescription>}
         <StorybookArgTypes of={of} />
       </Tabs.Content>
 
       {subComponentsList.map(([name, { of, description }]) => {
         return (
           <Tabs.Content key={name} value={name} className="py-none">
-            {description && <ComponentDescription>{description}</ComponentDescription>}
+            {description && <ComponentDescription name={name}>{description}</ComponentDescription>}
             <StorybookArgTypes of={of} />
           </Tabs.Content>
         )

--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -11,7 +11,7 @@ interface Props<T> {
 
 const ComponentDescription = ({ name, children }: { name: string; children: ReactNode }) => {
   return (
-    <div className="rounded-t-lg bg-surface bg-gradient-to-b from-info via-transparent via-80% to-transparent p-[16px] pb-none text-on-surface">
+    <div className="rounded-t-lg bg-surface bg-gradient-to-b from-info p-lg pb-none text-on-surface">
       <div className="rounded-lg bg-surface px-lg py-md shadow-sm">
         <p className="mb-md text-body-1 font-bold">{`<${name} />`}</p>
         <p className="text-body-2 italic">{children}</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,6 +2650,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,

--- a/packages/components/form-field/src/FormField.doc.mdx
+++ b/packages/components/form-field/src/FormField.doc.mdx
@@ -14,13 +14,13 @@ Provide context to your form elements easily.
 ## Install
 
 ```sh
-npm install @spark-ui/form-control
+npm install @spark-ui/form-field
 ```
 
 ## Import
 
 ```tsx
-import { FormField } from '@spark-ui/form-control'
+import { FormField } from '@spark-ui/form-field'
 ```
 
 ## Props

--- a/packages/components/form-field/src/FormField.doc.mdx
+++ b/packages/components/form-field/src/FormField.doc.mdx
@@ -27,14 +27,41 @@ import { FormField } from '@spark-ui/form-field'
 
 <ArgTypes
   of={FormField}
+  description="Wrap any type of input (Input, Checkbox, RadioGroup, etc.) to add contextual information to it and build accessible forms."
   subcomponents={{
-    'FormField.Label': { of: FormField.Label },
-    'FormField.HelperMessage': { of: FormField.HelperMessage },
-    'FormField.SuccessMessage': { of: FormField.SuccessMessage },
-    'FormField.AlertMessage': { of: FormField.AlertMessage },
-    'FormField.ErrorMessage': { of: FormField.ErrorMessage },
-    'FormField.Control': { of: FormField.Control },
-    'FormField.RequiredIndicator': { of: FormField.RequiredIndicator },
+    'FormField.Label': {
+      of: FormField.Label,
+      description:
+        'Label to attach to the associated input to describe it and give it an accessible name.',
+    },
+    'FormField.HelperMessage': {
+      of: FormField.HelperMessage,
+      description: 'Help users by showing an helper message below an input.',
+    },
+    'FormField.SuccessMessage': {
+      of: FormField.SuccessMessage,
+      description:
+        'Help users by showing an success message below an input. Indicates the input has been successfully filled in by the user.',
+    },
+    'FormField.AlertMessage': {
+      of: FormField.AlertMessage,
+      description:
+        'Help users by showing an alert message (warning) below an input. For example: a password input with an insecure password.',
+    },
+    'FormField.ErrorMessage': {
+      of: FormField.ErrorMessage,
+      description:
+        'Help users by showing an error message below an input. Indicated the input has not been successfully filled in by the user.',
+    },
+    'FormField.Control': {
+      of: FormField.Control,
+      description:
+        'This higher order component gives you access to the internal state of the field. Wrap an input with it to get access to the state. It can be used to build complex custom inputs.',
+    },
+    'FormField.RequiredIndicator': {
+      of: FormField.RequiredIndicator,
+      description: 'Render it inside the FormField.Label to mark the field as mandatory (required)',
+    },
   }}
 />
 

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -30,12 +30,37 @@ import { Input, InputGroup } from '@spark-ui/input'
 
 <ExtendedArgTypes
   of={Input}
+  description="Input component is a component that is used to get user input in a text field."
   subcomponents={{
-    InputGroup: { of: InputGroup },
-    'InputGroup.LeadingAddon': { of: InputGroup.LeadingAddon },
-    'InputGroup.LeadingIcon': { of: InputGroup.LeadingIcon },
-    'InputGroup.TrailingAddon': { of: InputGroup.TrailingAddon },
-    'InputGroup.TrailingIcon': { of: InputGroup.TrailingIcon },
+    InputGroup: {
+      of: InputGroup,
+      description:
+        'Use this wrapper whenever you need a more complex text input. For example if you need to have leading/trailing icons or addons.',
+    },
+    'InputGroup.LeadingAddon': {
+      of: InputGroup.LeadingAddon,
+      description:
+        'Add any type of component that will be displayed before the input field.\n This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
+    },
+    'InputGroup.LeadingIcon': {
+      of: InputGroup.LeadingIcon,
+      description: 'Prepend a decorative icon inside the input (to the left).',
+    },
+    'InputGroup.TrailingAddon': {
+      of: InputGroup.TrailingAddon,
+      description:
+        'Add any type of component that will be displayed after the input field. This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
+    },
+    'InputGroup.TrailingIcon': {
+      of: InputGroup.TrailingIcon,
+      description:
+        'Append a decorative icon inside the input (to the right). This element will be replaced by a status indicator whenever the input is in error/alert/success state.',
+    },
+    'InputGroup.ClearButton': {
+      of: InputGroup.ClearButton,
+      description:
+        'Clears the input value. Only for search inputs. This button will be shown when the user has typed something in the input.',
+    },
   }}
 />
 


### PR DESCRIPTION

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1045 

### Description, Motivation and Context

- fixed typo in Install section of `FormField` (it said "form-control")
- added missing `FormField.ClearButton` to the `FormField` props table
- added description to each component of the `FormField` compound
- added description to each component of the `Input` compound

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/8a0f25df-2aa8-4dba-968b-d0c5822eb509


