### PR TITLE
feat(dialog): header footer and body behaviour

### DIFF
--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -43,7 +43,21 @@ import { Dialog } from '@spark-ui/dialog'
     },
     'Dialog.Content': {
       of: Dialog.Content,
-      description: 'Contains content to be rendered in the open dialog.',
+      description: 'Contains Header/Body/Footer to be rendered in the open dialog.',
+    },
+    'Dialog.Header': {
+      of: Dialog.Header,
+      description: 'To use inside of Popover.Content. Sticky header inside the dialog.',
+    },
+    'Dialog.Body': {
+      of: Dialog.Body,
+      description:
+        'To use inside of Popover.Content. Main content of the dialog. Becomes scrollable when content is overflowing the screen.',
+    },
+    'Dialog.Footer': {
+      of: Dialog.Footer,
+      description:
+        'To use inside of Popover.Content. Sticky footer to be rendered in the open dialog. Use it to render CTAs and make them accessible in every condition.',
     },
     'Dialog.CloseButton': {
       of: Dialog.CloseButton,

--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -1,5 +1,6 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { Kbd } from '@spark-ui/kbd'
 
 import { Dialog } from '.'
 
@@ -11,13 +12,23 @@ import * as stories from './Dialog.stories'
 
 A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 
+- ✅ Supports modal and non-modal modes.
+- ✅ Focus is automatically trapped when modal.
+- ✅ Can be controlled or uncontrolled.
+- ✅ Manages screen reader announcements with `Title` and `Description` components.
+- ✅ Esc closes the component automatically.
+
 ## Install
+
+Install the component from your command line.
 
 ```sh
 npm install @spark-ui/dialog
 ```
 
 ## Import
+
+Import all parts and piece them together.
 
 ```tsx
 import { Dialog } from '@spark-ui/dialog'
@@ -77,3 +88,21 @@ import { Dialog } from '@spark-ui/dialog'
 ## Usage
 
 <Canvas of={stories.Usage} />
+
+## Accessibility
+
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+
+### Guidelines
+
+- **Usage of `Dialog.Title` is mandatory**. It serves as the accessible name for the dialog. If you prefer not to display the title, you can wrap it with `VisuallyHidden`.
+- **`Dialog.CloseButton` must be rendered as the last child of `Dialog.Content`**. When opening, the dialog forwards the focus to the first interactive element inside of it, it shouldn't be the close button. User can use `Shift + Tab` to easily access the close button after the dialog has been opened.
+- Be careful not to overlap content with `Dialog.CloseButton`, which has a large clickable area.
+
+### Keyboard Interactions
+
+- <Kbd>Space</Kbd> - Opens/closes the dialog.
+- <Kbd>Enter</Kbd> - Opens/closes the dialog.
+- <Kbd>Tab</Kbd> - Moves focus to the next focusable element.
+- <Kbd>Shift + Tab</Kbd> - Moves focus to the previous focusable element.
+- <Kbd>Esc</Kbd> - Closes the dialog and moves focus to `Dialog.Trigger`.

--- a/packages/components/dialog/src/Dialog.stories.tsx
+++ b/packages/components/dialog/src/Dialog.stories.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@spark-ui/button'
 import { Meta, StoryFn } from '@storybook/react'
+import { useState } from 'react'
 
 import { Dialog } from '.'
 
@@ -10,21 +11,46 @@ const meta: Meta<typeof Dialog> = {
 
 export default meta
 
-export const Usage: StoryFn = _args => {
+export const Usage: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <Dialog.Trigger asChild>
         <Button>Edit profile</Button>
       </Dialog.Trigger>
+
       <Dialog.Portal>
         <Dialog.Overlay />
-        <Dialog.Content>
-          <Dialog.Title>Edit profile</Dialog.Title>
-          <Dialog.Description>
-            Make changes to your profile here. Click save when you are done.
-          </Dialog.Description>
 
-          <p>Dialog contents</p>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Edit profile</Dialog.Title>
+          </Dialog.Header>
+
+          <Dialog.Body>
+            <Dialog.Description>
+              Make changes to your profile here. Click save when you are done.
+            </Dialog.Description>
+
+            {Array.from({ length: 10 }, (_, index) => (
+              <p key={index}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+                irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum.
+              </p>
+            ))}
+          </Dialog.Body>
+
+          <Dialog.Footer className="flex justify-end gap-md">
+            <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button>Submit</Button>
+          </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit profile" />
         </Dialog.Content>

--- a/packages/components/dialog/src/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog.tsx
@@ -1,8 +1,11 @@
 import type { FC } from 'react'
 
+import { Body } from './DialogBody'
 import { CloseButton } from './DialogCloseButton'
 import { Content } from './DialogContent'
 import { Description } from './DialogDescription' // aria-describedby
+import { Footer } from './DialogFooter'
+import { Header } from './DialogHeader'
 import { Overlay } from './DialogOverlay'
 import { Portal } from './DialogPortal'
 import { Root, type RootProps } from './DialogRoot'
@@ -13,6 +16,9 @@ Trigger.displayName = 'Dialog.Trigger'
 Portal.displayName = 'Dialog.Portal'
 Overlay.displayName = 'Dialog.Overlay'
 Content.displayName = 'Dialog.Content'
+Header.displayName = 'Dialog.Header'
+Body.displayName = 'Dialog.Body'
+Footer.displayName = 'Dialog.Footer'
 CloseButton.displayName = 'Dialog.CloseButton'
 Title.displayName = 'Dialog.Title'
 Description.displayName = 'Dialog.Description'
@@ -22,6 +28,9 @@ export const Dialog: FC<RootProps> & {
   Portal: typeof Portal
   Overlay: typeof Overlay
   Content: typeof Content
+  Header: typeof Header
+  Body: typeof Body
+  Footer: typeof Footer
   CloseButton: typeof CloseButton
   Title: typeof Title
   Description: typeof Description
@@ -30,6 +39,9 @@ export const Dialog: FC<RootProps> & {
   Portal,
   Overlay,
   Content,
+  Header,
+  Body,
+  Footer,
   CloseButton,
   Title,
   Description,

--- a/packages/components/dialog/src/DialogBody.tsx
+++ b/packages/components/dialog/src/DialogBody.tsx
@@ -10,7 +10,6 @@ export const Body = forwardRef(
   ({ children, className, ...rest }: BodyProps, ref: Ref<HTMLDivElement>): ReactElement => (
     <div
       ref={ref}
-      tabIndex={0}
       className={cx(
         className,
         ['px-xl', 'py-md', 'flex-grow', 'overflow-y-auto'],

--- a/packages/components/dialog/src/DialogBody.tsx
+++ b/packages/components/dialog/src/DialogBody.tsx
@@ -1,0 +1,26 @@
+import { cx } from 'class-variance-authority'
+import { forwardRef, type ReactElement, type ReactNode, type Ref } from 'react'
+
+export interface BodyProps {
+  children: ReactNode
+  className?: string
+}
+
+export const Body = forwardRef(
+  ({ children, className, ...rest }: BodyProps, ref: Ref<HTMLDivElement>): ReactElement => (
+    <div
+      ref={ref}
+      tabIndex={0}
+      className={cx(
+        className,
+        ['px-xl', 'py-md', 'flex-grow', 'overflow-y-auto'],
+        ['outline-none', 'focus-visible:ring-2', 'focus-visible:ring-outline-high']
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+)
+
+Body.displayName = 'Dialog.Body'

--- a/packages/components/dialog/src/DialogContent.styles.tsx
+++ b/packages/components/dialog/src/DialogContent.styles.tsx
@@ -1,0 +1,27 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const dialogContentStyles = cva([['fixed', 'z-modal', 'flex', 'flex-col'], ['bg-surface']], {
+  variants: {
+    size: {
+      fullscreen: ['w-screen', 'h-screen'],
+      sm: ['max-w-sz-480'],
+      md: ['max-w-sz-640'],
+      lg: ['max-w-sz-768'],
+    },
+  },
+  compoundVariants: [
+    {
+      size: ['sm', 'md', 'lg'],
+      class: [
+        ['top-1/2', 'left-1/2', '-translate-x-1/2', '-translate-y-1/2'],
+        ['w-full', 'max-h-[90%]', 'min-h-sz-240'],
+        ['shadow-md', 'rounded-lg'],
+      ],
+    },
+  ],
+  defaultVariants: {
+    size: 'md',
+  },
+})
+
+export type DialogContentStylesProps = VariantProps<typeof dialogContentStyles>

--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -1,35 +1,7 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
-import { cva, VariantProps } from 'class-variance-authority'
 import { forwardRef, type ReactElement, type Ref } from 'react'
 
-const dialogContentStyles = cva(
-  [
-    ['fixed', 'top-1/2', 'left-1/2', '-translate-x-1/2', '-translate-y-1/2', 'z-modal'],
-    ['bg-surface'],
-    ['p-xl'],
-  ],
-  {
-    variants: {
-      size: {
-        fullscreen: ['w-screen', 'h-screen'],
-        sm: ['max-w-sz-480'],
-        md: ['max-w-sz-640'],
-        lg: ['max-w-sz-768'],
-      },
-    },
-    compoundVariants: [
-      {
-        size: ['sm', 'md', 'lg'],
-        class: ['shadow-md', 'rounded-lg', 'w-full'],
-      },
-    ],
-    defaultVariants: {
-      size: 'md',
-    },
-  }
-)
-
-export type DialogContentStylesProps = VariantProps<typeof dialogContentStyles>
+import { dialogContentStyles, type DialogContentStylesProps } from './DialogContent.styles'
 
 export type ContentProps = RadixDialog.DialogContentProps & DialogContentStylesProps
 

--- a/packages/components/dialog/src/DialogFooter.tsx
+++ b/packages/components/dialog/src/DialogFooter.tsx
@@ -1,0 +1,17 @@
+import { cx } from 'class-variance-authority'
+import { forwardRef, type ReactElement, type ReactNode, type Ref } from 'react'
+
+export interface FooterProps {
+  children: ReactNode
+  className?: string
+}
+
+export const Footer = forwardRef(
+  ({ children, className, ...rest }: FooterProps, ref: Ref<HTMLDivElement>): ReactElement => (
+    <footer ref={ref} className={cx(className, ['px-xl', 'py-lg'])} {...rest}>
+      {children}
+    </footer>
+  )
+)
+
+Footer.displayName = 'Dialog.Footer'

--- a/packages/components/dialog/src/DialogHeader.tsx
+++ b/packages/components/dialog/src/DialogHeader.tsx
@@ -1,0 +1,17 @@
+import { cx } from 'class-variance-authority'
+import { forwardRef, type ReactElement, type ReactNode, type Ref } from 'react'
+
+export interface HeaderProps {
+  children: ReactNode
+  className?: string
+}
+
+export const Header = forwardRef(
+  ({ children, className, ...rest }: HeaderProps, ref: Ref<HTMLDivElement>): ReactElement => (
+    <header ref={ref} className={cx(className, ['px-xl', 'py-lg'])} {...rest}>
+      {children}
+    </header>
+  )
+)
+
+Header.displayName = 'Dialog.Header'

--- a/packages/components/dialog/src/index.ts
+++ b/packages/components/dialog/src/index.ts
@@ -5,5 +5,8 @@ export { type OverlayProps } from './DialogOverlay'
 export { type PortalProps } from './DialogPortal'
 export { type TitleProps } from './DialogTitle'
 export { type TriggerProps } from './DialogTrigger'
+export { type HeaderProps } from './DialogHeader'
+export { type BodyProps } from './DialogBody'
+export { type FooterProps } from './DialogFooter'
 
 export { Dialog } from './Dialog'


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1101 

### Description, Motivation and Context

- added `Dialog.Header` (sticky)
- added `Dialog.Body` (scrollable when content overflows)
- added `Dialog.Footer` (sticky)

a11y: 

- This [Axe rule](https://dequeuniversity.com/rules/axe/4.7/scrollable-region-focusable?application=AxeChrome) is saying that the body must be focusable or have a focusable child in order to be scrollable using the keyboard (Space or Shift + Space)

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/e50027e2-0b21-44d2-91c1-b243160064ad


