### PR TITLE
chore(icons): add github action to open a PR with updated icons

### DIFF
--- a/.github/workflows/pr-icon-update.yml
+++ b/.github/workflows/pr-icon-update.yml
@@ -1,0 +1,42 @@
+name: '🎨 PR icon updates'
+
+on:
+  push:
+    branches: [ "chore-updated-icons" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FOLDER: 'packages/components/icons/src'
+
+jobs:
+  pr-icon-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: chore-updated-icons
+          fetch-depth: 0
+      - run: gh pr create --fill
+        continue-on-error: true
+      - name: Install
+        uses: ./.github/composite-actions/install
+      - name: Generate Icons
+        run: cd packages/components/icons && npm run generate
+      - name: Commit and Push Changes
+        run: |
+          if ! git diff --quiet --exit-code -- "$FOLDER" ;
+          then
+            git config user.name 'spark-ui-bot'
+            git config user.email 'spark-ui-bot@users.noreply.github.com'
+            git add "$FOLDER"
+            git commit -m "chore: update icons in $FOLDER"
+            git show
+            git push
+            echo "::notice::UPDATED"
+          else
+            echo "::notice::UP-TO-DATE"
+          fi

--- a/.github/workflows/pr-icon-update.yml
+++ b/.github/workflows/pr-icon-update.yml
@@ -10,11 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FOLDER: 'packages/components/icons/src'
+  FOLDER: 'src'
 
 jobs:
   pr-icon-updates:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/components/icons
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,7 +28,7 @@ jobs:
       - name: Install
         uses: ./.github/composite-actions/install
       - name: Generate Icons
-        run: cd packages/components/icons && npm run generate
+        run: npm run generate
       - name: Commit and Push Changes
         run: |
           if ! git diff --quiet --exit-code -- "$FOLDER" ;

--- a/.github/workflows/pr-icon-update.yml
+++ b/.github/workflows/pr-icon-update.yml
@@ -36,7 +36,7 @@ jobs:
             git config user.name 'spark-ui-bot'
             git config user.email 'spark-ui-bot@users.noreply.github.com'
             git add "$FOLDER"
-            git commit -m "chore: update icons in $FOLDER"
+            git commit -m "chore(icons): generate icons in $FOLDER"
             git show
             git push
             echo "::notice::UPDATED"

--- a/packages/components/icons/scripts/build.mjs
+++ b/packages/components/icons/scripts/build.mjs
@@ -1,4 +1,5 @@
 import { pascalCase } from 'change-case'
+import fs from 'fs'
 import path from 'path'
 
 import componentize from './utils/componentize.mjs'
@@ -11,6 +12,15 @@ import tagify from './utils/tagify.mjs'
 import writeFile from './utils/writeFile.mjs'
 
 const main = async (pattern = 'assets/**/*.svg') => {
+  // Clean the output folder before generating icons
+  const outputDir = path.join(process.cwd(), 'src/icons')
+
+  // Remove existing files from the output directory
+  fs.readdirSync(outputDir).forEach(file => {
+    const filePath = path.join(outputDir, file)
+    fs.unlinkSync(filePath)
+  })
+
   const files = matchFileRoute(undefined, pattern)
   const data = new Map()
 


### PR DESCRIPTION
## chore(icons): add github action to open a PR with updated icons

### Description, Motivation and Context
This PR adds a GitHub action to re-generate the icon set every time a PR is sent from the `spark-tokens` repo.

### Types of changes
- [x] 🛠️ Tool
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
