### PR TITLE
fix(dialog): render overlay also in fullscreen to freeze scroll on body

### DIFF
--- a/packages/components/dialog/src/DialogOverlay.tsx
+++ b/packages/components/dialog/src/DialogOverlay.tsx
@@ -10,13 +10,12 @@ export const Overlay = forwardRef(
   ({ className, ...rest }: OverlayProps, ref: Ref<HTMLDivElement>): ReactElement | null => {
     const { isFullScreen } = useDialog()
 
-    if (isFullScreen) return null
-
     return (
       <RadixDialog.Overlay
         ref={ref}
         className={cx(
-          ['fixed', 'top-none', 'left-none', 'w-screen', 'h-screen', 'z-overlay'],
+          isFullScreen ? 'hidden' : 'fixed',
+          ['top-none', 'left-none', 'w-screen', 'h-screen', 'z-overlay'],
           ['bg-overlay/dim-3'],
           ['data-[state=open]:animate-fade-in'],
           ['data-[state=closed]:animate-fade-out'],


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1631

### Description, Motivation and Context

Instead of not rendering `Dialog.Overlay` in fullscreen mode, we hide it with css.

Its presence is necessary because it freeze the scroll of the page in the background.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧠 Refactor
- [x] 💄 Styles

