### PR TITLE
feat(input): disabled input styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,6 +2650,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -82,11 +82,11 @@ Use `value` and `onChange` props to control the value of the input.
 
 ## Addons
 
-Addons are sections before/after the input itself.
+Each `InputGroup` can have a `LeadingAddon` and a `TrailingAddon`.
 
 You can use them to achieve more complex custom inputs. Addons can be decorative or interactive.
 
-Addons are not considered part of the input itself and clicking on them won't move the focus to the input.
+**Note: we advise to use `solid` addons when possible to give the user a better cliackable area**
 
 <Canvas of={stories.Addons} />
 

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -80,12 +80,6 @@ Use `value` and `onChange` props to control the value of the input.
 
 <Canvas of={stories.Controlled} />
 
-## Disabled
-
-Use `disabled` prop to indicate the input is disabled (set the prop on `InputGroup` instead if you are wrapping your `Input` with it)
-
-<Canvas of={stories.Disabled} />
-
 ## Addons
 
 Addons are sections before/after the input itself.
@@ -103,6 +97,12 @@ An `InputGroup` can have a `LeadingIcon` and/or `TrailingIcon`.
 Please note that the `TrailingIcon` will be automatically replaced by the state indicator if the input has one (`error`, `alert` or `success`).
 
 <Canvas of={stories.Icons} />
+
+## Disabled
+
+Use `disabled` prop to indicate the input is disabled (set the prop on `InputGroup` instead if you are wrapping your `Input` with it)
+
+<Canvas of={stories.Disabled} />
 
 ## State
 

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -86,7 +86,7 @@ Each `InputGroup` can have a `LeadingAddon` and a `TrailingAddon`.
 
 You can use them to achieve more complex custom inputs. Addons can be decorative or interactive.
 
-**Note: we advise to use `solid` addons when possible to give the user a better cliackable area**
+**Note: we advise to use `solid` addons when possible to give the user a better clickable area**
 
 <Canvas of={stories.Addons} />
 
@@ -100,7 +100,7 @@ Please note that the `TrailingIcon` will be automatically replaced by the state 
 
 ## Disabled
 
-Use `disabled` prop to indicate the input is disabled (set the prop on `InputGroup` instead if you are wrapping your `Input` with it)
+To indicate that an input is disabled, use the `disabled` prop. If you're wrapping your `Input` with an `InputGroup`, set the prop on the `InputGroup` instead.
 
 <Canvas of={stories.Disabled} />
 

--- a/packages/components/input/src/Input.stories.tsx
+++ b/packages/components/input/src/Input.stories.tsx
@@ -38,9 +38,77 @@ export const Controlled: StoryFn = () => {
   return <Input value={value} onChange={handleChange} aria-label="Phone type" />
 }
 
-export const Disabled: StoryFn = _args => (
-  <Input defaultValue="IPhone" disabled aria-label="Phone type" />
-)
+export const Disabled: StoryFn = _args => {
+  const [isDisabled, setIsDisabled] = useState(true)
+
+  return (
+    <div className="flex flex-col gap-xl">
+      <Checkbox checked={isDisabled} onClick={() => setIsDisabled(!isDisabled)}>
+        Disabled
+      </Checkbox>
+
+      <div>
+        <StoryLabel>Standalone input</StoryLabel>
+        <Input
+          className="max-w-sz-320"
+          aria-label="Website"
+          disabled={isDisabled}
+          value="Hello world"
+        />
+      </div>
+
+      <div>
+        <StoryLabel>Addons - solid</StoryLabel>
+        <InputGroup className="max-w-sz-320" disabled={isDisabled}>
+          <InputGroup.LeadingAddon asChild>
+            <IconButton intent="primary" design="filled" aria-label="Search">
+              <Icon>
+                <EyeOutline />
+              </Icon>
+            </IconButton>
+          </InputGroup.LeadingAddon>
+          <InputGroup.ClearButton aria-label="clear" />
+          <InputGroup.LeadingIcon>
+            <PenOutline />
+          </InputGroup.LeadingIcon>
+          <Input aria-label="Website" value="Hello world" />
+          <InputGroup.TrailingAddon asChild>
+            <IconButton intent="neutral" design="ghost" aria-label="Search">
+              <Icon>
+                <EyeOutline />
+              </Icon>
+            </IconButton>
+          </InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+
+      <div>
+        <StoryLabel>Addons - text</StoryLabel>
+        <InputGroup className="max-w-sz-320" disabled={isDisabled}>
+          <InputGroup.LeadingAddon>https://</InputGroup.LeadingAddon>
+          <InputGroup.LeadingIcon>
+            <PenOutline />
+          </InputGroup.LeadingIcon>
+          <Input aria-label="Website" value="Hello world" />
+          <InputGroup.TrailingAddon>.com</InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+
+      <div>
+        <StoryLabel>Addons - inline</StoryLabel>
+        <InputGroup className="max-w-sz-320" disabled={isDisabled}>
+          <InputGroup.LeadingIcon>
+            <PenOutline />
+          </InputGroup.LeadingIcon>
+          <Input aria-label="Website" value="Hello world" />
+          <InputGroup.TrailingAddon>
+            <Button size="sm">Button</Button>
+          </InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+    </div>
+  )
+}
 
 export const Addons: StoryFn = _args => {
   return (
@@ -87,7 +155,7 @@ export const PasswordExample: StoryFn = () => {
     <InputGroup className="max-w-sz-320">
       <Input type={isVisible ? 'text' : 'password'} aria-label="Password" />
 
-      <InputGroup.TrailingAddon>
+      <InputGroup.TrailingAddon asChild>
         <IconButton
           intent="neutral"
           design="ghost"
@@ -112,7 +180,7 @@ export const SearchExample: StoryFn = _args => {
 
       <InputGroup.ClearButton aria-label="Clear value" />
 
-      <InputGroup.TrailingAddon>
+      <InputGroup.TrailingAddon asChild>
         <Button design="contrast">Search</Button>
       </InputGroup.TrailingAddon>
     </InputGroup>

--- a/packages/components/input/src/Input.stories.tsx
+++ b/packages/components/input/src/Input.stories.tsx
@@ -43,7 +43,7 @@ export const Disabled: StoryFn = _args => {
 
   return (
     <div className="flex flex-col gap-xl">
-      <Checkbox checked={isDisabled} onClick={() => setIsDisabled(!isDisabled)}>
+      <Checkbox checked={isDisabled} onClick={() => setIsDisabled(isDisabled => !isDisabled)}>
         Disabled
       </Checkbox>
 
@@ -53,7 +53,7 @@ export const Disabled: StoryFn = _args => {
           className="max-w-sz-320"
           aria-label="Website"
           disabled={isDisabled}
-          value="Hello world"
+          defaultValue="Hello world"
         />
       </div>
 
@@ -71,7 +71,7 @@ export const Disabled: StoryFn = _args => {
           <InputGroup.LeadingIcon>
             <PenOutline />
           </InputGroup.LeadingIcon>
-          <Input aria-label="Website" value="Hello world" />
+          <Input aria-label="Website" defaultValue="Hello world" />
           <InputGroup.TrailingAddon asChild>
             <IconButton intent="neutral" design="ghost" aria-label="Search">
               <Icon>
@@ -89,7 +89,7 @@ export const Disabled: StoryFn = _args => {
           <InputGroup.LeadingIcon>
             <PenOutline />
           </InputGroup.LeadingIcon>
-          <Input aria-label="Website" value="Hello world" />
+          <Input aria-label="Website" defaultValue="Hello world" />
           <InputGroup.TrailingAddon>.com</InputGroup.TrailingAddon>
         </InputGroup>
       </div>
@@ -100,7 +100,7 @@ export const Disabled: StoryFn = _args => {
           <InputGroup.LeadingIcon>
             <PenOutline />
           </InputGroup.LeadingIcon>
-          <Input aria-label="Website" value="Hello world" />
+          <Input aria-label="Website" defaultValue="Hello world" />
           <InputGroup.TrailingAddon>
             <Button size="sm">Button</Button>
           </InputGroup.TrailingAddon>

--- a/packages/components/input/src/Input.stories.tsx
+++ b/packages/components/input/src/Input.stories.tsx
@@ -112,11 +112,52 @@ export const Disabled: StoryFn = _args => {
 
 export const Addons: StoryFn = _args => {
   return (
-    <InputGroup className="max-w-sz-320">
-      <InputGroup.LeadingAddon className="px-lg">https://</InputGroup.LeadingAddon>
-      <Input aria-label="Website" />
-      <InputGroup.TrailingAddon className="px-lg">.com</InputGroup.TrailingAddon>
-    </InputGroup>
+    <div className="flex flex-col gap-xl">
+      <div className="flex flex-col gap-sm">
+        <StoryLabel>Solid</StoryLabel>
+        <InputGroup className="max-w-sz-320">
+          <InputGroup.LeadingAddon asChild>
+            <Button design="ghost" intent="neutral">
+              Click
+            </Button>
+          </InputGroup.LeadingAddon>
+          <Input aria-label="Website" />
+          <InputGroup.TrailingAddon asChild>
+            <IconButton intent="neutral" design="ghost" aria-label="Search">
+              <Icon>
+                <Search />
+              </Icon>
+            </IconButton>
+          </InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+
+      <div className="flex flex-col gap-sm">
+        <StoryLabel>Inline</StoryLabel>
+        <InputGroup className="max-w-sz-320">
+          <InputGroup.LeadingAddon className="px-lg">
+            <Button size="sm">Click</Button>
+          </InputGroup.LeadingAddon>
+          <Input aria-label="Website" />
+          <InputGroup.TrailingAddon className="px-lg">
+            <IconButton size="sm" aria-label="Search">
+              <Icon size="sm">
+                <Search />
+              </Icon>
+            </IconButton>
+          </InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+
+      <div className="flex flex-col gap-sm">
+        <StoryLabel>Raw text</StoryLabel>
+        <InputGroup className="max-w-sz-320">
+          <InputGroup.LeadingAddon className="px-lg">https://</InputGroup.LeadingAddon>
+          <Input aria-label="Website" />
+          <InputGroup.TrailingAddon className="px-lg">.com</InputGroup.TrailingAddon>
+        </InputGroup>
+      </div>
+    </div>
   )
 }
 

--- a/packages/components/input/src/Input.styles.ts
+++ b/packages/components/input/src/Input.styles.ts
@@ -15,6 +15,7 @@ export const inputStyles = cva(
     'autofill:shadow-surface',
     'autofill:shadow-[inset_0_0_0px_1000px]',
     'disabled:cursor-not-allowed',
+    'disabled:bg-on-surface/dim-5 disabled:text-on-surface/dim-3',
   ],
   {
     variants: {
@@ -28,9 +29,6 @@ export const inputStyles = cva(
         success: ['ring-success', 'ring-success'],
         alert: ['ring-alert', 'ring-alert'],
         error: ['ring-error', 'ring-error'],
-      },
-      isStandalone: {
-        true: 'disabled:opacity-dim-3',
       },
       hasLeadingAddon: {
         true: ['rounded-l-none'],

--- a/packages/components/input/src/Input.tsx
+++ b/packages/components/input/src/Input.tsx
@@ -62,7 +62,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         className={inputStyles({
           className,
           intent: state,
-          isStandalone: !!group.isStandalone,
           hasLeadingAddon: !!hasLeadingAddon,
           hasTrailingAddon: !!hasTrailingAddon,
           hasLeadingIcon: !!hasLeadingIcon,

--- a/packages/components/input/src/InputAddon.styles.ts
+++ b/packages/components/input/src/InputAddon.styles.ts
@@ -1,7 +1,36 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
+export const inputAddonContainerStyles = cva([''], {
+  variants: {
+    disabled: {
+      true: [
+        'relative',
+        'after:absolute',
+        'after:top-none',
+        'after:h-full',
+        // 'after:w-[calc(100%+1px)]',
+        'after:content-[""]',
+        'bg-on-surface/dim-5',
+      ],
+      false: 'after:hidden',
+    },
+    placement: {
+      left: ['rounded-l-lg', 'after:!right-[-1px]', 'after:rounded-l-lg'],
+      right: ['rounded-r-lg', 'after:!left-[-1px]', 'after:rounded-r-lg'],
+    },
+  },
+})
+
 export const inputAddonStyles = cva(
-  ['ring-1 ring-inset', 'shrink-0', 'focus-visible:relative', 'focus-visible:z-raised'],
+  [
+    'overflow-hidden',
+    'ring-1',
+    'ring-inset',
+    'shrink-0',
+    'h-full',
+    'focus-visible:relative',
+    'focus-visible:z-raised',
+  ],
   {
     variants: {
       asChild: { false: ['flex', 'items-center', 'px-lg'] },
@@ -14,12 +43,27 @@ export const inputAddonStyles = cva(
       disabled: {
         true: ['pointer-events-none'],
       },
+      design: {
+        text: '',
+        solid: '',
+        inline: '',
+      },
     },
     compoundVariants: [
       {
         disabled: false,
-        asChild: false,
+        design: 'text',
         class: ['bg-surface', 'text-on-surface'],
+      },
+      {
+        disabled: true,
+        design: 'text',
+        class: ['text-on-surface/dim-3'],
+      },
+      {
+        disabled: true,
+        design: ['solid', 'inline'],
+        class: ['opacity-dim-3'],
       },
     ],
     defaultVariants: {

--- a/packages/components/input/src/InputAddon.styles.ts
+++ b/packages/components/input/src/InputAddon.styles.ts
@@ -1,26 +1,5 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
-export const inputAddonContainerStyles = cva([''], {
-  variants: {
-    disabled: {
-      true: [
-        'relative',
-        'after:absolute',
-        'after:top-none',
-        'after:h-full',
-        // 'after:w-[calc(100%+1px)]',
-        'after:content-[""]',
-        'bg-on-surface/dim-5',
-      ],
-      false: 'after:hidden',
-    },
-    placement: {
-      left: ['rounded-l-lg', 'after:!right-[-1px]', 'after:rounded-l-lg'],
-      right: ['rounded-r-lg', 'after:!left-[-1px]', 'after:rounded-r-lg'],
-    },
-  },
-})
-
 export const inputAddonStyles = cva(
   [
     'overflow-hidden',

--- a/packages/components/input/src/InputAddon.tsx
+++ b/packages/components/input/src/InputAddon.tsx
@@ -1,21 +1,15 @@
 import { Slot } from '@spark-ui/slot'
 import { Children, type ComponentPropsWithoutRef, forwardRef, type PropsWithChildren } from 'react'
 
-import {
-  inputAddonContainerStyles,
-  inputAddonStyles,
-  type InputAddonStylesProps,
-} from './InputAddon.styles'
+import { inputAddonStyles, type InputAddonStylesProps } from './InputAddon.styles'
 import { useInputGroup } from './InputGroupContext'
 
 export interface InputAddonProps
   extends ComponentPropsWithoutRef<'div'>,
-    Omit<InputAddonStylesProps, 'intent' | 'disabled'> {
-  placement: 'left' | 'right'
-}
+    Omit<InputAddonStylesProps, 'intent' | 'disabled'> {}
 
 export const InputAddon = forwardRef<HTMLDivElement, PropsWithChildren<InputAddonProps>>(
-  ({ asChild: asChildProp = true, className, placement, children, ...others }, ref) => {
+  ({ asChild: asChildProp = true, className, children, ...others }, ref) => {
     const { state, disabled } = useInputGroup()
 
     const isRawText = typeof children === 'string'
@@ -32,22 +26,20 @@ export const InputAddon = forwardRef<HTMLDivElement, PropsWithChildren<InputAddo
     const design = getDesign()
 
     return (
-      <div className={inputAddonContainerStyles({ disabled, placement })}>
-        <Component
-          ref={ref}
-          className={inputAddonStyles({
-            className,
-            intent: state,
-            disabled,
-            asChild,
-            design,
-          })}
-          {...(disabled && { tabIndex: -1 })}
-          {...others}
-        >
-          {child}
-        </Component>
-      </div>
+      <Component
+        ref={ref}
+        className={inputAddonStyles({
+          className,
+          intent: state,
+          disabled,
+          asChild,
+          design,
+        })}
+        {...(disabled && { tabIndex: -1 })}
+        {...others}
+      >
+        {child}
+      </Component>
     )
   }
 )

--- a/packages/components/input/src/InputAddon.tsx
+++ b/packages/components/input/src/InputAddon.tsx
@@ -1,31 +1,53 @@
 import { Slot } from '@spark-ui/slot'
 import { Children, type ComponentPropsWithoutRef, forwardRef, type PropsWithChildren } from 'react'
 
-import { inputAddonStyles, InputAddonStylesProps } from './InputAddon.styles'
+import {
+  inputAddonContainerStyles,
+  inputAddonStyles,
+  type InputAddonStylesProps,
+} from './InputAddon.styles'
 import { useInputGroup } from './InputGroupContext'
 
 export interface InputAddonProps
   extends ComponentPropsWithoutRef<'div'>,
-    Omit<InputAddonStylesProps, 'intent' | 'disabled'> {}
+    Omit<InputAddonStylesProps, 'intent' | 'disabled'> {
+  placement: 'left' | 'right'
+}
 
 export const InputAddon = forwardRef<HTMLDivElement, PropsWithChildren<InputAddonProps>>(
-  ({ asChild: asChildProp = true, className, children, ...others }, ref) => {
+  ({ asChild: asChildProp = true, className, placement, children, ...others }, ref) => {
     const { state, disabled } = useInputGroup()
 
     const isRawText = typeof children === 'string'
-    const asChild = isRawText ? false : asChildProp
+    const asChild = !!(isRawText ? false : asChildProp)
     const child = isRawText ? children : Children.only(children)
     const Component = asChild && !isRawText ? Slot : 'div'
 
+    const getDesign = (): InputAddonStylesProps['design'] => {
+      if (isRawText) return 'text'
+
+      return asChild ? 'solid' : 'inline'
+    }
+
+    const design = getDesign()
+
     return (
-      <Component
-        ref={ref}
-        className={inputAddonStyles({ className, intent: state, disabled, asChild })}
-        {...(disabled && { tabIndex: -1 })}
-        {...others}
-      >
-        {child}
-      </Component>
+      <div className={inputAddonContainerStyles({ disabled, placement })}>
+        <Component
+          ref={ref}
+          className={inputAddonStyles({
+            className,
+            intent: state,
+            disabled,
+            asChild,
+            design,
+          })}
+          {...(disabled && { tabIndex: -1 })}
+          {...others}
+        >
+          {child}
+        </Component>
+      </div>
     )
   }
 )

--- a/packages/components/input/src/InputClearButton.tsx
+++ b/packages/components/input/src/InputClearButton.tsx
@@ -11,7 +11,9 @@ export interface InputClearButtonProps extends ComponentPropsWithoutRef<'button'
 
 export const InputClearButton = forwardRef<HTMLButtonElement, InputClearButtonProps>(
   ({ className, tabIndex = -1, onClick, ...others }, ref) => {
-    const { onClear, hasTrailingIcon } = useInputGroup()
+    const { disabled, onClear, hasTrailingIcon } = useInputGroup()
+
+    if (disabled) return null
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = event => {
       if (onClick) {

--- a/packages/components/input/src/InputGroup.styles.ts
+++ b/packages/components/input/src/InputGroup.styles.ts
@@ -3,7 +3,20 @@ import { cva, VariantProps } from 'class-variance-authority'
 export const inputGroupStyles = cva(['relative inline-flex w-full'], {
   variants: {
     disabled: {
-      true: 'cursor-not-allowed opacity-dim-3',
+      true: [
+        'cursor-not-allowed',
+        'relative',
+        'after:absolute',
+        'after:top-none',
+        'after:h-full',
+        'after:w-full',
+        'after:ring-1',
+        'after:ring-inset',
+        'after:ring-outline',
+        'after:content-[""]',
+        'after:rounded-lg',
+      ],
+      false: 'after:hidden',
     },
   },
 })

--- a/packages/components/input/src/InputIcon.tsx
+++ b/packages/components/input/src/InputIcon.tsx
@@ -1,16 +1,21 @@
 import { Icon, type IconProps } from '@spark-ui/icon'
 import { cx } from 'class-variance-authority'
 
+import { useInputGroup } from './InputGroupContext'
+
 export type InputIconProps = IconProps
 
 export const InputIcon = ({ className, intent, children, ...others }: InputIconProps) => {
+  const { disabled } = useInputGroup()
+
   return (
     <Icon
       intent={intent}
       className={cx(
         className,
         'pointer-events-none absolute top-1/2 -translate-y-1/2',
-        intent ? undefined : 'text-neutral peer-focus:text-outline-high'
+        intent ? undefined : 'text-neutral peer-focus:text-outline-high',
+        disabled ? 'opacity-dim-3' : undefined
       )}
       {...others}
     >

--- a/packages/components/input/src/InputLeadingAddon.tsx
+++ b/packages/components/input/src/InputLeadingAddon.tsx
@@ -2,22 +2,25 @@ import { cx } from 'class-variance-authority'
 import { forwardRef } from 'react'
 
 import { InputAddon, InputAddonProps } from './InputAddon'
+import { useInputGroup } from './InputGroupContext'
 
 export type InputLeadingAddonProps = InputAddonProps
 
-export const InputLeadingAddon = forwardRef<
-  HTMLDivElement,
-  Omit<InputLeadingAddonProps, 'placement'>
->(({ asChild = false, className, ...others }, ref) => {
-  return (
-    <InputAddon
-      ref={ref}
-      asChild={asChild}
-      placement="left"
-      className={cx(className, 'rounded-l-lg !rounded-r-none mr-[-1px]')}
-      {...others}
-    />
-  )
-})
+export const InputLeadingAddon = forwardRef<HTMLDivElement, InputLeadingAddonProps>(
+  ({ asChild = false, className, ...others }, ref) => {
+    const { disabled } = useInputGroup()
+
+    return (
+      <div className={cx('rounded-l-lg', disabled ? 'bg-on-surface/dim-5' : null)}>
+        <InputAddon
+          ref={ref}
+          asChild={asChild}
+          className={cx(className, 'rounded-l-lg !rounded-r-none mr-[-1px]')}
+          {...others}
+        />
+      </div>
+    )
+  }
+)
 
 InputLeadingAddon.displayName = 'InputGroup.LeadingAddon'

--- a/packages/components/input/src/InputLeadingAddon.tsx
+++ b/packages/components/input/src/InputLeadingAddon.tsx
@@ -5,14 +5,19 @@ import { InputAddon, InputAddonProps } from './InputAddon'
 
 export type InputLeadingAddonProps = InputAddonProps
 
-export const InputLeadingAddon = forwardRef<HTMLDivElement, InputLeadingAddonProps>(
-  ({ className, ...others }, ref) => (
+export const InputLeadingAddon = forwardRef<
+  HTMLDivElement,
+  Omit<InputLeadingAddonProps, 'placement'>
+>(({ asChild = false, className, ...others }, ref) => {
+  return (
     <InputAddon
       ref={ref}
+      asChild={asChild}
+      placement="left"
       className={cx(className, 'rounded-l-lg !rounded-r-none mr-[-1px]')}
       {...others}
     />
   )
-)
+})
 
 InputLeadingAddon.displayName = 'InputGroup.LeadingAddon'

--- a/packages/components/input/src/InputTrailingAddon.tsx
+++ b/packages/components/input/src/InputTrailingAddon.tsx
@@ -5,14 +5,17 @@ import { InputAddon, InputAddonProps } from './InputAddon'
 
 export type InputTrailingAddonProps = InputAddonProps
 
-export const InputTrailingAddon = forwardRef<HTMLDivElement, InputTrailingAddonProps>(
-  ({ className, ...others }, ref) => (
-    <InputAddon
-      ref={ref}
-      className={cx(className, '!rounded-l-none rounded-r-lg ml-[-1px]')}
-      {...others}
-    />
-  )
-)
+export const InputTrailingAddon = forwardRef<
+  HTMLDivElement,
+  Omit<InputTrailingAddonProps, 'placement'>
+>(({ asChild = false, className, ...others }, ref) => (
+  <InputAddon
+    ref={ref}
+    asChild={asChild}
+    placement="right"
+    className={cx(className, '!rounded-l-none rounded-r-lg ml-[-1px]')}
+    {...others}
+  />
+))
 
 InputTrailingAddon.displayName = 'InputGroup.TrailingAddon'

--- a/packages/components/input/src/InputTrailingAddon.tsx
+++ b/packages/components/input/src/InputTrailingAddon.tsx
@@ -2,20 +2,25 @@ import { cx } from 'class-variance-authority'
 import { forwardRef } from 'react'
 
 import { InputAddon, InputAddonProps } from './InputAddon'
+import { useInputGroup } from './InputGroupContext'
 
 export type InputTrailingAddonProps = InputAddonProps
 
-export const InputTrailingAddon = forwardRef<
-  HTMLDivElement,
-  Omit<InputTrailingAddonProps, 'placement'>
->(({ asChild = false, className, ...others }, ref) => (
-  <InputAddon
-    ref={ref}
-    asChild={asChild}
-    placement="right"
-    className={cx(className, '!rounded-l-none rounded-r-lg ml-[-1px]')}
-    {...others}
-  />
-))
+export const InputTrailingAddon = forwardRef<HTMLDivElement, InputTrailingAddonProps>(
+  ({ asChild = false, className, ...others }, ref) => {
+    const { disabled } = useInputGroup()
+
+    return (
+      <div className={cx('rounded-r-lg', disabled ? 'bg-on-surface/dim-5' : null)}>
+        <InputAddon
+          ref={ref}
+          asChild={asChild}
+          className={cx(className, '!rounded-l-none rounded-r-lg ml-[-1px]')}
+          {...others}
+        />
+      </div>
+    )
+  }
+)
 
 InputTrailingAddon.displayName = 'InputGroup.TrailingAddon'


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1034 

### Description, Motivation and Context

Disabled styles for `Input` and `InputGroup`.

Styles are applied on the input, as well as its addons and icons.
Styles is different depending on the type of (addon: raw text, solid, inline)

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/10c4ded7-a9b3-45f6-afca-a7511b7d011e


