### PR TITLE
ci: add canary branches passing the CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,7 +1,11 @@
 name: quality
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'canary/**'
+
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: <!--- #issueID -->

### Description, Motivation and Context
This change will able the possibility to have CI process in the PR's that triggers a canary branch

- 1st Create canary branch on server
`canary/[whatever]`
- 2nd Create a new branch comming from the canary
`canary/[whatever]-stage-[number]`
-  3rd Create a Pr from canary stage to canary branch

All PR's triggering a `canary/**` brach name will fire the Quality CI process

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes

- [x] 🛠️ Tool

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
