### PR TITLE
fix(form-field): fix undefined values when accessing length property

### DIFF
--- a/packages/components/form-field/src/FormField.test.tsx
+++ b/packages/components/form-field/src/FormField.test.tsx
@@ -246,4 +246,39 @@ describe('FormField error message', () => {
     expect(inputEl).toHaveValue('Hello')
     expect(charsCountEl).toBeVisible()
   })
+
+  it('should render the characters count component properly when `value` is undefined', () => {
+    const MAX_LENGTH = 6
+    const DEFAULT_VALUE = undefined
+
+    render(
+      <FormField name="text">
+        <FormField.Label>Text</FormField.Label>
+
+        <FormField.Control>
+          {({ id, name }) => (
+            <input
+              type="text"
+              id={id}
+              name={name}
+              defaultValue={DEFAULT_VALUE}
+              maxLength={MAX_LENGTH}
+            />
+          )}
+        </FormField.Control>
+
+        <div className="flex justify-between gap-md">
+          <FormField.HelperMessage>We will never share your email</FormField.HelperMessage>
+
+          <FormField.CharactersCount value={DEFAULT_VALUE} maxLength={MAX_LENGTH} />
+        </div>
+      </FormField>
+    )
+
+    const inputEl = screen.getByLabelText('Text')
+    const charsCountEl = screen.getByText('0/6')
+
+    expect(inputEl).toHaveValue('')
+    expect(charsCountEl).toBeVisible()
+  })
 })

--- a/packages/components/form-field/src/FormField.test.tsx
+++ b/packages/components/form-field/src/FormField.test.tsx
@@ -240,11 +240,8 @@ describe('FormField error message', () => {
       </FormField>
     )
 
-    const inputEl = screen.getByLabelText('Text')
-    const charsCountEl = screen.getByText('5/6')
-
-    expect(inputEl).toHaveValue('Hello')
-    expect(charsCountEl).toBeVisible()
+    expect(screen.getByLabelText('Text')).toHaveValue('Hello')
+    expect(screen.getByText('5/6')).toBeVisible()
   })
 
   it('should render the characters count component properly when `value` is undefined', () => {
@@ -275,10 +272,7 @@ describe('FormField error message', () => {
       </FormField>
     )
 
-    const inputEl = screen.getByLabelText('Text')
-    const charsCountEl = screen.getByText('0/6')
-
-    expect(inputEl).toHaveValue('')
-    expect(charsCountEl).toBeVisible()
+    expect(screen.getByLabelText('Text')).toHaveValue('')
+    expect(screen.getByText('0/6')).toBeVisible()
   })
 })

--- a/packages/components/form-field/src/FormFieldCharactersCount.tsx
+++ b/packages/components/form-field/src/FormFieldCharactersCount.tsx
@@ -13,8 +13,8 @@ export type FormFieldCharactersCountProps = ComponentPropsWithoutRef<'span'> & {
 }
 
 export const FormFieldCharactersCount = forwardRef<HTMLSpanElement, FormFieldCharactersCountProps>(
-  ({ className, value, maxLength, ...others }, ref) => {
-    const count = value.length ?? 0
+  ({ className, value = '', maxLength, ...others }, ref) => {
+    const count = value.length
 
     return (
       <span

--- a/packages/components/form-field/src/FormFieldCharactersCount.tsx
+++ b/packages/components/form-field/src/FormFieldCharactersCount.tsx
@@ -5,7 +5,7 @@ export type FormFieldCharactersCountProps = ComponentPropsWithoutRef<'span'> & {
   /**
    * Current value for the input this component belongs to.
    */
-  value: string
+  value?: string
   /**
    * Maximum numeric value to be displayed.
    */


### PR DESCRIPTION
## fix(form-field): fix undefined values when accessing length property

### Description, Motivation and Context
`FormField.CharactersCount`: The component throws and error when `value` prop is `undefined`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)