### PR TITLE
feat: outline design components must have transparent background

### DIFF
--- a/packages/components/tabs/src/TabsTrigger.styles.ts
+++ b/packages/components/tabs/src/TabsTrigger.styles.ts
@@ -7,7 +7,7 @@ export const triggerVariants = cva(
     'relative flex flex-none items-center',
     'border-outline',
     'outline-none',
-    'bg-surface hover:bg-surface-hovered',
+    'hover:bg-surface-hovered',
     'after:absolute',
     'spark-orientation-horizontal:border-b-sm spark-orientation-horizontal:after:inset-x-none spark-orientation-horizontal:after:bottom-[-1px] spark-orientation-horizontal:after:h-sz-2',
     'spark-orientation-vertical:border-r-sm spark-orientation-vertical:after:inset-y-none spark-orientation-vertical:after:right-[-1px] spark-orientation-vertical:after:w-sz-2',

--- a/packages/components/tag/src/Tag.styles.tsx
+++ b/packages/components/tag/src/Tag.styles.tsx
@@ -20,7 +20,7 @@ export const tagStyles = cva(
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted']>({
         filled: [],
-        outlined: ['bg-surface', 'ring-1', 'ring-current'],
+        outlined: ['ring-1', 'ring-current'],
         tinted: [],
       }),
       /**


### PR DESCRIPTION
**TASK**: #1423 

### Description, Motivation and Context
- All components must have a background transparent in outline versions
- Tabs have a background transparent too

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
