### PR TITLE
fix(tag): replaced boxShadow by a border

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,6 +2401,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/tag/src/Tag.styles.tsx
+++ b/packages/components/tag/src/Tag.styles.tsx
@@ -20,7 +20,7 @@ export const tagStyles = cva(
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted']>({
         filled: [],
-        outlined: ['ring-1', 'ring-current'],
+        outlined: ['border-sm', 'border-current'],
         tinted: [],
       }),
       /**


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: subtask of #1509

### Description, Motivation and Context
We are using an external boxShadow on outlined `tag` instead of a border.

It means two things:
- an overflow:hidden will crop the "border"
- it is not vertically aligned with other tags (22px height instead of 20px)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations

Before
![Capture d’écran 2023-09-29 à 14 58 35](https://github.com/adevinta/spark/assets/2033710/175d021f-9539-4697-96a1-6b5e35c130ee)

After
![Capture d’écran 2023-09-29 à 15 02 10](https://github.com/adevinta/spark/assets/2033710/2f1db120-cf43-417a-9441-9f36b892e2d1)

Bug example:
![Screenshot 2023-09-29 at 09 54 48](https://github.com/adevinta/spark/assets/2033710/601f4e53-8543-450d-b7ac-a0f4c0cd2bc1)



