### PR TITLE
fix(dialog): improved focus styles when focusable children disappear

### DIFF
--- a/packages/components/dialog/src/DialogContent.styles.tsx
+++ b/packages/components/dialog/src/DialogContent.styles.tsx
@@ -2,31 +2,39 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const dialogContentWrapperStyles = cva([
   'fixed inset-none z-modal flex items-center justify-center',
+  'focus-visible:ring-2 focus-visible:ring-outline-high focus-visible:outline-none',
 ])
 
-export const dialogContentStyles = cva([['relative', 'flex', 'flex-col'], ['bg-surface']], {
-  variants: {
-    size: {
-      fullscreen: ['w-full', 'h-full'],
-      sm: ['max-w-sz-480'],
-      md: ['max-w-sz-672'],
-      lg: ['max-w-sz-864'],
-    },
-  },
-  compoundVariants: [
-    {
-      size: ['sm', 'md', 'lg'],
-      class: [
-        ['w-full', 'max-h-[80%]'],
-        ['shadow-md', 'rounded-lg'],
-        ['data-[state=open]:animate-fade-in'],
-        ['data-[state=closed]:animate-fade-out'],
-      ],
-    },
+export const dialogContentStyles = cva(
+  [
+    ['relative', 'flex', 'flex-col'],
+    ['bg-surface'],
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-high',
   ],
-  defaultVariants: {
-    size: 'md',
-  },
-})
+  {
+    variants: {
+      size: {
+        fullscreen: ['w-full', 'h-full'],
+        sm: ['max-w-sz-480'],
+        md: ['max-w-sz-672'],
+        lg: ['max-w-sz-864'],
+      },
+    },
+    compoundVariants: [
+      {
+        size: ['sm', 'md', 'lg'],
+        class: [
+          ['w-full', 'max-h-[80%]'],
+          ['shadow-md', 'rounded-lg'],
+          ['data-[state=open]:animate-fade-in'],
+          ['data-[state=closed]:animate-fade-out'],
+        ],
+      },
+    ],
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
 
 export type DialogContentStylesProps = VariantProps<typeof dialogContentStyles>


### PR DESCRIPTION

### Description, Motivation and Context

whenever a focused element inside the Dialod disappear, focus is forwarded to the Dialog.Content instead (a11y)

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/71f40063-800d-46b3-90fa-3bd80f8ff572


