### PR TITLE
fix(tailwind-plugins): override "max-w-*" native tailwind classes

### DIFF
--- a/packages/utils/tailwind-plugins/spark-theme/index.js
+++ b/packages/utils/tailwind-plugins/spark-theme/index.js
@@ -86,6 +86,17 @@ module.exports = plugin.withOptions(
 
     if (!themes.default) throw new Error(missingDefaultThemeErrorMsg)
 
-    return { theme: getCSSVariableReferences(themes.default) }
+    return {
+      theme: {
+        ...getCSSVariableReferences(themes.default),
+        maxWidth: ({ breakpoints, theme }) => ({
+          none: 'none',
+          full: '100%',
+          min: 'min-content',
+          max: 'max-content',
+          ...breakpoints(theme('screens')),
+        }),
+      },
+    }
   }
 )


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1600

### Description, Motivation and Context
Removing `max-w-*` native Tailwind classes from our Tailwind plugin because they are based on a fixed base font-size of 16px.

This lack of adaptability causes confusion at the call site, as the values displayed on the different TCV's or hinted by the IDE may differ from the actual computed values when using a different base font-size

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
