### PR TITLE
refactor(button): improv. loading state focus management

### DIFF
--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -115,13 +115,7 @@ export const Loading: StoryFn = () => {
         Toggle loading state
       </Checkbox>
 
-      <Button
-        isLoading={isLoading}
-        loadingLabel="Loading..."
-        onKeyDown={() => {
-          console.log('totokeydown')
-        }}
-      >
+      <Button isLoading={isLoading} loadingLabel="Loading...">
         <Icon>
           <FavoriteOutline />
         </Icon>

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -115,7 +115,13 @@ export const Loading: StoryFn = () => {
         Toggle loading state
       </Checkbox>
 
-      <Button isLoading={isLoading} loadingLabel="Loading...">
+      <Button
+        isLoading={isLoading}
+        loadingLabel="Loading..."
+        onKeyDown={() => {
+          console.log('totokeydown')
+        }}
+      >
         <Icon>
           <FavoriteOutline />
         </Icon>

--- a/packages/components/button/src/Button.test.tsx
+++ b/packages/components/button/src/Button.test.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
 }
 
 const clickEvent = vi.fn()
+const keyboardEvent = vi.fn()
 
 describe('Button', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -52,15 +53,21 @@ describe('Button', () => {
     const props = {
       ...defaultProps,
       onClick: clickEvent,
+      onKeyDown: keyboardEvent,
       disabled: true,
     }
 
     render(<Button {...props} />)
     const element = screen.getByRole('button', { name: props.children })
 
+    element.focus()
+    await user.keyboard('{Enter}')
+
     await user.click(element)
 
-    expect(clickEvent).toHaveBeenCalledTimes(0)
+    expect(clickEvent).not.toHaveBeenCalled()
+    expect(keyboardEvent).not.toHaveBeenCalled()
+
     expect(element).toHaveAttribute('disabled')
   })
 
@@ -98,17 +105,23 @@ describe('Button', () => {
 
       const props = {
         onClick: clickEvent,
+        onKeyDown: keyboardEvent,
         isLoading: true,
         loadingText: 'Loading...',
         children: 'Hello World!',
       }
 
       render(<Button {...props} />)
-
       const element = screen.getByRole('button', { name: props.loadingText })
+
+      element.focus()
+      await user.keyboard('{Enter}')
+
       await user.click(element)
 
-      expect(clickEvent).toHaveBeenCalledTimes(0)
+      expect(clickEvent).not.toHaveBeenCalled()
+      expect(keyboardEvent).not.toHaveBeenCalled()
+
       expect(element).toHaveAttribute('aria-busy', 'true')
     })
   })

--- a/packages/components/spinner/src/index.ts
+++ b/packages/components/spinner/src/index.ts
@@ -1,1 +1,1 @@
-export { Spinner } from './Spinner'
+export * from './Spinner'


### PR DESCRIPTION
**TASK**: #1256 

### Description, Motivation and Context
Button loading state was previously linked to a disabled state. This caused focus loss that we don't want here. So we will update implementation using `aria-busy` attribute instead.

### Types of changes
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/6e6406e7-f023-42a4-bb25-55c474b76c0b)
