### PR TITLE
fix(input): leading and trailing icon font size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,6 +2407,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/input/src/InputLeadingIcon.tsx
+++ b/packages/components/input/src/InputLeadingIcon.tsx
@@ -5,7 +5,7 @@ import { InputIcon, InputIconProps } from './InputIcon'
 export type InputLeadingIconProps = InputIconProps
 
 export const InputLeadingIcon = ({ className, ...others }: InputLeadingIconProps) => (
-  <InputIcon className={cx(className, 'left-lg')} {...others} />
+  <InputIcon className={cx(className, 'left-lg text-body-1')} {...others} />
 )
 
 InputLeadingIcon.id = 'LeadingIcon'

--- a/packages/components/input/src/InputTrailingIcon.tsx
+++ b/packages/components/input/src/InputTrailingIcon.tsx
@@ -5,7 +5,7 @@ import { InputIcon, InputIconProps } from './InputIcon'
 export type InputTrailingIconProps = InputIconProps
 
 export const InputTrailingIcon = ({ className, ...others }: InputTrailingIconProps) => (
-  <InputIcon className={cx(className, 'right-lg')} {...others} />
+  <InputIcon className={cx(className, 'right-lg text-body-1')} {...others} />
 )
 
 InputTrailingIcon.id = 'TrailingIcon'


### PR DESCRIPTION
Fixed #1547 

### Description, Motivation and Context

Because leading/trailing icons are technically outside of the input (just positionned over it) they were inheriting the font-size of the closest parent of the input, which was causing inconsistencies in icon sizes.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles


### Screenshots - Animations
![Capture d’écran 2023-10-04 à 13 34 12](https://github.com/adevinta/spark/assets/2033710/ee2e5da6-f380-4d4c-9dfd-08aba69e7e25)

