### PR TITLE
chore(icons): fix github action

### DIFF
--- a/.github/workflows/pr-icon-update.yml
+++ b/.github/workflows/pr-icon-update.yml
@@ -1,4 +1,4 @@
-name: '🎨 PR icon updates'
+name: 'PR-icon-updates'
 
 on:
   push:

--- a/.github/workflows/pr-icon-update.yml
+++ b/.github/workflows/pr-icon-update.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GH_TOKEN: ${{ github.token }}
   FOLDER: 'src'
 
 jobs:


### PR DESCRIPTION
## chore(icons): fix github action

### Description, Motivation and Context
This PR resolves the issue with the new GitHub action responsible for opening a PR and building icons with every update from `spark-tokens`. We've renamed the action and included the necessary GitHub token to establish a connection with GitHub CLI.

### Types of changes
- [x] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
