### PR TITLE
docs: component alphabetical order fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,6 +2585,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,

--- a/packages/components/checkbox/src/Checkbox.stories.tsx
+++ b/packages/components/checkbox/src/Checkbox.stories.tsx
@@ -11,7 +11,7 @@ import { Checkbox, CheckboxProps } from './Checkbox'
 import { CheckboxGroup } from './CheckboxGroup'
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'components/Checkbox',
+  title: 'Components/Checkbox',
   component: Checkbox,
 }
 

--- a/packages/components/icons/src/index.stories.tsx
+++ b/packages/components/icons/src/index.stories.tsx
@@ -7,7 +7,7 @@ import { ChangeEvent, FC, useEffect, useState } from 'react'
 import { Check as IconCheck } from './icons/Check'
 
 const meta: Meta = {
-  title: 'components/Icons',
+  title: 'Components/Icons',
   component: IconCheck,
 }
 


### PR DESCRIPTION
## TYPE(SCOPE): TITLE


### Description, Motivation and Context

`icons` and `checkbox` were at the end of the components in the sidebar instead of being alphabetically sorted.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations

Before
![Capture d’écran 2023-07-26 à 14 15 17](https://github.com/adevinta/spark/assets/2033710/1c24a51a-6d70-446b-a53c-8e2369ef819e)

After
![Capture d’écran 2023-07-26 à 14 12 37](https://github.com/adevinta/spark/assets/2033710/fba9bdc7-94ee-4076-bfa6-77edbf1a3dcd)

