### PR TITLE
fix(dialog): avoid animating overlay dialog when size is fullscreen

### DIFF
--- a/packages/components/dialog/src/Dialog.test.tsx
+++ b/packages/components/dialog/src/Dialog.test.tsx
@@ -53,8 +53,8 @@ describe('Dialog', () => {
       </Dialog>
     )
 
-    const fullscreenClass = 'modal-is-fullscreen'
-    const animationPreventionSelector = '[body.modal-is-fullscreen_&]:[animation:none]'
+    const fullscreenClass = 'dialog-is-fullscreen'
+    const animationPreventionSelector = '[body.dialog-is-fullscreen_&]:[animation:none]'
 
     const user = userEvent.setup()
     const { rerender } = render(<MakeDialog size="md" />)

--- a/packages/components/dialog/src/Dialog.test.tsx
+++ b/packages/components/dialog/src/Dialog.test.tsx
@@ -35,4 +35,44 @@ describe('Dialog', () => {
 
     expect(screen.getByText('Dialog contents')).toBeInTheDocument()
   })
+
+  it('should prevent exit animation when the dialog is in fullscreen mode', async () => {
+    type DialogSize = Parameters<typeof Dialog.Content>['0']['size']
+    const MakeDialog = ({ size }: { size: DialogSize }) => (
+      <Dialog>
+        <Dialog.Trigger asChild>
+          <button>open dialog</button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay />
+          <Dialog.Content size={size}>
+            <Dialog.Description>hello</Dialog.Description>
+            <Dialog.CloseButton aria-label="Close" />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    )
+
+    const fullscreenClass = 'modal-is-fullscreen'
+    const animationPreventionSelector = '[body.modal-is-fullscreen_&]:[animation:none]'
+
+    const user = userEvent.setup()
+    const { rerender } = render(<MakeDialog size="md" />)
+
+    await user.click(screen.getByText('open dialog'))
+    expect(new Set(document.body.classList)).not.toContain(fullscreenClass)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /close/i,
+      })
+    )
+
+    rerender(<MakeDialog size="fullscreen" />)
+
+    await user.click(screen.getByText('open dialog'))
+
+    expect(document.getElementsByClassName(animationPreventionSelector)).toHaveLength(1)
+    expect(new Set(document.body.classList)).toContain(fullscreenClass)
+  })
 })

--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -1,5 +1,5 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
-import { forwardRef, type ReactElement, type Ref } from 'react'
+import { forwardRef, type ReactElement, type Ref, useEffect } from 'react'
 
 import {
   dialogContentStyles,
@@ -13,21 +13,30 @@ export const Content = forwardRef(
   (
     { children, className, size = 'md', ...rest }: ContentProps,
     ref: Ref<HTMLDivElement>
-  ): ReactElement => (
-    <div className={dialogContentWrapperStyles()}>
-      <RadixDialog.Content
-        data-spark-component="dialog-content"
-        ref={ref}
-        className={dialogContentStyles({
-          size,
-          className,
-        })}
-        {...rest}
-      >
-        {children}
-      </RadixDialog.Content>
-    </div>
-  )
+  ): ReactElement => {
+    useEffect(() => {
+      if (size !== 'fullscreen') return
+      document.body.classList.add('modal-is-fullscreen')
+
+      return () => document.body.classList.remove('modal-is-fullscreen')
+    }, [size])
+
+    return (
+      <div className={dialogContentWrapperStyles()}>
+        <RadixDialog.Content
+          data-spark-component="dialog-content"
+          ref={ref}
+          className={dialogContentStyles({
+            size,
+            className,
+          })}
+          {...rest}
+        >
+          {children}
+        </RadixDialog.Content>
+      </div>
+    )
+  }
 )
 
 Content.displayName = 'Dialog.Content'

--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -16,9 +16,9 @@ export const Content = forwardRef(
   ): ReactElement => {
     useEffect(() => {
       if (size !== 'fullscreen') return
-      document.body.classList.add('modal-is-fullscreen')
+      document.body.classList.add('dialog-is-fullscreen')
 
-      return () => document.body.classList.remove('modal-is-fullscreen')
+      return () => document.body.classList.remove('dialog-is-fullscreen')
     }, [size])
 
     return (

--- a/packages/components/dialog/src/DialogOverlay.tsx
+++ b/packages/components/dialog/src/DialogOverlay.tsx
@@ -13,6 +13,7 @@ export const Overlay = forwardRef(
         ['bg-overlay/dim-3'],
         ['data-[state=open]:animate-fade-in'],
         ['data-[state=closed]:animate-fade-out'],
+        ['[body.modal-is-fullscreen_&]:[animation:none]'],
         className
       )}
       {...rest}

--- a/packages/components/dialog/src/DialogOverlay.tsx
+++ b/packages/components/dialog/src/DialogOverlay.tsx
@@ -13,7 +13,7 @@ export const Overlay = forwardRef(
         ['bg-overlay/dim-3'],
         ['data-[state=open]:animate-fade-in'],
         ['data-[state=closed]:animate-fade-out'],
-        ['[body.modal-is-fullscreen_&]:[animation:none]'],
+        ['[body.dialog-is-fullscreen_&]:[animation:none]'],
         className
       )}
       {...rest}


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1374

### Description, Motivation and Context
Avoid animating overlay dialog when size is fullscreen

> [!WARNING]  
After discussing with @Powerplex and @soykje ,we have decided to put this PR on hold for now.
> We may discard this pull request and instead refactor the Dialog component to use React Context.
> This will allow us to handle the bug without resorting to the escape hatch used in the current PR (adding a class to the body)

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
