### PR TITLE
fix(dialog): dialog prevent mouse events in controlled mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,6 +2401,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dialog/src/DialogContent.styles.tsx
+++ b/packages/components/dialog/src/DialogContent.styles.tsx
@@ -1,33 +1,25 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
-export const dialogContentWrapperStyles = cva([
-  'fixed inset-none z-modal flex items-center justify-center',
-  'focus-visible:u-ring focus-visible:outline-none',
-])
-
 export const dialogContentStyles = cva(
-  [
-    ['relative', 'flex', 'flex-col'],
-    ['bg-surface'],
-    'focus-visible:outline-none focus-visible:u-ring',
-  ],
+  ['z-modal flex flex-col bg-surface', 'focus-visible:outline-none focus-visible:u-ring'],
   {
     variants: {
       size: {
-        fullscreen: ['w-full', 'h-full'],
-        sm: ['max-w-sz-480'],
-        md: ['max-w-sz-672'],
-        lg: ['max-w-sz-864'],
+        fullscreen: 'fixed w-full h-full  top-none left-none',
+        sm: 'max-w-sz-480',
+        md: 'max-w-sz-672',
+        lg: 'max-w-sz-864',
       },
     },
     compoundVariants: [
       {
         size: ['sm', 'md', 'lg'],
         class: [
-          ['w-full', 'max-h-[80%]'],
-          ['shadow-md', 'rounded-lg'],
-          ['data-[state=open]:animate-fade-in'],
-          ['data-[state=closed]:animate-fade-out'],
+          'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+          'w-full max-h-[80%]',
+          'shadow-md rounded-lg',
+          'data-[state=open]:animate-fade-in',
+          'data-[state=closed]:animate-fade-out',
         ],
       },
     ],

--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -1,11 +1,7 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
 import { forwardRef, type ReactElement, type Ref, useEffect } from 'react'
 
-import {
-  dialogContentStyles,
-  type DialogContentStylesProps,
-  dialogContentWrapperStyles,
-} from './DialogContent.styles'
+import { dialogContentStyles, type DialogContentStylesProps } from './DialogContent.styles'
 import { useDialog } from './DialogContext'
 
 export type ContentProps = RadixDialog.DialogContentProps & DialogContentStylesProps
@@ -24,19 +20,17 @@ export const Content = forwardRef(
     }, [setIsFullScreen, size])
 
     return (
-      <div className={dialogContentWrapperStyles()}>
-        <RadixDialog.Content
-          data-spark-component="dialog-content"
-          ref={ref}
-          className={dialogContentStyles({
-            size,
-            className,
-          })}
-          {...rest}
-        >
-          {children}
-        </RadixDialog.Content>
-      </div>
+      <RadixDialog.Content
+        data-spark-component="dialog-content"
+        ref={ref}
+        className={dialogContentStyles({
+          size,
+          className,
+        })}
+        {...rest}
+      >
+        {children}
+      </RadixDialog.Content>
     )
   }
 )


### PR DESCRIPTION

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1620 

### Description, Motivation and Context

Check attached ticket please.

Summary: A piece of JSX around `Dialog.Content` does not have access to the radix context of the dialog and is always rendered as an invisible overlay in some cases. It prevents users from interacting with the page.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

