### PR TITLE
fix(button): fixed keyboard focus on outlined buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,6 +2401,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/button/src/Button.styles.tsx
+++ b/packages/components/button/src/Button.styles.tsx
@@ -35,7 +35,7 @@ export const buttonStyles = cva(
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted', 'ghost', 'contrast']>({
         filled: [],
-        outlined: ['bg-transparent', 'ring-1', 'ring-current'],
+        outlined: ['bg-transparent', 'border-sm', 'border-current'],
         tinted: [],
         ghost: [],
         contrast: ['bg-surface'],


### PR DESCRIPTION

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: subtask of #1509 

### Description, Motivation and Context

Keyboard focus styles was removing the outline of the button. Switch to using `border` now for `outlined` buttons, so it is no longer impacted by the focus styles.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles


### Screenshots - Animations

Before
https://github.com/adevinta/spark/assets/2033710/2e876552-279d-451d-a442-f9914a8b35e7

After
https://github.com/adevinta/spark/assets/2033710/f98c03b3-08da-4bba-9526-2581886c957f

