### PR TITLE
fix(popover): popover trigger was using forwardRef without ref

### DIFF
--- a/packages/components/popover/src/PopoverTrigger.tsx
+++ b/packages/components/popover/src/PopoverTrigger.tsx
@@ -1,11 +1,17 @@
 import * as RadixPopover from '@radix-ui/react-popover'
-import { forwardRef } from 'react'
+import { type ElementRef, forwardRef } from 'react'
 
+type TriggerElement = ElementRef<typeof RadixPopover.Trigger>
 export type TriggerProps = RadixPopover.PopoverTriggerProps
 
-export const Trigger = forwardRef<HTMLDivElement, TriggerProps>(
-  ({ asChild = false, children, ...rest }) => (
-    <RadixPopover.Trigger data-spark-component="popover-trigger" asChild={asChild} {...rest}>
+export const Trigger = forwardRef<TriggerElement, TriggerProps>(
+  ({ asChild = false, children, ...rest }, ref) => (
+    <RadixPopover.Trigger
+      data-spark-component="popover-trigger"
+      ref={ref}
+      asChild={asChild}
+      {...rest}
+    >
       {children}
     </RadixPopover.Trigger>
   )


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1276 

### Description, Motivation and Context

Using `forwardRef` without exploiting the `ref` argument throws a react warning in the console/terminal.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
