### PR TITLE
feat(chip): add ref type to prop

### DIFF
--- a/packages/components/chip/src/Chip.stories.tsx
+++ b/packages/components/chip/src/Chip.stories.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@spark-ui/popover'
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
 import { Meta, StoryFn } from '@storybook/react'
 import { cx } from 'class-variance-authority'
-import { ChangeEvent, ComponentProps, useState } from 'react'
+import { ChangeEvent, ComponentProps, useRef, useState } from 'react'
 
 import { Chip } from '.'
 import { ChipLeadingIcon } from './ChipLeadingIcon'
@@ -44,10 +44,11 @@ export const Default: StoryFn = _args => <Chip>default chip</Chip>
 
 export const Kind: StoryFn = () => {
   const [pressed, setPressed] = useState(true)
+  const ref = useRef<HTMLButtonElement>(null)
 
   return (
     <div className="flex flex-row gap-xl">
-      <Chip onClick={() => console.log('assist')}>
+      <Chip onClick={() => console.log('assist')} ref={ref}>
         <ChipLeadingIcon>
           <Icon label="calendar">
             <CalendarOutline />

--- a/packages/components/chip/src/Chip.tsx
+++ b/packages/components/chip/src/Chip.tsx
@@ -1,11 +1,13 @@
-import React, { ComponentPropsWithRef, forwardRef, PropsWithChildren } from 'react'
+import React, { ButtonHTMLAttributes, forwardRef, PropsWithChildren } from 'react'
 
 import { chipStyles, type ChipStylesProps } from './Chip.styles'
 import { ChipContext } from './useChipContext'
 import { useChipElement } from './useChipElement'
 
 export interface ChipProps
-  extends PropsWithChildren<Omit<ComponentPropsWithRef<'button'>, 'type' | 'onClick' | 'disabled'>>,
+  extends PropsWithChildren<
+      Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick' | 'disabled'>
+    >,
     Omit<ChipStylesProps, 'hasClearButton'> {
   /**
    * Configures a toggleButton aria-pressed initial value
@@ -30,9 +32,13 @@ export interface ChipProps
    * Clear chip handler
    */
   onClear?: (event?: React.MouseEvent<HTMLButtonElement>) => void
+  /**
+   * Pass react ref from the outside
+   */
+  ref?: React.Ref<HTMLButtonElement | HTMLDivElement>
 }
 
-export const Chip = forwardRef<ComponentPropsWithRef<'button' | 'div'>, ChipProps>(
+export const Chip = forwardRef<HTMLButtonElement | HTMLDivElement, ChipProps>(
   (
     {
       design = 'outlined',

--- a/packages/components/chip/src/Chip.tsx
+++ b/packages/components/chip/src/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, forwardRef, PropsWithChildren } from 'react'
+import React, { ButtonHTMLAttributes, forwardRef, PropsWithChildren, Ref } from 'react'
 
 import { chipStyles, type ChipStylesProps } from './Chip.styles'
 import { ChipContext } from './useChipContext'
@@ -35,7 +35,7 @@ export interface ChipProps
   /**
    * Pass react ref from the outside
    */
-  ref?: React.Ref<HTMLButtonElement | HTMLDivElement>
+  ref?: Ref<HTMLButtonElement | HTMLDivElement>
 }
 
 export const Chip = forwardRef<HTMLButtonElement | HTMLDivElement, ChipProps>(

--- a/packages/components/chip/src/Chip.tsx
+++ b/packages/components/chip/src/Chip.tsx
@@ -1,13 +1,11 @@
-import React, { ButtonHTMLAttributes, forwardRef, PropsWithChildren } from 'react'
+import React, { ComponentPropsWithRef, forwardRef, PropsWithChildren } from 'react'
 
 import { chipStyles, type ChipStylesProps } from './Chip.styles'
 import { ChipContext } from './useChipContext'
 import { useChipElement } from './useChipElement'
 
 export interface ChipProps
-  extends PropsWithChildren<
-      Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick' | 'disabled'>
-    >,
+  extends PropsWithChildren<Omit<ComponentPropsWithRef<'button'>, 'type' | 'onClick' | 'disabled'>>,
     Omit<ChipStylesProps, 'hasClearButton'> {
   /**
    * Configures a toggleButton aria-pressed initial value
@@ -34,7 +32,7 @@ export interface ChipProps
   onClear?: (event?: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-export const Chip = forwardRef<HTMLButtonElement | HTMLDivElement, ChipProps>(
+export const Chip = forwardRef<ComponentPropsWithRef<'button' | 'div'>, ChipProps>(
   (
     {
       design = 'outlined',


### PR DESCRIPTION
### Description, Motivation and Context
Add ref props type to Chip component to avoid Type error when passing reference prop from outside.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
- [x] 🧠 Refactor


### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
