### PR TITLE
refactor: update eslint rules for unused vars

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -57,7 +57,7 @@ module.exports = {
     '@typescript-eslint/no-object-literal-type-assertion': 0,
     '@typescript-eslint/no-shadow': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
-    '@typescript-eslint/no-unused-vars': 0,
+    '@typescript-eslint/no-unused-vars': 2,
     '@typescript-eslint/no-use-before-define': [
       2,
       { functions: false, classes: true, variables: false },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -57,7 +57,7 @@ module.exports = {
     '@typescript-eslint/no-object-literal-type-assertion': 0,
     '@typescript-eslint/no-shadow': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
-    '@typescript-eslint/no-unused-vars': 2,
+    '@typescript-eslint/no-unused-vars': [2, { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': [
       2,
       { functions: false, classes: true, variables: false },

--- a/packages/components/icons/scripts/build.mjs
+++ b/packages/components/icons/scripts/build.mjs
@@ -17,7 +17,7 @@ const main = async (pattern = 'assets/**/*.svg') => {
   await Promise.all(
     files.map(async filepath => {
       const relativePath = path.relative(path.join(process.cwd()), filepath)
-      const { root, dir, base, ext, name } = path.parse(relativePath)
+      const { dir, base, name } = path.parse(relativePath)
 
       const svgData = await pathSVG(readFile(path.join(dir, base)))
 
@@ -37,7 +37,7 @@ const main = async (pattern = 'assets/**/*.svg') => {
     })
   )
 
-  data.forEach(({ value, dir }, name) => {
+  data.forEach(({ value }, name) => {
     writeFile(path.join('src/icons', `${name}.tsx`), value)
   })
 

--- a/packages/components/icons/scripts/utils/componentize.mjs
+++ b/packages/components/icons/scripts/utils/componentize.mjs
@@ -4,11 +4,10 @@ import { parseSync, stringify } from 'svgson'
 const componentize = ({ name = 'componentName', node = '<svg />', tags = [] }) => {
   const {
     children,
-    attributes: { fill, stroke, 'data-title': dataTitle, ...otherAttributes } = {
+    attributes: { fill, stroke, ...otherAttributes } = {
       fill: 'currentColor',
       stroke: 'currentColor',
     },
-    ...others
   } = parseSync(node)
   const nameTags = [name]
 

--- a/packages/components/icons/scripts/utils/indexify.mjs
+++ b/packages/components/icons/scripts/utils/indexify.mjs
@@ -1,6 +1,6 @@
 const indexify = componentsMap =>
   `${Array.from(componentsMap.entries())
-    .map(([name, { dir }]) => `export { ${name} } from './icons/${name}'`)
+    .map(([name]) => `export { ${name} } from './icons/${name}'`)
     .join('\n')}\n`
 
 export default indexify

--- a/packages/components/icons/scripts/utils/tagify.mjs
+++ b/packages/components/icons/scripts/utils/tagify.mjs
@@ -2,9 +2,7 @@ import { camelCase } from 'change-case'
 
 const tagify = componentsMap =>
   `${Array.from(componentsMap.entries())
-    .map(
-      ([name, { dir }]) => `export { tags as ${camelCase(`${name}Tags`)} } from './icons/${name}'`
-    )
+    .map(([name]) => `export { tags as ${camelCase(`${name}Tags`)} } from './icons/${name}'`)
     .join('\n')}\n`
 
 export default tagify

--- a/packages/components/icons/scripts/utils/writeFile.mjs
+++ b/packages/components/icons/scripts/utils/writeFile.mjs
@@ -3,7 +3,7 @@ import path from 'path'
 
 const writeFile = (file, data, cwd = process.cwd()) => {
   const filePath = path.relative(cwd, file)
-  const { root, dir, base, ext, name } = path.parse(filePath)
+  const { dir, base } = path.parse(filePath)
   fs.mkdirSync(path.dirname(file), { recursive: true })
 
   return fs.writeFileSync(path.join(dir, base), data)

--- a/packages/components/popover/src/PopoverHeader.tsx
+++ b/packages/components/popover/src/PopoverHeader.tsx
@@ -1,5 +1,6 @@
 import { useId } from '@radix-ui/react-id'
-import { forwardRef, ReactNode, useLayoutEffect } from 'react'
+import { cx } from 'class-variance-authority'
+import { forwardRef, type ReactNode, useLayoutEffect } from 'react'
 
 import { usePopover } from './PopoverContext'
 
@@ -20,7 +21,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
     }, [id, setHeaderId])
 
     return (
-      <header id={id} className="mb-md text-headline-2" {...rest}>
+      <header id={id} className={cx('mb-md text-headline-2', className)} {...rest}>
         {children}
       </header>
     )

--- a/packages/components/radio-group/src/RadioGroup.tsx
+++ b/packages/components/radio-group/src/RadioGroup.tsx
@@ -77,6 +77,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
           ref={ref}
           disabled={disabled}
           orientation={orientation}
+          loop={loop}
           required={required}
           aria-labelledby={labelId}
           aria-invalid={isInvalid}

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -9,7 +9,7 @@ import { Label } from './SwitchLabel'
 export type SwitchProps = InputProps
 
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ value = 'on', size = 'md', children, className, id, disabled, ...rest }, ref) => {
+  ({ size = 'md', children, className, id, disabled, ...rest }, ref) => {
     const field = useFormFieldControl()
 
     const innerId = useId(id)

--- a/packages/utils/cli/src/generate/generators/TemplateGenerator.mjs
+++ b/packages/utils/cli/src/generate/generators/TemplateGenerator.mjs
@@ -1,11 +1,9 @@
-import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { camelCase } from 'camel-case'
 import glob from 'glob'
 import { pascalCase } from 'pascal-case'
 
-import { System } from '../../core/index.mjs'
 import { Generator } from './Generator.mjs'
 
 export class TemplateGenerator extends Generator {

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.stories.tsx].js
@@ -1,21 +1,21 @@
 import { pascalCase } from 'pascal-case'
 
-export default ({ name, description }) => {
+export default ({ name }) => {
   const componentName = pascalCase(name)
 
-  return `import { Meta, StoryFn } from '@storybook/react'
+  return `
+    import { Meta, StoryFn } from '@storybook/react'
+    import { ${componentName} } from '.'
 
-import { ${componentName} } from '.'
+    const meta: Meta<typeof ${componentName}> = {
+      title: 'Components/${componentName}',
+      component: ${componentName},
+    }
 
-const meta: Meta<typeof ${componentName}> = {
-  title: 'Components/${componentName}',
-  component: ${componentName},
-}
+    export default meta
 
-export default meta
-
-export const Default: StoryFn = _args => (
-  <${componentName}>Hello World!</${componentName}>
-)
-`
+    export const Default: StoryFn = _args => (
+      <${componentName}>Hello World!</${componentName}>
+    )
+  `
 }

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.styles.ts].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.styles.ts].js
@@ -1,0 +1,1 @@
+export default () => ''

--- a/packages/utils/cli/src/generate/templates/component/src/[Component.styles.tsx].js
+++ b/packages/utils/cli/src/generate/templates/component/src/[Component.styles.tsx].js
@@ -1,8 +1,0 @@
-import { pascalCase } from 'pascal-case'
-
-export default ({ name }) => {
-  const componentName = pascalCase(name)
-
-  return `
-`
-}

--- a/packages/utils/cli/src/generate/validators/NameValidator.mjs
+++ b/packages/utils/cli/src/generate/validators/NameValidator.mjs
@@ -1,4 +1,3 @@
-import { System } from '../../core/index.mjs'
 import { Validator } from './Validator.mjs'
 
 export class NameValidator extends Validator {

--- a/packages/utils/cli/test/spark-generate.test.ts
+++ b/packages/utils/cli/test/spark-generate.test.ts
@@ -30,7 +30,7 @@ describe('CLI `spark generate` (component package)', () => {
       '/.npmignore',
       '/package.json',
       '/src/index.ts',
-      '/src/Bar.styles.tsx',
+      '/src/Bar.styles.ts',
       '/src/Bar.tsx',
       '/vite.config.ts',
       '/src/Bar.doc.mdx',
@@ -38,6 +38,7 @@ describe('CLI `spark generate` (component package)', () => {
       '/src/Bar.stories.tsx',
       '/tsconfig.json',
     ]
+
     const assertExpectedFiles = (filePath: string) => {
       expect(response).toContain(`Created ${packagePath}${filePath}`)
       expect(fse.pathExistsSync(`${packagePath}${filePath}`)).toBe(true)

--- a/packages/utils/tailwind-plugins/animations/index.js
+++ b/packages/utils/tailwind-plugins/animations/index.js
@@ -19,9 +19,10 @@ const playStates = ['running', 'paused']
 const commonValuesObj = arrToObj(commonValues)
 
 function removeKeyFromObj(obj, key) {
-  const { [key]: _, ...rest } = obj
+  const copyObj = obj
+  delete copyObj[key]
 
-  return rest
+  return copyObj
 }
 
 module.exports = plugin.withOptions(
@@ -36,7 +37,7 @@ module.exports = plugin.withOptions(
    * @returns {Function} The PostCSS plugin function.
    */
   options =>
-    ({ addUtilities, addVariant, matchUtilities, theme }) => {
+    ({ addUtilities, matchUtilities, theme }) => {
       const opts = options || {}
 
       const { variantPrefix = 'spark-anime' } = opts

--- a/packages/utils/tailwind-plugins/utilities/index.js
+++ b/packages/utils/tailwind-plugins/utilities/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const plugin = require('tailwindcss/plugin')
 
-module.exports = plugin.withOptions(options => ({ addUtilities, theme }) => {
+module.exports = plugin.withOptions(() => ({ addUtilities, theme }) => {
   addUtilities({
     '.u-current-font-size': {
       width: '1em',

--- a/packages/utils/tailwind-plugins/variants/index.js
+++ b/packages/utils/tailwind-plugins/variants/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const plugin = require('tailwindcss/plugin')
 
-module.exports = plugin.withOptions(options => ({ addVariant, e }) => {
+module.exports = plugin.withOptions(() => ({ addVariant }) => {
   addVariant('retina', '@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)')
 })


### PR DESCRIPTION
**TASK**: #1110 

### Description, Motivation and Context
We initially turned off the ESLint rule for unused vars. This lead some issues we want to fix.

Most of changes should have minimal impact, but in some cases we should check that everything still works as expected (ex. when declared props weren't used within a component):
- `PopoverHeader`
- `RadioGroup`
- `Switch`

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧠 Refactor
