### PR TITLE
feat: remove misleading onChange prop on some components

### DIFF
--- a/packages/components/checkbox/src/CheckboxInput.tsx
+++ b/packages/components/checkbox/src/CheckboxInput.tsx
@@ -11,7 +11,7 @@ type CheckedStatus = boolean | 'indeterminate'
 
 export interface CheckboxInputProps
   extends CheckboxInputStylesProps,
-    Omit<ComponentPropsWithoutRef<'button'>, 'value' | 'checked' | 'defaultChecked'> {
+    Omit<ComponentPropsWithoutRef<'button'>, 'onChange' | 'value' | 'checked' | 'defaultChecked'> {
   /**
    * The checked icon to use.
    */

--- a/packages/components/radio-group/src/RadioGroup.tsx
+++ b/packages/components/radio-group/src/RadioGroup.tsx
@@ -9,7 +9,7 @@ import { RadioInputVariantsProps } from './RadioInput.styles'
 export interface RadioGroupProps
   extends RadioGroupVariantsProps,
     Pick<RadioInputVariantsProps, 'intent'>,
-    Omit<HTMLAttributes<HTMLDivElement>, 'value' | 'defaultValue' | 'dir'> {
+    Omit<HTMLAttributes<HTMLDivElement>, 'value' | 'defaultValue' | 'dir' | 'onChange'> {
   /**
    * Change the component to the HTML tag or custom component of the only child.
    */

--- a/packages/components/radio-group/src/RadioInput.tsx
+++ b/packages/components/radio-group/src/RadioInput.tsx
@@ -7,7 +7,7 @@ import { radioInputVariants, RadioInputVariantsProps } from './RadioInput.styles
 
 export interface RadioInputProps
   extends RadioInputVariantsProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'onChange'> {
   /**
    * Change the component to the HTML tag or custom component of the only child.
    */


### PR DESCRIPTION
**TASK**: #1320 

### Description, Motivation and Context
**RadioGroup:**
- remove misleading `onChange` prop from types as it is not actually supported

**Checkbox:**
- remove misleading `onChange` prop from types as it is not actually supported

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
