### PR TITLE
fix(checkbox): set parent element's position to relative

### DIFF
--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -79,7 +79,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     return (
       <div
         data-spark-component="checkbox"
-        className={cx('flex items-start gap-md text-body-1', className)}
+        className={cx('relative flex items-start gap-md text-body-1', className)}
       >
         <CheckboxInput
           ref={ref}


### PR DESCRIPTION
## fix(checkbox): set parent element's position to relative

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1489

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Since this was not set element could be appear in any parent whose position not static and so could mess up with the layout.

Setting the main div's position to `relative` makes sure it doesn't get rendered in a random div (ie: the first parent whose position is set).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
<!---
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
 -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
