### PR TITLE
style(dialog): fixed fullscreen size and title styles

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -25,12 +25,12 @@
     max-width: unset;
   }
 
-  h1 {
+  .sbdocs > h1 {
     color: #140E79 !important;
     font-weight: 700 !important;
   }
 
-  h2, h3, h4, h5 {
+  .sbdocs > h2, .sbdocs > h3, .sbdocs > h4, .sbdocs > h5 {
     color: #982253 !important;
     font-weight: 700 !important;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,6 +2286,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",

--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -89,6 +89,12 @@ import { Dialog } from '@spark-ui/dialog'
 
 <Canvas of={stories.Usage} />
 
+## Sizes
+
+Pick a size among `sm`, `md`, `lg` and `fullscreen`.
+
+<Canvas of={stories.Sizes} />
+
 ## Accessibility
 
 Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).

--- a/packages/components/dialog/src/Dialog.stories.tsx
+++ b/packages/components/dialog/src/Dialog.stories.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@spark-ui/button'
+import { RadioGroup } from '@spark-ui/radio-group'
 import { Meta, StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-import { Dialog } from '.'
+import { type ContentProps, Dialog } from '.'
 
 const meta: Meta<typeof Dialog> = {
   title: 'Experimental/Dialog',
@@ -56,5 +57,54 @@ export const Usage: StoryFn = () => {
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog>
+  )
+}
+
+export const Sizes = () => {
+  const [size, setSizes] = useState<ExcludeNull<ContentProps>['size']>('md')
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog.Trigger asChild>
+          <Button>Edit size</Button>
+        </Dialog.Trigger>
+
+        <Dialog.Portal>
+          <Dialog.Overlay />
+
+          <Dialog.Content size={size}>
+            <Dialog.Header>
+              <Dialog.Title>Edit size</Dialog.Title>
+            </Dialog.Header>
+
+            <Dialog.Body className="flex flex-col gap-lg">
+              <Dialog.Description>Please select a dialog size</Dialog.Description>
+
+              <RadioGroup
+                className="flex gap-md"
+                value={size}
+                onValueChange={value => setSizes(value as ExcludeNull<ContentProps>['size'])}
+              >
+                <RadioGroup.Radio value="sm">Small</RadioGroup.Radio>
+                <RadioGroup.Radio value="md">Medium</RadioGroup.Radio>
+                <RadioGroup.Radio value="lg">Large</RadioGroup.Radio>
+                <RadioGroup.Radio value="fullscreen">Fullscreen</RadioGroup.Radio>
+              </RadioGroup>
+            </Dialog.Body>
+
+            <Dialog.Footer className="flex justify-end gap-md">
+              <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button>Submit</Button>
+            </Dialog.Footer>
+
+            <Dialog.CloseButton aria-label="Close edit size" />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    </>
   )
 }

--- a/packages/components/dialog/src/DialogContent.styles.tsx
+++ b/packages/components/dialog/src/DialogContent.styles.tsx
@@ -3,7 +3,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 export const dialogContentStyles = cva([['fixed', 'z-modal', 'flex', 'flex-col'], ['bg-surface']], {
   variants: {
     size: {
-      fullscreen: ['w-screen', 'h-screen'],
+      fullscreen: ['inset-none'],
       sm: ['max-w-sz-480'],
       md: ['max-w-sz-640'],
       lg: ['max-w-sz-768'],

--- a/packages/components/dialog/src/DialogTitle.tsx
+++ b/packages/components/dialog/src/DialogTitle.tsx
@@ -1,10 +1,13 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
+import { cx } from 'class-variance-authority'
 import { type ReactElement } from 'react'
 
 export type TitleProps = RadixDialog.DialogTitleProps
 
-export const Title = ({ children, ...rest }: TitleProps): ReactElement => (
-  <RadixDialog.Title {...rest}>{children}</RadixDialog.Title>
+export const Title = ({ className, children, ...rest }: TitleProps): ReactElement => (
+  <RadixDialog.Title {...rest} className={cx('text-on-surface text-headline-2', className)}>
+    {children}
+  </RadixDialog.Title>
 )
 
 Title.displayName = 'Dialog.Title'


### PR DESCRIPTION
### Description, Motivation and Context

- use of `inset` to position fullscreen `dialog`
- added story to display `sizes`
- fixed global sb styles interfering with our components styles in stories

### Types of changes
- [x] 🧾 Documentation
- [x] 🧠 Refactor
- [x] 💄 Styles
