### PR TITLE
fix(popover): adapt popover width on smaller screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,6 +2407,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/popover/src/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent.styles.ts
@@ -16,7 +16,7 @@ export const styles = cva(
       },
       enforceBoundaries: {
         true: ['max-w-[--radix-popper-available-width]'],
-        false: ['max-w-sz-384'],
+        false: ['max-w-[min(var(--sz-384),100vw)]'],
       },
       /**
        * When there is a close button, padding to the right side must be adjusted to avoid content overlapping with it.


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1611 

### Description, Motivation and Context

Popover was cropped on screen smaller than 384px.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

