### PR TITLE
docs(input): fix displayNames broken in sb source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2396,6 +2396,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/input/src/index.ts
+++ b/packages/components/input/src/index.ts
@@ -18,6 +18,13 @@ export { type InputTrailingAddonProps } from './InputTrailingAddon'
 export { type InputStateIndicatorProps } from './InputStateIndicator'
 export { type InputClearButtonProps } from './InputClearButton'
 
+InputLeadingAddon.displayName = 'InputGroup.LeadingAddon'
+InputTrailingAddon.displayName = 'InputGroup.TrailingAddon'
+InputLeadingIcon.displayName = 'InputGroup.LeadingIcon'
+InputTrailingIcon.displayName = 'InputGroup.TrailingIcon'
+InputStateIndicator.displayName = 'InputGroup.StateIndicator'
+InputClearButton.displayName = 'InputGroup.ClearButton'
+
 export const InputGroup: FC<InputGroupProps> & {
   LeadingAddon: typeof InputLeadingAddon
   TrailingAddon: typeof InputTrailingAddon


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1282 

### Description, Motivation and Context

Developers told us that displayNames are missing in the documentation.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations

Before:
![before](https://github.com/adevinta/spark/assets/2033710/2aa9ca5b-54eb-42a3-ab87-698ee56a4cc6)


After:
![after](https://github.com/adevinta/spark/assets/2033710/65aaa290-ab35-448e-b416-2d889f726bc8)


