### PR TITLE
chore(icons): remove nested regex argument

### DIFF
--- a/packages/components/icons/scripts/build.mjs
+++ b/packages/components/icons/scripts/build.mjs
@@ -11,7 +11,7 @@ import readFile from './utils/readFile.mjs'
 import tagify from './utils/tagify.mjs'
 import writeFile from './utils/writeFile.mjs'
 
-const main = async (pattern = 'assets/**/*.svg') => {
+const main = async (pattern = 'assets/*.svg') => {
   // Clean the output folder before generating icons
   const outputDir = path.join(process.cwd(), 'src/icons')
 

--- a/packages/components/icons/scripts/build.mjs
+++ b/packages/components/icons/scripts/build.mjs
@@ -11,7 +11,7 @@ import readFile from './utils/readFile.mjs'
 import tagify from './utils/tagify.mjs'
 import writeFile from './utils/writeFile.mjs'
 
-const main = async (pattern = 'assets/*.svg') => {
+const main = async () => {
   // Clean the output folder before generating icons
   const outputDir = path.join(process.cwd(), 'src/icons')
 
@@ -21,7 +21,7 @@ const main = async (pattern = 'assets/*.svg') => {
     fs.unlinkSync(filePath)
   })
 
-  const files = matchFileRoute(undefined, pattern)
+  const files = matchFileRoute(undefined, 'assets/*.svg')
   const data = new Map()
 
   await Promise.all(


### PR DESCRIPTION
## chore(icons): remove nested regex argument

### Description, Motivation and Context
This pull request resolves a potential performance concern by eliminating a nested regular expression in the main function, which is responsible for building icons. The previous regular expression pattern used for matching files, which was passed as an argument, was overly complex, especially considering our flat architecture for icons. This modification simplifies the pattern and removes the argument, making it more straightforward and less susceptible to unexpected behaviors.

### Types of changes
- [x ] 🛠️ Tool