### PR TITLE
fix(form-field): improved render of CharactersCount value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/form-field/src/FormFieldCharactersCount.tsx
+++ b/packages/components/form-field/src/FormFieldCharactersCount.tsx
@@ -14,7 +14,7 @@ export type FormFieldCharactersCountProps = ComponentPropsWithoutRef<'span'> & {
 
 export const FormFieldCharactersCount = forwardRef<HTMLSpanElement, FormFieldCharactersCountProps>(
   ({ className, value = '', maxLength, ...others }, ref) => {
-    const count = value.length
+    const displayValue = `${value.length}/${maxLength}`
 
     return (
       <span
@@ -23,7 +23,7 @@ export const FormFieldCharactersCount = forwardRef<HTMLSpanElement, FormFieldCha
         className={cx(className, 'text-caption', 'text-neutral')}
         {...others}
       >
-        {count}/{maxLength}
+        {displayValue}
       </span>
     )
   }


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1451 

### Description, Motivation and Context

Rendered value of `CharactersCount` is rendered as 3 distinct text nodes in the HTML, making it difficult to parse or use in unit tests.

### Types of changes
- [x] 🧠 Refactor


### Screenshots - Animations

BEFORE

![Capture d’écran 2023-09-15 à 10 59 51](https://github.com/adevinta/spark/assets/2033710/7da803d2-104b-4853-a1f2-9c340a19f4b4)

AFTER
![Capture d’écran 2023-09-15 à 10 59 42](https://github.com/adevinta/spark/assets/2033710/fffb27e3-608d-49f1-9cef-4e73c49dc39c)

