### PR TITLE
docs: adapted custom ArgTypes table for mobile screens

### DIFF
--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@spark-ui/tabs'
+import { Tabs, type TabsRootProps } from '@spark-ui/tabs'
 import { ArgTypes as StorybookArgTypes } from '@storybook/blocks'
 import { type FC, type ReactNode, useEffect, useState } from 'react'
 
@@ -20,12 +20,14 @@ const ComponentDescription = ({ name, children }: { name: string; children: Reac
   )
 }
 
-function useWindowWidth() {
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+function useTabsOrientation() {
+  const [tabsOrientation, setTabsOrientation] = useState<TabsRootProps['orientation']>(
+    window.innerWidth < 640 ? 'horizontal' : 'vertical'
+  )
 
   useEffect(() => {
     const handleResize = () => {
-      setWindowWidth(window.innerWidth)
+      setTabsOrientation(window.innerWidth < 640 ? 'horizontal' : 'vertical')
     }
 
     window.addEventListener('resize', handleResize)
@@ -35,18 +37,16 @@ function useWindowWidth() {
     }
   }, [])
 
-  return windowWidth
+  return tabsOrientation
 }
 
 export const ArgTypes = <T extends FC>({ of, description, subcomponents = null }: Props<T>) => {
-  const windowWidth = useWindowWidth()
+  const tabsOrientation = useTabsOrientation()
 
   if (!subcomponents) return <StorybookArgTypes of={of} />
 
   const { displayName: name = 'Root' } = of // "Root" in case the root component is missing a displayName
   const subComponentsList = Object.entries(subcomponents)
-
-  const tabsOrientation = windowWidth < 640 ? 'horizontal' : 'vertical'
 
   return (
     <Tabs

--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from '@spark-ui/tabs'
 import { ArgTypes as StorybookArgTypes } from '@storybook/blocks'
-import { type FC, type ReactNode } from 'react'
+import { type FC, type ReactNode, useEffect, useState } from 'react'
 
 interface Props<T> {
   of: T
@@ -20,15 +20,41 @@ const ComponentDescription = ({ name, children }: { name: string; children: Reac
   )
 }
 
+function useWindowWidth() {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth)
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  return windowWidth
+}
+
 export const ArgTypes = <T extends FC>({ of, description, subcomponents = null }: Props<T>) => {
+  const windowWidth = useWindowWidth()
+
   if (!subcomponents) return <StorybookArgTypes of={of} />
 
   const { displayName: name = 'Root' } = of // "Root" in case the root component is missing a displayName
   const subComponentsList = Object.entries(subcomponents)
 
+  const tabsOrientation = windowWidth < 640 ? 'horizontal' : 'vertical'
+
   return (
-    <Tabs defaultValue={name} orientation="vertical" className="sb-unstyled mt-xl">
-      <Tabs.List>
+    <Tabs
+      defaultValue={name}
+      orientation={tabsOrientation}
+      className="sb-unstyled mt-xl overflow-hidden"
+    >
+      <Tabs.List className={tabsOrientation === 'horizontal' ? 'mb-md' : ''}>
         <Tabs.Trigger key={name} value={name}>
           {name}
         </Tabs.Trigger>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,6 +2289,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",


### PR DESCRIPTION
### Description, Motivation and Context

I know SB is not aimed to be used a lot on mobile, but this bug also happened on smaller screens or when we have the console opened.

Our `ArgTypes` component was in `vertical` orientation even on smaller screens, meaning we don't have much room to display the content (when the sidebar is still rendered).

### Types of changes

- [x] 🧾 Documentation
- [x] 💄 Styles


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/eb8e1cb5-d7cc-4a45-a260-0caab579b3e1


