### PR TITLE
feat(text-link): textLink inherit current font weight by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -36,8 +36,12 @@
     "url": "git@github.com:adevinta/spark.git",
     "directory": "packages/components/text-link"
   },
+  "config": {
+    "title": "text-link",
+    "category": "components"
+  },
   "bugs": {
-    "url": "https://github.com/adevinta/spark/issues"
+    "url": "https://github.com/adevinta/spark/issues?q=label%3Acomponent+label%3Atext-link"
   },
   "homepage": "https://sparkui.vercel.app",
   "license": "MIT"

--- a/packages/components/text-link/src/TextLink.doc.mdx
+++ b/packages/components/text-link/src/TextLink.doc.mdx
@@ -37,6 +37,14 @@ This component support [all HTML attributes](https://developer.mozilla.org/en-US
 
 <Canvas of={stories.Default} />
 
+### Bold
+
+By default, `TextLink` will inherit the font weight of the current font.
+
+Use `bold` to highlight a link inside a paragraph.
+
+<Canvas of={stories.Bold} />
+
 ### Intents
 
 By default, `TextLink` will inherit the color of the current font.

--- a/packages/components/text-link/src/TextLink.stories.tsx
+++ b/packages/components/text-link/src/TextLink.stories.tsx
@@ -27,6 +27,18 @@ export const Default: StoryFn = _args => {
   )
 }
 
+export const Bold: StoryFn = _args => {
+  return (
+    <p>
+      You should learn more about{' '}
+      <TextLink href="https://en.wikipedia.org/wiki/Kitten" target="_blank" bold>
+        kitten
+      </TextLink>
+      .
+    </p>
+  )
+}
+
 const intents: TextLinkProps['intent'][] = [
   'main',
   'support',

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -3,10 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import React, { type ComponentPropsWithoutRef, forwardRef } from 'react'
 
 const textLinkStyles = cva(
-  [
-    'inline-flex items-center font-bold underline',
-    'focus-visible:u-ring focus-visible:outline-none',
-  ],
+  ['inline-flex items-center underline', 'focus-visible:u-ring focus-visible:outline-none'],
   {
     variants: {
       intent: {
@@ -21,9 +18,14 @@ const textLinkStyles = cva(
         info: 'text-info hover:text-info-hovered',
         neutral: 'text-neutral hover:text-neutral-hovered',
       },
+      /** By default, TextLink inherits the current font weight. Use `bold` to highlight it. */
+      bold: {
+        true: 'font-bold',
+      },
     },
     defaultVariants: {
       intent: 'current',
+      bold: false,
     },
   }
 )
@@ -39,11 +41,11 @@ export type TextLinkProps = ComponentPropsWithoutRef<'a'> &
   }
 
 export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
-  ({ asChild = false, children, className, intent = 'current', ...props }, ref) => {
+  ({ asChild = false, bold = false, children, className, intent = 'current', ...props }, ref) => {
     const Component = asChild ? Slot : 'a'
 
     return (
-      <Component ref={ref} className={textLinkStyles({ className, intent })} {...props}>
+      <Component ref={ref} className={textLinkStyles({ className, bold, intent })} {...props}>
         {children}
       </Component>
     )


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1485 

### Description, Motivation and Context

`TextLink` was bold by default. This is no longer wanted in the specs, font-weight should be inherited by default.

It's possible to have a bold `TextLink` in a `regular` font paragraph too.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
