### PR TITLE
feat(button): PROPOSAL - toggle button example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,6 +2407,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -104,6 +104,12 @@ This polymorphic behaviour can be used with any type of HTML element.
 
 <Canvas of={ButtonStories.Link} />
 
+### Toggle
+
+Use `aria-pressed` to transform the button into a toggle button.
+
+<Canvas of={ButtonStories.Toggle} />
+
 ## Accessibility
 
 This component adheres to the [`button` role requirements](https://www.w3.org/WAI/ARIA/apg/patterns/button).

--- a/packages/components/button/src/Button.stories.tsx
+++ b/packages/components/button/src/Button.stories.tsx
@@ -162,3 +162,19 @@ export const Link: StoryFn = _args => (
     </Button>
   </div>
 )
+
+export const Toggle: StoryFn = () => {
+  const [pressed, setPressed] = useState(false)
+  const toggle = () => setPressed(!pressed)
+
+  return (
+    <Button aria-pressed={pressed} onClick={toggle} design={pressed ? 'filled' : 'outlined'}>
+      Toggle button
+      {pressed && (
+        <Icon>
+          <Check />
+        </Icon>
+      )}
+    </Button>
+  )
+}

--- a/packages/components/icon-button/src/IconButton.doc.mdx
+++ b/packages/components/icon-button/src/IconButton.doc.mdx
@@ -89,6 +89,12 @@ This polymorphic behaviour can be used with any type of HTML element.
 
 <Canvas of={stories.Link} />
 
+### Toggle
+
+Use `aria-pressed` to transform the button into a toggle button.
+
+<Canvas of={stories.Toggle} />
+
 ## Accessibility
 
 This component adheres to the [`button` role requirements](https://www.w3.org/WAI/ARIA/apg/patterns/button). In this specific usecase it is strongly recommended to define an accessible name through `aria-label` or `aria-labelledby` attributes.

--- a/packages/components/icon-button/src/IconButton.stories.tsx
+++ b/packages/components/icon-button/src/IconButton.stories.tsx
@@ -1,6 +1,8 @@
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { Checkbox } from '@spark-ui/checkbox'
 import { Icon } from '@spark-ui/icon'
+import { LikeFill } from '@spark-ui/icons/dist/icons/LikeFill'
+import { LikeOutline } from '@spark-ui/icons/dist/icons/LikeOutline'
 import { Meta, StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
@@ -128,3 +130,19 @@ export const Link: StoryFn = _args => (
     </IconButton>
   </div>
 )
+
+export const Toggle: StoryFn = () => {
+  const [pressed, setPressed] = useState(false)
+  const toggle = () => setPressed(!pressed)
+
+  return (
+    <IconButton
+      aria-label="Add to favorites"
+      aria-pressed={pressed}
+      onClick={toggle}
+      design={pressed ? 'filled' : 'outlined'}
+    >
+      <Icon>{pressed ? <LikeFill /> : <LikeOutline />}</Icon>
+    </IconButton>
+  )
+}


### PR DESCRIPTION
### Description, Motivation and Context

I worked on multiple ways to approach toggle buttons, noticed a few things:

1. We will not have specific design specs for every intent/design for toggle buttons (`Button` and `IconButton`). 
2. Because we don't have any design, we can't make use of `defaultPressed` to apply any style that would make it obvious to the user that a button is pressed.
3. We are left with only `pressed` and `onPressedChange`. Pressed is just an alias for `aria-pressed`. `onPressedChange` is simply called on `onClick` internally to toggle the boolean.
4. `Toggle` from radix is not meant to be used as an HoC, it's a proper/distinct component. We are not meant to customize it into an HoC.

I came to the conclusion that we shouldn't do anything to manage toggle buttons, we already have what's necessary to manage toggle button in a a11y way.

Until the day comes where we are given clear design for toggle buttons for EVERY `intent` and `design` combination, we shouldn't consider implementing it as a true feature.

NOTE/SUMMARY:

If we DO want to implement it as a 1st class feature, it means we must require specs/figma for each `intent/design`combination first from designers. This is a prerequisite.

### Types of changes
- [x] 🧾 Documentation


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/e3baeb0e-7314-44f2-a8de-b7ed373fe343


