### PR TITLE
fix(badge): do not display outline when badge is standalone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2396,6 +2396,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/badge/src/Badge.doc.mdx
+++ b/packages/components/badge/src/Badge.doc.mdx
@@ -25,45 +25,37 @@ import { Badge } from '@spark-ui/badge'
 
 <ArgTypes of={Badge} />
 
-## Default
+## Usage
+
+### Default
+
+When using `Badge` as a wrapper, it will position itself to the top-right corner of its child element.
 
 <Canvas of={stories.Default} />
 
-## Standalone
-
-<Canvas of={stories.Standalone} />
-
-## Standalone with count
-
-<Canvas of={stories.StandaloneWithCount} />
-
-## Standalone within another element
-
-<Canvas of={stories.StandaloneWithinAnotherElement} />
-
-## Wrapping an icon
-
-<Canvas of={stories.WrappingAnIcon} />
-
-## Regular count
-
-<Canvas of={stories.RegularCount} />
-
-## Large count
-
-<Canvas of={stories.LargeCount} />
-
-## Large custom count
-
-<Canvas of={stories.LargeCustomCount} />
-
-## Intents
+### Intents
 
 Use `intent` prop to set the color intent of the badge.
 
 <Canvas of={stories.Intents} />
 
-## Sizes
+### Standalone
+
+When using `Badge` as a self-closing element, it is rendered inline, and is no longer positionned relatively to a specific element.
+
+<Canvas of={stories.Standalone} />
+
+### No count
+
+<Canvas of={stories.NoCount} />
+
+### Count threshold
+
+Use `count` prop to display a number inside the `Badge`. There is a default threshold of `99` if you pass a larger number.
+
+<Canvas of={stories.CountThreshold} />
+
+### Sizes
 
 Use `size` prop to set the size of the badge.
 

--- a/packages/components/badge/src/Badge.stories.tsx
+++ b/packages/components/badge/src/Badge.stories.tsx
@@ -1,6 +1,5 @@
-import { Icon } from '@spark-ui/icon'
-import { LikeFill } from '@spark-ui/icons/dist/icons/LikeFill'
-import { RadioGroup } from '@spark-ui/radio-group'
+import { StoryLabel } from '@docs/helpers/StoryLabel'
+import { Button } from '@spark-ui/button'
 import { Meta, StoryFn } from '@storybook/react'
 import { type ComponentProps } from 'react'
 
@@ -28,55 +27,72 @@ const intents: BadgeProps['intent'][] = [
 
 const fakeAvatar = <div className="h-sz-40 w-sz-40 rounded-lg bg-outline" />
 
-export const Default: StoryFn = _args => <Badge>{fakeAvatar}</Badge>
-export const Standalone: StoryFn = _args => <Badge aria-label="New notification" />
-export const StandaloneWithCount: StoryFn = _args => <Badge count={1} />
-export const StandaloneWithinAnotherElement: StoryFn = _args => (
-  <RadioGroup>
-    <RadioGroup.Radio value="foo">
-      Foo <Badge size="sm" count={3} aria-label={({ count }) => `${count} notifications`} />
-    </RadioGroup.Radio>
-  </RadioGroup>
-)
-export const WrappingAnIcon: StoryFn = _args => (
-  <Badge size="sm" count={3}>
-    {/** TODO: Check the real behaviour with icons in order to avoid custom styles on them. **/}
-    <Icon size="lg">
-      <LikeFill />
-    </Icon>
-  </Badge>
-)
-export const RegularCount: StoryFn = _args => <Badge count={1}>{fakeAvatar}</Badge>
-export const LargeCount: StoryFn = _args => (
-  <Badge
-    count={1000}
-    aria-label={({ overflowCount }) => `More than ${overflowCount} notifications`}
-  >
-    {fakeAvatar}
-  </Badge>
-)
-export const LargeCustomCount: StoryFn = _args => (
-  <Badge count={1000} overflowCount={999}>
-    {fakeAvatar}
-  </Badge>
-)
+export const Default: StoryFn = _args => <Badge count={1}>{fakeAvatar}</Badge>
 
 export const Intents: StoryFn = _args => (
-  <div className="flex flex-wrap gap-md">
+  <div className="flex flex-wrap justify-evenly gap-md">
     {intents.map(intent => (
-      <Badge key={intent} intent={intent} count={1}>
-        {fakeAvatar}
-      </Badge>
+      <div>
+        <StoryLabel className="mb-xl">{intent}</StoryLabel>
+        <Badge key={intent} intent={intent} count={1}>
+          {fakeAvatar}
+        </Badge>
+      </div>
     ))}
   </div>
 )
 
-export const Sizes: StoryFn = _args => (
-  <div className="flex flex-wrap gap-md">
-    {sizes.map(size => (
-      <Badge key={size} size={size} count={25}>
+export const Standalone: StoryFn = _args => (
+  <Button design="tinted">
+    Standalone <Badge count={100} aria-label="New notification" />
+  </Button>
+)
+
+export const NoCount: StoryFn = _args => <Badge>{fakeAvatar}</Badge>
+
+export const CountThreshold: StoryFn = _args => (
+  <div className="flex gap-xl">
+    <div>
+      <StoryLabel className="mb-xl">Default threshold</StoryLabel>
+      <Badge
+        count={1000}
+        aria-label={({ overflowCount }) => `More than ${overflowCount} notifications`}
+      >
         {fakeAvatar}
       </Badge>
+    </div>
+    <div>
+      <StoryLabel className="mb-xl">Custom threshold</StoryLabel>
+      <Badge
+        count={1000}
+        overflowCount={999}
+        aria-label={({ overflowCount }) => `More than ${overflowCount} notifications`}
+      >
+        {fakeAvatar}
+      </Badge>
+    </div>
+  </div>
+)
+
+export const Sizes: StoryFn = _args => (
+  <div className="flex flex-col gap-xl">
+    {sizes.map(size => (
+      <div className="flex gap-xl">
+        <div>
+          <StoryLabel className="mb-xl">{size}</StoryLabel>
+
+          <Badge key={size} size={size}>
+            {fakeAvatar}
+          </Badge>
+        </div>
+        <div>
+          <StoryLabel className="mb-xl">{size} (count)</StoryLabel>
+
+          <Badge key={size} size={size} count={25}>
+            {fakeAvatar}
+          </Badge>
+        </div>
+      </div>
     ))}
   </div>
 )

--- a/packages/components/badge/src/BadgeItem.styles.tsx
+++ b/packages/components/badge/src/BadgeItem.styles.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { DEFAULT_INTENT, DEFAULT_SIZE, DEFAULT_TYPE } from './config'
 
 export const styles = cva(
-  ['inline-flex h-fit', 'empty:p-none', 'text-center font-bold', 'rounded-full ring-2'],
+  ['inline-flex h-fit', 'empty:p-none', 'text-center font-bold', 'rounded-full'],
   {
     variants: {
       intent: makeVariants<
@@ -38,7 +38,7 @@ export const styles = cva(
         md: ['text-caption', 'px-md py-sm', 'empty:h-sz-16 empty:w-sz-16'],
       }),
       type: {
-        relative: ['relative -translate-x-2/4 -translate-y-2/4'],
+        relative: ['relative -translate-x-2/4 -translate-y-2/4 ring-2'],
         standalone: [],
       },
     },


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1240

### Description, Motivation and Context
- Updated docs to match latest agreements: https://sparkui.vercel.app/?path=/docs/contributing-writing-packages-documentation--docs
- Updated `Badge` styles: no longer has an outline when used as standalone.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧾 Documentation

![Capture d’écran 2023-08-09 à 15 31 23](https://github.com/adevinta/spark/assets/2033710/65e97dd0-7989-4886-9876-b614390a9810)


![Capture d’écran 2023-08-09 à 15 28 57](https://github.com/adevinta/spark/assets/2033710/fde54df6-1247-4613-a2cb-6e931087d87a)

