### PR TITLE
feat(dialog): add inset prop

### DIFF
--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -103,6 +103,12 @@ Pick a size among `sm`, `md`, `lg` and `fullscreen`.
 
 <Canvas of={stories.Sizes} />
 
+### Inset
+
+When set to `true`, this option will remove the internal padding of the `Dialog.Body` component. This allows you to have an image or any content that occupies the full width, for example.
+
+<Canvas of={stories.Inset} />
+
 ## Advanced usage
 
 ### Form inside a dialog

--- a/packages/components/dialog/src/Dialog.stories.tsx
+++ b/packages/components/dialog/src/Dialog.stories.tsx
@@ -144,6 +144,41 @@ export const Sizes = () => {
   )
 }
 
+export const Inset = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <Button>Open dialog</Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay />
+
+        <Dialog.Content size="sm">
+          <Dialog.Header>
+            <Dialog.Title>Inset example</Dialog.Title>
+          </Dialog.Header>
+
+          <Dialog.Body inset className="flex flex-col gap-lg">
+            <img src="https://placehold.co/600x400" alt="" />
+            <p className="px-md">The image above is taking up the full width.</p>
+          </Dialog.Body>
+
+          <Dialog.Footer className="flex justify-end gap-md">
+            <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </Dialog.Footer>
+
+          <Dialog.CloseButton aria-label="Close dialog" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}
+
 export const Form = () => {
   const [open, setOpen] = useState(false)
 

--- a/packages/components/dialog/src/Dialog.test.tsx
+++ b/packages/components/dialog/src/Dialog.test.tsx
@@ -161,4 +161,31 @@ describe('Dialog', () => {
     expect(screen.queryByRole('dialog', { name: 'Edit profile' })).not.toBeInTheDocument()
     expect(onEscapeKeyDown).toHaveBeenCalled()
   })
+
+  it('should handle the inset prop', async () => {
+    render(
+      <Dialog defaultOpen>
+        <Dialog.Portal>
+          <Dialog.Overlay />
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Edit profile</Dialog.Title>
+            </Dialog.Header>
+
+            <Dialog.Body inset>
+              <p>Dialog contents</p>
+            </Dialog.Body>
+
+            <Dialog.Footer>
+              <Button>Close</Button>
+            </Dialog.Footer>
+
+            <Dialog.CloseButton aria-label="Close" />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    )
+
+    expect(screen.getByText(/dialog contents/i).parentElement).not.toHaveClass('px-xl py-lg')
+  })
 })

--- a/packages/components/dialog/src/DialogBody.styles.ts
+++ b/packages/components/dialog/src/DialogBody.styles.ts
@@ -1,0 +1,15 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const dialogBodyStyles = cva(
+  ['grow', 'overflow-y-auto', 'outline-none', 'focus-visible:u-ring'],
+  {
+    variants: {
+      inset: {
+        true: '',
+        false: 'px-xl py-lg',
+      },
+    },
+  }
+)
+
+export type DialogBodyStylesProps = VariantProps<typeof dialogBodyStyles>

--- a/packages/components/dialog/src/DialogBody.tsx
+++ b/packages/components/dialog/src/DialogBody.tsx
@@ -1,22 +1,17 @@
-import { cx } from 'class-variance-authority'
 import { forwardRef, type ReactElement, type ReactNode, type Ref } from 'react'
 
-export interface BodyProps {
+import { dialogBodyStyles, type DialogBodyStylesProps } from './DialogBody.styles'
+export interface BodyProps extends DialogBodyStylesProps {
   children: ReactNode
   className?: string
 }
 
 export const Body = forwardRef(
-  ({ children, className, ...rest }: BodyProps, ref: Ref<HTMLDivElement>): ReactElement => (
-    <div
-      ref={ref}
-      className={cx(
-        className,
-        ['px-xl', 'py-lg', 'flex-grow', 'overflow-y-auto'],
-        ['outline-none', 'focus-visible:u-ring']
-      )}
-      {...rest}
-    >
+  (
+    { children, className, inset = false, ...rest }: BodyProps,
+    ref: Ref<HTMLDivElement>
+  ): ReactElement => (
+    <div ref={ref} className={dialogBodyStyles({ inset, className })} {...rest}>
       {children}
     </div>
   )


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1652

### Description, Motivation and Context
Add `inset` prop to remove internal padding of `Dialog.Body` for better handling of full-width content

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
