### PR TITLE
fix: updating deprecated formField versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,6 +2585,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "1.0.4",
     "@radix-ui/react-id": "1.0.1",
-    "@spark-ui/form-field": "^0.7.0",
+    "@spark-ui/form-field": "^1.1.0",
     "@spark-ui/icon": "^1.7.7",
     "@spark-ui/icons": "^1.19.2",
     "@spark-ui/internal-utils": "^1.6.1",

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -12,7 +12,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@spark-ui/form-field": "^0.7.0",
+    "@spark-ui/form-field": "^1.1.0",
     "@spark-ui/icon": "^1.7.7",
     "@spark-ui/icons": "^1.19.2",
     "@spark-ui/slot": "^1.6.1",

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-label": "2.0.1",
     "@radix-ui/react-radio-group": "1.1.2",
-    "@spark-ui/form-field": "^0.7.0",
+    "@spark-ui/form-field": "^1.1.0",
     "@spark-ui/internal-utils": "^1.6.1",
     "class-variance-authority": "0.5.2"
   },

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-switch": "1.0.3",
-    "@spark-ui/form-field": "^0.7.0",
+    "@spark-ui/form-field": "^1.1.0",
     "@spark-ui/icons": "^1.19.2",
     "@spark-ui/internal-utils": "^1.6.1",
     "@spark-ui/label": "^1.5.0",


### PR DESCRIPTION
### Description, Motivation and Context

`FormField`version has not been updated properly in dependant packages.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
