### PR TITLE
feat(dropdown): dropdown bootstrap package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,6 +2401,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7742,6 +7743,10 @@
     },
     "node_modules/@spark-ui/drawer": {
       "resolved": "packages/components/drawer",
+      "link": true
+    },
+    "node_modules/@spark-ui/dropdown": {
+      "resolved": "packages/components/dropdown",
       "link": true
     },
     "node_modules/@spark-ui/form-field": {
@@ -34208,6 +34213,15 @@
       },
       "peerDependencies": {
         "@spark-ui/theme-utils": "^4.0.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "tailwindcss": "^3.0.0"
+      }
+    },
+    "packages/components/dropdown": {
+      "version": "0.1.5",
+      "license": "MIT",
+      "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0",
         "tailwindcss": "^3.0.0"

--- a/packages/components/dropdown/.npmignore
+++ b/packages/components/dropdown/.npmignore
@@ -1,0 +1,2 @@
+src
+**/*.stories.*

--- a/packages/components/dropdown/LICENSE.md
+++ b/packages/components/dropdown/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Adevinta ASA.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/components/dropdown/README.md
+++ b/packages/components/dropdown/README.md
@@ -1,0 +1,13 @@
+# Dropdown
+> @spark-ui/dropdown
+
+[![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-dropdown--docs)
+[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/dropdown)
+[![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=component,dropdown)
+[![npm](https://img.shields.io/npm/dt/%40spark-ui/dropdown?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/dropdown)
+
+
+This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
+
+[![Issues open](https://img.shields.io/github/issues-search/adevinta/spark?query=is%3Aopen%20label%3Acomponent%20label%3Aselect&logo=openbugbounty&logoColor=red&label=issues%20open&color=red)](https://github.com/adevinta/spark/issues?q=is%3Aopen+label%3Acomponent+label%3Aselect)
+[![NPM](https://img.shields.io/npm/l/%40spark-ui%2Fselect)](https://github.com/adevinta/spark/blob/main/packages/components/dropdown/LICENSE.md)

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@spark-ui/dropdown",
+  "version": "0.0.1",
+  "description": "Displays a list of options for the user to pick from—triggered by a button. Differs from Select in that it offers multiple select and its list is not native.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "@spark-ui",
+    "react",
+    "component",
+    "accessible",
+    "accessibility",
+    "wai-aria",
+    "aria",
+    "a11y",
+    "dropdown"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "vite build"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0",
+    "tailwindcss": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adevinta/spark.git",
+    "directory": "packages/components/dropdown"
+  },
+  "config": {
+    "title": "dropdown",
+    "category": "components"
+  },
+  "bugs": {
+    "url": "https://github.com/adevinta/spark/issues?q=is%3Aopen+label%3Autility+label%3Aselect"
+  },
+  "homepage": "https://sparkui.vercel.app",
+  "license": "MIT"
+}

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -1,0 +1,32 @@
+import { Meta, Canvas } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks'
+
+import { Dropdown } from '.'
+
+import * as stories from './Dropdown.stories'
+
+<Meta of={stories} />
+
+# Dropdown
+
+Displays a list of options for the user to pick from—triggered by a button.
+
+## Install
+
+```sh
+npm install @spark-ui/dropdown
+```
+
+## Import
+
+```tsx
+import { Dropdown } from '@spark-ui/dropdown'
+```
+
+## Props
+
+<ArgTypes of={Dropdown} />
+
+## Variants
+
+<Canvas of={stories.Default} />

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -1,0 +1,12 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { Dropdown } from '.'
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Experimental/Dropdown',
+  component: Dropdown,
+}
+
+export default meta
+
+export const Default: StoryFn = _args => <Dropdown />

--- a/packages/components/dropdown/src/Dropdown.test.tsx
+++ b/packages/components/dropdown/src/Dropdown.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Dropdown } from './Dropdown'
+
+describe('Dropdown', () => {
+  it('should render', () => {
+    render(<Dropdown />)
+
+    expect(screen.getByText(/dropdown/)).toBeInTheDocument()
+  })
+})

--- a/packages/components/dropdown/src/Dropdown.tsx
+++ b/packages/components/dropdown/src/Dropdown.tsx
@@ -1,0 +1,1 @@
+export const Dropdown = () => <>dropdown</>

--- a/packages/components/dropdown/src/index.ts
+++ b/packages/components/dropdown/src/index.ts
@@ -1,0 +1,1 @@
+export { Dropdown } from './Dropdown'

--- a/packages/components/dropdown/tsconfig.json
+++ b/packages/components/dropdown/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src/**/*", "../../../global.d.ts"]
+}

--- a/packages/components/dropdown/vite.config.ts
+++ b/packages/components/dropdown/vite.config.ts
@@ -1,0 +1,6 @@
+import path from 'path'
+import { getComponentConfiguration } from '../../../config/index'
+
+const { name } = require(path.resolve(__dirname, 'package.json'))
+
+export default getComponentConfiguration(process.cwd(), name)


### PR DESCRIPTION
### Description, Motivation and Context

Simply bootstraping `Dropdown` package in order to have smaller PRs when we start working on it. We will need it to work on it in parallel of working on `Select`.

### Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality)
