### PR TITLE
1616 component alertdialog review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,6 +2401,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/alert-dialog/src/AlertDialog.doc.mdx
+++ b/packages/components/alert-dialog/src/AlertDialog.doc.mdx
@@ -92,37 +92,11 @@ import { AlertDialog } from '@spark-ui/alert-dialog'
 
 <Canvas of={stories.Usage} />
 
-### Uncontrolled
-
-Use `defaultOpen` prop to set the default state of the dialog. Optionally `onOpenChange` prop can be used to know when the state of the dialog changes.
-
-<Canvas of={stories.Uncontrolled} />
-
 ### Controlled
 
-Use `open` and `onOpenChange` props to control the state of the dialog.
+Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
 
 <Canvas of={stories.Controlled} />
-
-## Advanced usage
-
-### Escape
-
-Use `onEscapeKeyDown` prop to listen to when the escape key is pressed. Optionally, the dialog could be prevented from closing by calling `event.preventDefault`.
-
-<Canvas of={stories.Escape} />
-
-### Focus open
-
-Use `onOpenAutoFocus` prop to listen to when focus moves to the less destructive action after opening. Optionally, the autofocus behavior could be prevented by calling `event.preventDefault`.
-
-<Canvas of={stories.OpenFocus} />
-
-### Focus close
-
-Use `onCloseAutoFocus` prop to listen to when focus moves to the trigger after closing. Optionally, the autofocus behavior could be prevented by calling `event.preventDefault`.
-
-<Canvas of={stories.CloseFocus} />
 
 ## Accessibility
 

--- a/packages/components/alert-dialog/src/AlertDialog.doc.mdx
+++ b/packages/components/alert-dialog/src/AlertDialog.doc.mdx
@@ -10,7 +10,7 @@ import * as stories from './AlertDialog.stories'
 
 # AlertDialog
 
-A modal dialog that interrupts the user with important content and expects a response.
+A modal dialog that interrupts the user with important content and expects a response. Examples include action confirmation prompts and error message confirmations.
 
 - Focus is automatically trapped.
 - Can be controlled or uncontrolled.

--- a/packages/components/alert-dialog/src/AlertDialog.stories.tsx
+++ b/packages/components/alert-dialog/src/AlertDialog.stories.tsx
@@ -49,58 +49,16 @@ export const Usage: StoryFn = _args => {
   )
 }
 
-export const Uncontrolled: StoryFn = () => {
-  return (
-    <AlertDialog defaultOpen={false}>
-      <AlertDialog.Trigger asChild>
-        <Button intent="danger">Delete</Button>
-      </AlertDialog.Trigger>
-
-      <AlertDialog.Portal>
-        <AlertDialog.Overlay />
-
-        <AlertDialog.Content>
-          <AlertDialog.Header>
-            <AlertDialog.Title>Delete account</AlertDialog.Title>
-          </AlertDialog.Header>
-
-          <AlertDialog.Body>
-            <AlertDialog.Description>
-              Are you sure? You can not undo this action afterwards.
-            </AlertDialog.Description>
-          </AlertDialog.Body>
-
-          <AlertDialog.Footer className="flex justify-end gap-md">
-            <AlertDialog.Cancel asChild>
-              <Button intent="neutral" design="ghost">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-
-            <AlertDialog.Action asChild>
-              <Button intent="danger">Delete</Button>
-            </AlertDialog.Action>
-          </AlertDialog.Footer>
-        </AlertDialog.Content>
-      </AlertDialog.Portal>
-    </AlertDialog>
-  )
-}
-
 export const Controlled: StoryFn = () => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const handleClick = () => {
-    setIsOpen(true)
-  }
-
   return (
     <>
-      <Button intent="danger" onClick={handleClick}>
-        Delete
-      </Button>
-
       <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+        <AlertDialog.Trigger asChild>
+          <Button intent="danger">Delete</Button>
+        </AlertDialog.Trigger>
+
         <AlertDialog.Portal>
           <AlertDialog.Overlay />
 
@@ -110,9 +68,7 @@ export const Controlled: StoryFn = () => {
             </AlertDialog.Header>
 
             <AlertDialog.Body>
-              <AlertDialog.Description>
-                Are you sure? You can not undo this action afterwards.
-              </AlertDialog.Description>
+              Are you sure? You can not undo this action afterwards.
             </AlertDialog.Body>
 
             <AlertDialog.Footer className="flex justify-end gap-md">
@@ -130,134 +86,5 @@ export const Controlled: StoryFn = () => {
         </AlertDialog.Portal>
       </AlertDialog>
     </>
-  )
-}
-
-export const Escape: StoryFn = () => {
-  const handleEscapeKeyDown = (event: KeyboardEvent) => {
-    // optional
-    event.preventDefault()
-  }
-
-  return (
-    <AlertDialog>
-      <AlertDialog.Trigger asChild>
-        <Button intent="danger">Delete</Button>
-      </AlertDialog.Trigger>
-
-      <AlertDialog.Portal>
-        <AlertDialog.Overlay />
-
-        <AlertDialog.Content onEscapeKeyDown={handleEscapeKeyDown}>
-          <AlertDialog.Header>
-            <AlertDialog.Title>Delete account</AlertDialog.Title>
-          </AlertDialog.Header>
-
-          <AlertDialog.Body>
-            <AlertDialog.Description>
-              Are you sure? You can not undo this action afterwards.
-            </AlertDialog.Description>
-          </AlertDialog.Body>
-
-          <AlertDialog.Footer className="flex justify-end gap-md">
-            <AlertDialog.Cancel asChild>
-              <Button intent="neutral" design="ghost">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-
-            <AlertDialog.Action asChild>
-              <Button intent="danger">Delete</Button>
-            </AlertDialog.Action>
-          </AlertDialog.Footer>
-        </AlertDialog.Content>
-      </AlertDialog.Portal>
-    </AlertDialog>
-  )
-}
-
-export const OpenFocus: StoryFn = () => {
-  const handleOpenAutoFocus = (event: Event) => {
-    // optional
-    event.preventDefault()
-  }
-
-  return (
-    <AlertDialog>
-      <AlertDialog.Trigger asChild>
-        <Button intent="danger">Delete</Button>
-      </AlertDialog.Trigger>
-
-      <AlertDialog.Portal>
-        <AlertDialog.Overlay />
-
-        <AlertDialog.Content onOpenAutoFocus={handleOpenAutoFocus}>
-          <AlertDialog.Header>
-            <AlertDialog.Title>Delete account</AlertDialog.Title>
-          </AlertDialog.Header>
-
-          <AlertDialog.Body>
-            <AlertDialog.Description>
-              Are you sure? You can not undo this action afterwards.
-            </AlertDialog.Description>
-          </AlertDialog.Body>
-
-          <AlertDialog.Footer className="flex justify-end gap-md">
-            <AlertDialog.Cancel asChild>
-              <Button intent="neutral" design="ghost">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-
-            <AlertDialog.Action asChild>
-              <Button intent="danger">Delete</Button>
-            </AlertDialog.Action>
-          </AlertDialog.Footer>
-        </AlertDialog.Content>
-      </AlertDialog.Portal>
-    </AlertDialog>
-  )
-}
-
-export const CloseFocus: StoryFn = () => {
-  const handleCloseAutoFocus = (event: Event) => {
-    // optional
-    event.preventDefault()
-  }
-
-  return (
-    <AlertDialog>
-      <AlertDialog.Trigger asChild>
-        <Button intent="danger">Delete</Button>
-      </AlertDialog.Trigger>
-
-      <AlertDialog.Portal>
-        <AlertDialog.Overlay />
-
-        <AlertDialog.Content onCloseAutoFocus={handleCloseAutoFocus}>
-          <AlertDialog.Header>
-            <AlertDialog.Title>Delete account</AlertDialog.Title>
-          </AlertDialog.Header>
-
-          <AlertDialog.Body>
-            <AlertDialog.Description>
-              Are you sure? You can not undo this action afterwards.
-            </AlertDialog.Description>
-          </AlertDialog.Body>
-
-          <AlertDialog.Footer className="flex justify-end gap-md">
-            <AlertDialog.Cancel asChild>
-              <Button intent="neutral" design="ghost">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-
-            <AlertDialog.Action asChild>
-              <Button intent="danger">Delete</Button>
-            </AlertDialog.Action>
-          </AlertDialog.Footer>
-        </AlertDialog.Content>
-      </AlertDialog.Portal>
-    </AlertDialog>
   )
 }

--- a/packages/components/alert-dialog/src/AlertDialogContent.tsx
+++ b/packages/components/alert-dialog/src/AlertDialogContent.tsx
@@ -8,7 +8,7 @@ import { AlertDialogContext } from './AlertDialogContext'
 export type AlertDialogContentElement = ElementRef<typeof Dialog.Content>
 export type AlertDialogContentProps = Omit<
   DialogContentProps,
-  'size' | 'onPointerDownOutside' | 'onInteractOutside'
+  'size' | 'isNarrow' | 'onPointerDownOutside' | 'onInteractOutside'
 >
 
 export const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
@@ -38,12 +38,13 @@ export const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDia
           ref={ref}
           data-spark-component="alert-dialog-content"
           {...others}
-          className={cx(className, '!w-auto min-w-sz-288')}
+          className={cx(className, 'min-w-sz-288')}
           role="alertdialog"
           size="md"
           onOpenAutoFocus={composeEventHandlers(onOpenAutoFocus, handleOpenAutoFocus)}
           onPointerDownOutside={handlePointerDownOutside}
           onInteractOutside={handleInteractOutside}
+          isNarrow
         />
       </AlertDialogContext.Provider>
     )

--- a/packages/components/alert-dialog/src/AlertDialogContent.tsx
+++ b/packages/components/alert-dialog/src/AlertDialogContent.tsx
@@ -1,5 +1,6 @@
 import { composeEventHandlers } from '@radix-ui/primitive'
 import { Dialog, DialogContentProps } from '@spark-ui/dialog'
+import { cx } from 'class-variance-authority'
 import { ElementRef, forwardRef, useMemo, useRef } from 'react'
 
 import { AlertDialogContext } from './AlertDialogContext'
@@ -7,11 +8,11 @@ import { AlertDialogContext } from './AlertDialogContext'
 export type AlertDialogContentElement = ElementRef<typeof Dialog.Content>
 export type AlertDialogContentProps = Omit<
   DialogContentProps,
-  'onPointerDownOutside' | 'onInteractOutside'
+  'size' | 'onPointerDownOutside' | 'onInteractOutside'
 >
 
 export const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
-  ({ onOpenAutoFocus, ...others }, ref) => {
+  ({ className, onOpenAutoFocus, ...others }, ref) => {
     const cancelRef = useRef<HTMLButtonElement | null>(null)
 
     const value = useMemo(() => {
@@ -37,7 +38,9 @@ export const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDia
           ref={ref}
           data-spark-component="alert-dialog-content"
           {...others}
+          className={cx(className, '!w-auto min-w-sz-288')}
           role="alertdialog"
+          size="md"
           onOpenAutoFocus={composeEventHandlers(onOpenAutoFocus, handleOpenAutoFocus)}
           onPointerDownOutside={handlePointerDownOutside}
           onInteractOutside={handleInteractOutside}

--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -12,11 +12,11 @@ import * as stories from './Dialog.stories'
 
 A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 
-- ✅ Supports modal and non-modal modes.
-- ✅ Focus is automatically trapped when modal.
-- ✅ Can be controlled or uncontrolled.
-- ✅ Manages screen reader announcements with `Title` and `Description` components.
-- ✅ Esc closes the component automatically.
+- Supports modal and non-modal modes.
+- Focus is automatically trapped when modal.
+- Can be controlled or uncontrolled.
+- Manages screen reader announcements with `Title` and `Description` components.
+- Esc closes the component automatically.
 
 ## Install
 
@@ -89,9 +89,13 @@ import { Dialog } from '@spark-ui/dialog'
 
 ### Default
 
-Use the various parts of `Dialog` to build a highly customizable dialog.
-
 <Canvas of={stories.Default} />
+
+### Controlled
+
+Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
+
+<Canvas of={stories.Controlled} />
 
 ### Sizes
 
@@ -103,13 +107,13 @@ Pick a size among `sm`, `md`, `lg` and `fullscreen`.
 
 ### Form inside a dialog
 
-This example shows you how to combine `Dialog` with an `HTML` form.
+The `Dialog` component can be effortlessly combined with a form element.
 
-<Canvas of={stories.HTMLForm} />
+<Canvas of={stories.Form} />
 
 ### Forward focus
 
-You can use `onOpenAutoFocus` and a `ref` to pass the focus to a specific element when the dialog opens.
+Use `onOpenAutoFocus` and a `ref` to direct focus to a specific element when the dialog opens.
 
 <Canvas of={stories.ForwardFocus} />
 

--- a/packages/components/dialog/src/Dialog.stories.tsx
+++ b/packages/components/dialog/src/Dialog.stories.tsx
@@ -39,12 +39,8 @@ export const Default: StoryFn = () => {
 
           <Dialog.Footer className="flex justify-end gap-md">
             <Dialog.Close asChild>
-              <Button intent="neutral" design="outlined">
-                Cancel
-              </Button>
+              <Button>Close</Button>
             </Dialog.Close>
-
-            <Button>Submit</Button>
           </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit profile" />
@@ -90,12 +86,8 @@ export const Controlled: StoryFn = () => {
 
           <Dialog.Footer className="flex justify-end gap-md">
             <Dialog.Close asChild>
-              <Button intent="neutral" design="outlined">
-                Cancel
-              </Button>
+              <Button>Close</Button>
             </Dialog.Close>
-
-            <Button>Submit</Button>
           </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit profile" />
@@ -141,12 +133,8 @@ export const Sizes = () => {
 
           <Dialog.Footer className="flex justify-end gap-md">
             <Dialog.Close asChild>
-              <Button intent="neutral" design="outlined">
-                Cancel
-              </Button>
+              <Button>Close</Button>
             </Dialog.Close>
-
-            <Button>Save</Button>
           </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit size" />
@@ -158,17 +146,14 @@ export const Sizes = () => {
 
 export const Form = () => {
   const [open, setOpen] = useState(false)
-  const [isAccountCreated, setIsAccountCreated] = useState(false)
 
   const handleOpenChange = (open: boolean) => {
     setOpen(open)
-
-    if (!open) setIsAccountCreated(false)
   }
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    setIsAccountCreated(true)
+    setOpen(false)
   }
 
   return (
@@ -187,18 +172,14 @@ export const Form = () => {
             </Dialog.Header>
 
             <Dialog.Body className="flex flex-col gap-lg">
-              {!isAccountCreated ? (
-                <FormField name="pseudo" isRequired className="flex-1">
-                  <FormField.Label>Pseudo</FormField.Label>
-                  <Input placeholder="Luke" />
-                </FormField>
-              ) : (
-                <p className="text-success">Welcome to Spark !</p>
-              )}
+              <FormField name="pseudo" isRequired className="flex-1">
+                <FormField.Label>Pseudo</FormField.Label>
+                <Input placeholder="Luke" />
+              </FormField>
             </Dialog.Body>
 
             <Dialog.Footer className="flex justify-end gap-md">
-              {!isAccountCreated && <Button type="submit">Submit</Button>}
+              <Button type="submit">Submit</Button>
             </Dialog.Footer>
           </form>
 

--- a/packages/components/dialog/src/Dialog.stories.tsx
+++ b/packages/components/dialog/src/Dialog.stories.tsx
@@ -15,10 +15,50 @@ const meta: Meta<typeof Dialog> = {
 export default meta
 
 export const Default: StoryFn = () => {
-  const [open, setOpen] = useState(false)
+  return (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button>Edit profile</Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay />
+
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Edit profile</Dialog.Title>
+          </Dialog.Header>
+
+          <Dialog.Body>
+            <Dialog.Description>
+              Make changes to your profile here. Click save when you are done.
+            </Dialog.Description>
+
+            <p>Lorem ipsum dolor sit amet</p>
+          </Dialog.Body>
+
+          <Dialog.Footer className="flex justify-end gap-md">
+            <Dialog.Close asChild>
+              <Button intent="neutral" design="outlined">
+                Cancel
+              </Button>
+            </Dialog.Close>
+
+            <Button>Submit</Button>
+          </Dialog.Footer>
+
+          <Dialog.CloseButton aria-label="Close edit profile" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}
+
+export const Controlled: StoryFn = () => {
+  const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
         <Button>Edit profile</Button>
       </Dialog.Trigger>
@@ -49,9 +89,12 @@ export const Default: StoryFn = () => {
           </Dialog.Body>
 
           <Dialog.Footer className="flex justify-end gap-md">
-            <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
+            <Dialog.Close asChild>
+              <Button intent="neutral" design="outlined">
+                Cancel
+              </Button>
+            </Dialog.Close>
+
             <Button>Submit</Button>
           </Dialog.Footer>
 
@@ -64,25 +107,16 @@ export const Default: StoryFn = () => {
 
 export const Sizes = () => {
   const [size, setSize] = useState<ExcludeNull<DialogContentProps>['size']>('md')
-  const [open, setOpen] = useState(false)
+
+  const handleValueChange = (value: string) => {
+    setSize(value as ExcludeNull<DialogContentProps>['size'])
+  }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog>
       <div className="flex gap-md">
         <Dialog.Trigger asChild>
-          <Button onClick={() => setSize('sm')}>Small</Button>
-        </Dialog.Trigger>
-
-        <Dialog.Trigger asChild>
-          <Button onClick={() => setSize('md')}>Medium</Button>
-        </Dialog.Trigger>
-
-        <Dialog.Trigger asChild>
-          <Button onClick={() => setSize('lg')}>Large</Button>
-        </Dialog.Trigger>
-
-        <Dialog.Trigger asChild>
-          <Button onClick={() => setSize('fullscreen')}>Fullscreen</Button>
+          <Button>Open</Button>
         </Dialog.Trigger>
       </div>
 
@@ -97,11 +131,7 @@ export const Sizes = () => {
           <Dialog.Body className="flex flex-col gap-lg">
             <Dialog.Description>Please select a dialog size</Dialog.Description>
 
-            <RadioGroup
-              className="flex gap-md"
-              value={size}
-              onValueChange={value => setSize(value as ExcludeNull<DialogContentProps>['size'])}
-            >
+            <RadioGroup className="flex gap-md" value={size} onValueChange={handleValueChange}>
               <RadioGroup.Radio value="sm">Small</RadioGroup.Radio>
               <RadioGroup.Radio value="md">Medium</RadioGroup.Radio>
               <RadioGroup.Radio value="lg">Large</RadioGroup.Radio>
@@ -110,10 +140,13 @@ export const Sizes = () => {
           </Dialog.Body>
 
           <Dialog.Footer className="flex justify-end gap-md">
-            <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-            <Button>Submit</Button>
+            <Dialog.Close asChild>
+              <Button intent="neutral" design="outlined">
+                Cancel
+              </Button>
+            </Dialog.Close>
+
+            <Button>Save</Button>
           </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit size" />
@@ -123,7 +156,7 @@ export const Sizes = () => {
   )
 }
 
-export const HTMLForm = () => {
+export const Form = () => {
   const [open, setOpen] = useState(false)
   const [isAccountCreated, setIsAccountCreated] = useState(false)
 
@@ -165,7 +198,7 @@ export const HTMLForm = () => {
             </Dialog.Body>
 
             <Dialog.Footer className="flex justify-end gap-md">
-              {!isAccountCreated && <Button>Submit</Button>}
+              {!isAccountCreated && <Button type="submit">Submit</Button>}
             </Dialog.Footer>
           </form>
 

--- a/packages/components/dialog/src/DialogContent.styles.tsx
+++ b/packages/components/dialog/src/DialogContent.styles.tsx
@@ -10,21 +10,31 @@ export const dialogContentStyles = cva(
         md: 'max-w-sz-672',
         lg: 'max-w-sz-864',
       },
+      isNarrow: {
+        true: [],
+        false: [],
+      },
     },
     compoundVariants: [
       {
         size: ['sm', 'md', 'lg'],
         class: [
           'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-          'w-full max-h-[80%]',
+          'max-h-[80%]',
           'shadow-md rounded-lg',
           'data-[state=open]:animate-fade-in',
           'data-[state=closed]:animate-fade-out',
         ],
       },
+      {
+        size: ['sm', 'md', 'lg'],
+        isNarrow: false,
+        class: ['w-full'],
+      },
     ],
     defaultVariants: {
       size: 'md',
+      isNarrow: false,
     },
   }
 )

--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -4,11 +4,16 @@ import { forwardRef, type ReactElement, type Ref, useEffect } from 'react'
 import { dialogContentStyles, type DialogContentStylesProps } from './DialogContent.styles'
 import { useDialog } from './DialogContext'
 
-export type ContentProps = RadixDialog.DialogContentProps & DialogContentStylesProps
+export interface ContentProps extends RadixDialog.DialogContentProps, DialogContentStylesProps {
+  /**
+   * When set to true, the content will adjust its width to fit the content rather than taking up the full available width.
+   */
+  isNarrow?: boolean
+}
 
 export const Content = forwardRef(
   (
-    { children, className, size = 'md', ...rest }: ContentProps,
+    { children, className, isNarrow = false, size = 'md', ...rest }: ContentProps,
     ref: Ref<HTMLDivElement>
   ): ReactElement => {
     const { setIsFullScreen } = useDialog()
@@ -24,8 +29,9 @@ export const Content = forwardRef(
         data-spark-component="dialog-content"
         ref={ref}
         className={dialogContentStyles({
-          size,
           className,
+          isNarrow,
+          size,
         })}
         {...rest}
       >


### PR DESCRIPTION
## AlertDialog size

<!-- https://github.com/adevinta/spark/issues -->
**TASK**:  #1616 

### Description, Motivation and Context
This PR align `AlertDialog` with the specs.
- Remove `size` prop support. It should be fixed to `md` and the width should be adapted to the content.
- Add `isNarrow` prop to `Dialog` component
- Update both `Dialog` and `AlertDialog` documentation

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
