### PR TITLE
ci: mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Add remote internal repository url
         run: git remote add internal ${{ secrets.GH_ENTERPRISE_INTERNAL_SSH_REPOSITORY_URL }}
       - name: Push main to internal repository
-        run: git push -u internal main
+        run: git push -u internal main --force

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,20 @@
+name: mirror
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7,19 * * 1,2,3,4,5"
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.GH_ENTERPRISE_INTERNAL_SSH_PRIVATE_KEY }}
+      - name: Add remote internal repository url
+        run: git remote add internal ${{ secrets.GH_ENTERPRISE_INTERNAL_SSH_REPOSITORY_URL }}
+      - name: Push main to internal repository
+        run: git push -u internal main


### PR DESCRIPTION
### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Vulcan only tracks internal gh repositories (gh enterprise) for now. The idea of this task+PR is to mirror the repo and at the same time add a periodic sync task in order to do never maintain its sync process manually.

This process will run:
["At minute 0 past hour 7 and 19 on Monday, Tuesday, Wednesday, Thursday, and Friday."](https://crontab.guru/#0_7,19_*_*_1,2,3,4,5)

When vulcan will be able to track public repositories the [mirror repo](https://github.dev.mpi-internal.com/scmspain/frontend-common--uilib-spark) will be removed and also this action.

This action is also prepared to be fired manually in order to sync it on demand if necessary

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->

- [x] 🛠️ Tool
- [x] ⚙️ Engine


### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
