### PR TITLE
docs: new agreement for stories order

### DIFF
--- a/documentation/contributing/writing-packages/WritingStories.mdx
+++ b/documentation/contributing/writing-packages/WritingStories.mdx
@@ -1,8 +1,6 @@
 import { Meta } from '@storybook/blocks'
 import { Callout } from '@docs/helpers/Callout'
 
-import ArgstableImg from '@docs/assets/argstable.png'
-
 <Meta title="Contributing/Writing packages/Documentation" />
 
 # Writing stories
@@ -19,113 +17,181 @@ Each component must have a `doc` and a `stories` file. For example:
   - This file contains every example (story) for your component.
   - It is using the CSF format.
 
-## Docs
+**Only the `docs` file will be visible in the sidebar**
 
-### Docs guidelines
+## Docs page
 
-- Every Docs file must have the following extension: `*.doc.mdx`.
-- You must write the following sections in the same order for every component.
+- Every Docs file must have the following extension: `*.doc.mdx` (ex: `Input.doc.mdx`).
+- **You must write the following sections in the same order for every component.**
 
-### 1. Referencing the Meta
+### 1. Title
 
-The meta is the semantic information about the documented component.
-It must be located in the `*stories.tsx` file, but must be referenced in this one to link both files.
+Every page must have an `h1` heading, followed by the description of the component.
 
 ```
-// Radio.doc.mdx
+# Input
 
+Component used to get user input in a text field, etc.
+```
+
+### 2. Meta
+
+The meta is the semantic information about the documented component. Storybook needs it to properly link the `docs` page to its stories.
+
+The meta itself must be declared in the `*stories.tsx` file, but must be referenced in this one to link both files.
+
+```
 import { Meta } from '@storybook/addon-docs'
 
-import * as RadioStories from './Radio.stories'
+import * as stories from './Input.stories'
 
-<Meta of={RadioStories} />
+<Meta of={stories} />
 ```
 
-### 2. Install
+### 3. Install
 
 Add a section to show developers how to install this component on their repository.
 
 ````
-// Radio.doc.mdx
-
 ## Install
 
-\```sh
-npm install @spark-ui/radio-group
-\```
+Install the component from your command line.
+
+```sh
+npm install @spark-ui/input
+```
 ````
 
-### 3. Import
+### 4. Import
 
 Add a section to show developers how to import this component from their repository.
 
 ````
-// Radio.doc.mdx
-
 ## Import
 
-\```ts
-import { RadioGroup, Radio } from '@spark-ui/radio-group'
-\```
+Import all parts and piece them together.
+
+```tsx
+import { Input, InputGroup } from '@spark-ui/input'
+```
 ````
 
-### 4. Props
+### 5. Props table
 
-#### Props for single components
+We provide a custom `ArgTypes` component to display the component's props. This component also works for compound components, as opposed to Storybook native one.
 
-For prop, we rely on `ArgTypes` to read TS files and generate them automatically.
+**For compound components, you can use `subcomponent` key to also showcase props for each.**
 
 ```
-// Radio.doc.mdx
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 
-import { ArgTypes } from '@storybook/blocks';
-
-import { Radio } from '.'
-
-## Props
-
-<ArgTypes of={Radio} />
+<ArgTypes
+  of={Input}
+  description="Input component is a component that is used to get user input in a text field."
+  subcomponents={{
+    InputGroup: {
+      of: InputGroup,
+      description:
+        'Use this wrapper whenever you need a more complex text input. For example if you need to have leading/trailing icons or addons.',
+    },
+    'InputGroup.LeadingAddon': {
+      of: InputGroup.LeadingAddon,
+      description:
+        'Add any type of component that will be displayed before the input field.\n This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
+    },
+    etc...
+  }}
+/>
 ```
 
-**Here is what the ArgTypes looks like for a simple component:**
+### 5. Usage
 
-<img width={800} src={ArgstableImg} alt="ArgTypes shows a table of the component's props" />
+From here you will showcase examples of how to use your component in a "feature by feature" way.
 
-#### Props for compound components
-
-TODO
-
-### 5. Linking stories
-
-Stories are imported from the associated `*.stories.tsx` file, which is written with CSF format.
-
-`Canvas` is used to allow preview of source code for each story.
+- **Each story should come with an explicit description preceding the interactive canvas**
+- **Each story displayed under this section should be in a very specific order (for consistency)**
+  - "Default" (a minimal story showcasing how to use your component for the most common case)
+  - "Uncontrolled" (stateful example where you don't use props but rely on internal state)
+  - "Controlled" (stateless example where you use props instead of internal state)
+  - **Every other example should be sorted in alphabetical order**
 
 <Callout kind="warning">
   Each story should showcase a single prop/feature of your component. **Avoid stories mixing many
   properties at once to keep things simple**.
 </Callout>
 
+Example `input` "Usage" section:
+
 ```
-// RadioGroup.doc.mdx
 
 import { Canvas, Story } from '@storybook/addon-docs'
 
-## Default
+## Usage
 
-Compound `RadioGroup` and `Radio` components to create a radio group.
+### Default
 
-<Canvas>
-  <Story of={RadioStories.Default} />
-</Canvas>
+<Canvas of={stories.Default} />
+
+### Uncontrolled
+
+Use `defaultValue` prop to set the default value of the input. Optionally `onChange` prop can be used to know when the value of the input changes.
+
+<Canvas of={stories.Uncontrolled} />
+
+### Controlled
+
+Use `value` and `onChange` props to control the value of the input.
+
+<Canvas of={stories.Controlled} />
+
+### Addons
+
+Each `InputGroup` can have a `LeadingAddon` and a `TrailingAddon`. You can use them to achieve more complex custom inputs. Addons can be decorative or interactive.
+
+**Note: we advise to use `solid` addons when possible to give the user a better clickable area**
+
+<Canvas of={stories.Addons} />
+
+### Disabled
+
+To indicate that an input is disabled, use the `disabled` prop. If you're wrapping your `Input` with an `InputGroup`, set the prop on the group instead.
+
+<Canvas of={stories.Disabled} />
+
+### etc. (be careful about alphabetical order)
 ```
 
-### 6. Accessibility
+### 6. Advanced Usage
+
+Same as previous section, but this is where you should move more advanced examples:
+
+- Combination with other Spark components
+- Highly customized styles to showcase alternate use
+- Obscure features that are reserved for edge-cases or should not be encouraged
+
+The goal of this section is to keep "Usage" clean and focused on most generic usage of the component.
+
+```
+## Advanced usage
+
+### Search
+
+Let's use `InputGroup` and its components to create a search input with a clear button
+
+<Canvas of={stories.SearchExample} />
+
+### Password
+
+Let's use `InputGroup` and its components to create a password input with a show/hide password functionality
+
+<Canvas of={stories.PasswordExample} />
+```
+
+### 7. Accessibility
 
 It is nice to add an `Accessibility` section at the end to summarize keyboard interactions and important a11y requirements of the component.
 
 ```
-// Radio.doc.mdx
 
 ## Accessibility
 
@@ -176,8 +242,8 @@ export default meta
 Please refer to [official Storybook documentation](https://storybook.js.org/docs/7.0/react/writing-stories/introduction#defining-stories) to see how you can write stories
 
 <Callout kind="warning">
-  Each story must use the `_args` parameter, otherwise the `show source` button of the Canvas will
-  show raw js code instead of dynamic JSX.
+  Avoid using `_args` if you story has some JS logic (`useState`, etc). When using `_args`, only JSX
+  will be visible when interacting the `show source` button of the Canvas.
 </Callout>
 
 ```tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -29560,6 +29560,7 @@
       }
     },
     "packages/components/alert-dialog": {
+      "name": "@spark-ui/alert-dialog",
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
@@ -29601,6 +29602,7 @@
       }
     },
     "packages/components/badge": {
+      "name": "@spark-ui/badge",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29620,6 +29622,7 @@
       "integrity": "sha512-Rq3MrD+KASXobcTIqec4RVXRTcBGMNgQq0Q8YMxlorSHTVJTFCoLBZkJkrrZZWCuEYKl3a2X39DXSMOmWnq44w=="
     },
     "packages/components/button": {
+      "name": "@spark-ui/button",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29670,6 +29673,7 @@
       }
     },
     "packages/components/checkbox": {
+      "name": "@spark-ui/checkbox",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29794,6 +29798,7 @@
       }
     },
     "packages/components/dialog": {
+      "name": "@spark-ui/dialog",
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
@@ -29851,6 +29856,7 @@
       }
     },
     "packages/components/form-field": {
+      "name": "@spark-ui/form-field",
       "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
@@ -29928,6 +29934,7 @@
       }
     },
     "packages/components/icon": {
+      "name": "@spark-ui/icon",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29942,6 +29949,7 @@
       }
     },
     "packages/components/icon-button": {
+      "name": "@spark-ui/icon-button",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29991,6 +29999,7 @@
       }
     },
     "packages/components/icons": {
+      "name": "@spark-ui/icons",
       "version": "1.19.5",
       "license": "MIT",
       "devDependencies": {
@@ -30007,6 +30016,7 @@
       }
     },
     "packages/components/input": {
+      "name": "@spark-ui/input",
       "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
@@ -30137,6 +30147,7 @@
       }
     },
     "packages/components/kbd": {
+      "name": "@spark-ui/kbd",
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
@@ -30150,6 +30161,7 @@
       }
     },
     "packages/components/label": {
+      "name": "@spark-ui/label",
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
@@ -30164,6 +30176,7 @@
       }
     },
     "packages/components/popover": {
+      "name": "@spark-ui/popover",
       "version": "1.0.15",
       "dependencies": {
         "@radix-ui/react-id": "1.0.0",
@@ -30223,6 +30236,7 @@
       }
     },
     "packages/components/portal": {
+      "name": "@spark-ui/portal",
       "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
@@ -30295,6 +30309,7 @@
       }
     },
     "packages/components/radio-group": {
+      "name": "@spark-ui/radio-group",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -30368,6 +30383,7 @@
       "integrity": "sha512-Rq3MrD+KASXobcTIqec4RVXRTcBGMNgQq0Q8YMxlorSHTVJTFCoLBZkJkrrZZWCuEYKl3a2X39DXSMOmWnq44w=="
     },
     "packages/components/slot": {
+      "name": "@spark-ui/slot",
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
@@ -30380,6 +30396,7 @@
       }
     },
     "packages/components/spinner": {
+      "name": "@spark-ui/spinner",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -30413,6 +30430,7 @@
       }
     },
     "packages/components/switch": {
+      "name": "@spark-ui/switch",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -30540,6 +30558,7 @@
       }
     },
     "packages/components/tabs": {
+      "name": "@spark-ui/tabs",
       "version": "2.0.2",
       "dependencies": {
         "@radix-ui/react-tabs": "1.0.4",
@@ -30601,6 +30620,7 @@
       }
     },
     "packages/components/tag": {
+      "name": "@spark-ui/tag",
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
@@ -30633,6 +30653,7 @@
       }
     },
     "packages/components/textarea": {
+      "name": "@spark-ui/textarea",
       "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
@@ -30684,6 +30705,7 @@
       "integrity": "sha512-TmDoZtSSLna5OtS+pHAbXmthXmE3oHWIOwz1mRqWf2i6KfwJjtOs7TYLBLXD3l6rVVp99RJFhizZIkAzKrrfXA=="
     },
     "packages/components/visually-hidden": {
+      "name": "@spark-ui/visually-hidden",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
@@ -30696,6 +30718,7 @@
       }
     },
     "packages/hooks/use-combined-state": {
+      "name": "@spark-ui/use-combined-state",
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
@@ -30718,6 +30741,7 @@
       }
     },
     "packages/hooks/use-merge-refs": {
+      "name": "@spark-ui/use-merge-refs",
       "version": "0.3.4",
       "license": "MIT",
       "peerDependencies": {
@@ -30726,6 +30750,7 @@
       }
     },
     "packages/hooks/use-mounted-state": {
+      "name": "@spark-ui/use-mounted-state",
       "version": "0.2.2",
       "license": "MIT",
       "peerDependencies": {
@@ -30734,6 +30759,7 @@
       }
     },
     "packages/utils/cli": {
+      "name": "@spark-ui/cli-utils",
       "version": "2.11.13",
       "license": "MIT",
       "dependencies": {
@@ -30768,10 +30794,12 @@
       }
     },
     "packages/utils/internal-utils": {
+      "name": "@spark-ui/internal-utils",
       "version": "2.0.2",
       "license": "MIT"
     },
     "packages/utils/tailwind-plugins": {
+      "name": "@spark-ui/tailwind-plugins",
       "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
@@ -30792,6 +30820,7 @@
       }
     },
     "packages/utils/theme": {
+      "name": "@spark-ui/theme-utils",
       "version": "3.0.2",
       "license": "MIT",
       "dependencies": {

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -1,6 +1,5 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
-import { ArgTypes } from '@storybook/blocks'
-import { ArgTypes as ExtendedArgTypes } from '@docs/helpers/ArgTypes'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 
 import { Input, InputGroup } from '.'
 
@@ -28,7 +27,7 @@ import { Input, InputGroup } from '@spark-ui/input'
 
 ## Props
 
-<ExtendedArgTypes
+<ArgTypes
   of={Input}
   description="Input component is a component that is used to get user input in a text field."
   subcomponents={{
@@ -66,21 +65,23 @@ import { Input, InputGroup } from '@spark-ui/input'
 
 ## Usage
 
-<Canvas of={stories.Usage} />
+### Default
 
-## Uncontrolled
+<Canvas of={stories.Default} />
+
+### Uncontrolled
 
 Use `defaultValue` prop to set the default value of the input. Optionally `onChange` prop can be used to know when the value of the input changes.
 
 <Canvas of={stories.Uncontrolled} />
 
-## Controlled
+### Controlled
 
 Use `value` and `onChange` props to control the value of the input.
 
 <Canvas of={stories.Controlled} />
 
-## Addons
+### Addons
 
 Each `InputGroup` can have a `LeadingAddon` and a `TrailingAddon`. You can use them to achieve more complex custom inputs. Addons can be decorative or interactive.
 
@@ -88,37 +89,39 @@ Each `InputGroup` can have a `LeadingAddon` and a `TrailingAddon`. You can use t
 
 <Canvas of={stories.Addons} />
 
-## Icons
-
-An `InputGroup` can have a `LeadingIcon` and/or `TrailingIcon`. Please note that the `TrailingIcon` will be automatically replaced by the state indicator if the input has one (`error`, `alert` or `success`).
-
-<Canvas of={stories.Icons} />
-
-## Disabled
+### Disabled
 
 To indicate that an input is disabled, use the `disabled` prop. If you're wrapping your `Input` with an `InputGroup`, set the prop on the group instead.
 
 <Canvas of={stories.Disabled} />
 
-## State
+### Icons
+
+An `InputGroup` can have a `LeadingIcon` and/or `TrailingIcon`. Please note that the `TrailingIcon` will be automatically replaced by the state indicator if the input has one (`error`, `alert` or `success`).
+
+<Canvas of={stories.Icons} />
+
+### State
 
 Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
 
 <Canvas of={stories.State} />
 
-## Search
+## Advanced usage
+
+### Search
 
 Let's use `InputGroup` and its components to create a search input with a clear button
 
 <Canvas of={stories.SearchExample} />
 
-## Password
+### Password
 
 Let's use `InputGroup` and its components to create a password input with a show/hide password functionality
 
 <Canvas of={stories.PasswordExample} />
 
-## FormField
+## Form field
 
 When using the `Input` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.
 

--- a/packages/components/input/src/Input.stories.tsx
+++ b/packages/components/input/src/Input.stories.tsx
@@ -22,7 +22,9 @@ const meta: Meta<typeof Input> = {
 
 export default meta
 
-export const Usage: StoryFn = _args => <Input placeholder="Type here..." aria-label="Phone type" />
+export const Default: StoryFn = _args => (
+  <Input placeholder="Type here..." aria-label="Phone type" />
+)
 
 export const Uncontrolled: StoryFn = _args => (
   <Input defaultValue="IPhone 12" aria-label="Phone type" />


### PR DESCRIPTION
### Description, Motivation and Context

During the sharing session this morning we agreed on updating the guidelines on how to sort/order the stories in a cohesive way across component.

Here is the proposal with the adapted "Input" (other components will be updated in separate PRs)

### Types of changes
- [x] 🧾 Documentation


### Screenshots - Animations
![Capture d’écran 2023-08-02 à 18 24 20](https://github.com/adevinta/spark/assets/2033710/eac3833b-9e08-4f61-bc32-56d15d6a903d)


