### PR TITLE
fix(icon-button): update small IconButton icon size to 16x16

### DIFF
--- a/packages/components/icon-button/src/IconButton.styles.tsx
+++ b/packages/components/icon-button/src/IconButton.styles.tsx
@@ -4,7 +4,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 export const iconButtonStyles = cva(['px-none'], {
   variants: {
     size: makeVariants<'size', ['sm', 'md', 'lg']>({
-      sm: ['text-caption'],
+      sm: ['text-body-1'],
       md: ['text-body-1'],
       lg: ['text-display-3'],
     }),


### PR DESCRIPTION
**TASK**: #1427

### Description, Motivation and Context
The icon size for small IconButtons should be 16x16, but was currently set to 12x12

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
