### PR TITLE
feat(theme-utils): add "basic" and "accents" color tokens to the Spark theme's color structure

### DIFF
--- a/packages/utils/theme/src/defaultTheme.ts
+++ b/packages/utils/theme/src/defaultTheme.ts
@@ -23,6 +23,32 @@ export const defaultTheme: Theme = {
     none: 'none',
   },
   colors: {
+    // Basic
+    basic: '#35376A',
+    onBasic: '#FFFFFF',
+    basicContainer: '#DCDCE5',
+    onBasicContainer: '#1D1F2A',
+    basicHovered: '#4D4E7B',
+    basicPressed: '#4D4E7B',
+    basicFocused: '#4D4E7B',
+    // Accent
+    accent: '#CC99FF',
+    onAccent: '#1D1F2A',
+    accentHovered: '#DBB7FF',
+    accentPressed: '#DBB7FF',
+    accentFocused: '#DBB7FF',
+    // Accent Container
+    accentContainer: '#F9F3FF',
+    onAccentContainer: '#362555',
+    accentContainerHovered: '#F9F3FF',
+    accentContainerPressed: '#F9F3FF',
+    accentContainerFocused: '#F9F3FF',
+    // Accent Variant
+    accentVariant: '#513877',
+    onAccentVariant: '#FFFFFF',
+    accentVariantHovered: '#6E4D99',
+    accentVariantPressed: '#6E4D99',
+    accentVariantFocused: '#6E4D99',
     // Primary
     primary: '#2118C9',
     onPrimary: '#FFFFFF',

--- a/packages/utils/theme/src/defaultThemeDark.ts
+++ b/packages/utils/theme/src/defaultThemeDark.ts
@@ -3,6 +3,32 @@ import { type Theme } from './types'
 
 export const defaultThemeDark: Theme = createTheme({
   colors: {
+    // Basic
+    basic: '#DCDCE5',
+    onBasic: '#1D1F2A',
+    basicContainer: '#4D4E7B',
+    onBasicContainer: '#FFFFFF',
+    basicHovered: '#C4C5D3',
+    basicPressed: '#C4C5D3',
+    basicFocused: '#C4C5D3',
+    // Accent
+    accent: '#CC99FF',
+    onAccent: '#1D1F2A',
+    accentHovered: '#AC7DDD',
+    accentPressed: '#AC7DDD',
+    accentFocused: '#AC7DDD',
+    // Accent Container
+    accentContainer: '#8D64BB',
+    onAccentContainer: '#FFFFFF',
+    accentContainerHovered: '#6E4D99',
+    accentContainerPressed: '#6E4D99',
+    accentContainerFocused: '#6E4D99',
+    // Accent Variant
+    accentVariant: '#DBB7FF',
+    onAccentVariant: '#1D1F2A',
+    accentVariantHovered: '#CC99FF',
+    accentVariantPressed: '#CC99FF',
+    accentVariantFocused: '#CC99FF',
     // Primary
     primary: '#7583FF',
     onPrimary: '#000000',

--- a/packages/utils/theme/src/types.ts
+++ b/packages/utils/theme/src/types.ts
@@ -32,6 +32,31 @@ export interface Theme {
    * Spark color specifications: https://zeroheight.com/1186e1705/p/0879a9-colors/b/27d7a3
    */
   colors: {
+    // Basic
+    basic: string
+    onBasic: string
+    basicContainer: string
+    onBasicContainer: string
+    basicHovered: string
+    basicPressed: string
+    basicFocused: string
+    // Accent
+    accent: string
+    onAccent: string
+    accentHovered: string
+    accentPressed: string
+    accentFocused: string
+    accentContainer: string
+    onAccentContainer: string
+    accentContainerHovered: string
+    accentContainerPressed: string
+    accentContainerFocused: string
+    // Accent Variant
+    accentVariant: string
+    onAccentVariant: string
+    accentVariantHovered: string
+    accentVariantPressed: string
+    accentVariantFocused: string
     // Primary
     primary: string
     onPrimary: string


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1073 

### Description, Motivation and Context
Add "basic" and "accents" color tokens to the Spark theme's color structure

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
