### PR TITLE
docs(textarea): updated docs to match latest agreements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,6 +2288,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",

--- a/packages/components/checkbox/src/Checkbox.doc.mdx
+++ b/packages/components/checkbox/src/Checkbox.doc.mdx
@@ -132,11 +132,11 @@ When implementing a custom checkbox, it is important to be careful to properly h
 
 When using the `Checkbox` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.
 
-### Label
+### Helper message
 
-Use `FormField.Label` to add a label to the input.
+Use the `FormField.HelperMessage` component to provide a description to the input.
 
-<Canvas of={stories.FieldLabel} />
+<Canvas of={stories.FieldHelperMessage} />
 
 #### Hidden label
 
@@ -144,17 +144,17 @@ In certain cases, a visible label may not be necessary, such as when using an in
 
 <Canvas of={stories.FieldHiddenLabel} />
 
+### Label
+
+Use `FormField.Label` to add a label to the input.
+
+<Canvas of={stories.FieldLabel} />
+
 ### Required
 
 Use the `isRequired` prop of the `FormField` to indicate that the input is required.
 
 <Canvas of={stories.FieldRequired} />
-
-### Helper message
-
-Use the `FormField.HelperMessage` component to provide a description to the input.
-
-<Canvas of={stories.FieldHelperMessage} />
 
 ### Validation
 

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -131,23 +131,11 @@ Let's use `InputGroup` and its components to create a password input with a show
 
 When using the `Input` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.
 
-### Label
+### Characters count
 
-Use `FormField.Label` to add a label to the input.
+Use the `FormField.CharactersCount` component to display the actual text count and the max length allowed.
 
-<Canvas of={stories.FieldLabel} />
-
-#### Hidden label
-
-In certain cases, a visible label may not be necessary, such as when using an input as a searcher. To achieve this behavior, use the `VisuallyHidden` component.
-
-<Canvas of={stories.FieldHiddenLabel} />
-
-### Required
-
-Use the `isRequired` prop of the `FormField` to indicate that the input is required.
-
-<Canvas of={stories.FieldRequired} />
+<Canvas of={stories.FieldCharactersCount} />
 
 ### Helper message
 
@@ -155,11 +143,23 @@ Use the `FormField.HelperMessage` component to provide a description to the inpu
 
 <Canvas of={stories.FieldHelperMessage} />
 
-### Characters count
+#### Hidden label
 
-Use the `FormField.CharactersCount` component to display the actual text count and the max length allowed.
+In certain cases, a visible label may not be necessary, such as when using an input as a searcher. To achieve this behavior, use the `VisuallyHidden` component.
 
-<Canvas of={stories.FieldCharactersCount} />
+<Canvas of={stories.FieldHiddenLabel} />
+
+### Label
+
+Use `FormField.Label` to add a label to the input.
+
+<Canvas of={stories.FieldLabel} />
+
+### Required
+
+Use the `isRequired` prop of the `FormField` to indicate that the input is required.
+
+<Canvas of={stories.FieldRequired} />
 
 ### Validation
 

--- a/packages/components/textarea/src/Textarea.doc.mdx
+++ b/packages/components/textarea/src/Textarea.doc.mdx
@@ -50,63 +50,51 @@ import { Textarea, TextareaGroup } from '@spark-ui/textarea'
 
 <Canvas of={stories.Default} />
 
-## Uncontrolled
+### Uncontrolled
 
 Use `defaultValue` prop to set the default value of the textarea. Optionally `onChange` prop can be used to know when the value of the textarea changes.
 
 <Canvas of={stories.Uncontrolled} />
 
-## Controlled
+### Controlled
 
 Use `value` and `onChange` props to control the value of the textarea.
 
 <Canvas of={stories.Controlled} />
 
-## Icons
-
-A `TextareaGroup` can have a `LeadingIcon` and/or `TrailingIcon`. Please note that the `TrailingIcon` will be automatically replaced by the state indicator if the input has one (`error`, `alert` or `success`).
-
-<Canvas of={stories.Icon} />
-
-## Resizable
-
-By default, the textarea component is resizable. However, you can set the `isResizable` prop to `false` to disable this feature and prevent resizing.
-
-<Canvas of={stories.Resizable} />
-
-## Disabled
+### Disabled
 
 To indicate that a textarea is disabled, use the `disabled` prop. If you're wrapping your `Textarea` with a `TextareaGroup`, set the prop on the group instead.
 
 <Canvas of={stories.Disabled} />
 
-## State
+### Icons
+
+A `TextareaGroup` can have a `LeadingIcon` and/or `TrailingIcon`. Please note that the `TrailingIcon` will be automatically replaced by the state indicator if the input has one (`error`, `alert` or `success`).
+
+<Canvas of={stories.Icon} />
+
+### Resizable
+
+By default, the textarea component is resizable. However, you can set the `isResizable` prop to `false` to disable this feature and prevent resizing.
+
+<Canvas of={stories.Resizable} />
+
+### State
 
 Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
 
 <Canvas of={stories.State} />
 
-## FormField
+## Form field
 
 When using the `Textarea` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.
 
-### Label
+### Characters count
 
-Use `FormField.Label` to add a label to the textarea.
+Use the `FormField.CharactersCount` component to display the actual text count and the max length allowed.
 
-<Canvas of={stories.FieldLabel} />
-
-#### Hidden label
-
-In certain cases, a visible label may not be necessary. To achieve this behavior, use the `VisuallyHidden` component.
-
-<Canvas of={stories.FieldHiddenLabel} />
-
-### Required
-
-Use the `isRequired` prop of the `FormField` to indicate that the textarea is required.
-
-<Canvas of={stories.FieldRequired} />
+<Canvas of={stories.FieldCharactersCount} />
 
 ### Helper message
 
@@ -114,11 +102,23 @@ Use the `FormField.HelperMessage` component to provide a description to the text
 
 <Canvas of={stories.FieldHelperMessage} />
 
-### Characters count
+#### Hidden label
 
-Use the `FormField.CharactersCount` component to display the actual text count and the max length allowed.
+In certain cases, a visible label may not be necessary. To achieve this behavior, use the `VisuallyHidden` component.
 
-<Canvas of={stories.FieldCharactersCount} />
+<Canvas of={stories.FieldHiddenLabel} />
+
+### Label
+
+Use `FormField.Label` to add a label to the textarea.
+
+<Canvas of={stories.FieldLabel} />
+
+### Required
+
+Use the `isRequired` prop of the `FormField` to indicate that the textarea is required.
+
+<Canvas of={stories.FieldRequired} />
 
 ### Validation
 


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1163

### Description, Motivation and Context

Updated `Textarea` docs to match latest agreements 

- I also synced the "Form field" sections

### Types of changes
- [x] 🧾 Documentation
