### PR TITLE
feat(drawer): add inset prop to drawer

### DIFF
--- a/packages/components/drawer/src/Drawer.doc.mdx
+++ b/packages/components/drawer/src/Drawer.doc.mdx
@@ -97,6 +97,12 @@ Pick a size among `sm`, `md`, `lg`.
 
 <Canvas of={stories.Sizes} />
 
+### Inset
+
+When set to `true`, this option will remove the internal padding of the `Drawer.Body` component. This allows you to have an image or any content that occupies the full width, for example.
+
+<Canvas of={stories.Inset} />
+
 ### Side
 
 Pick a side among `right`, `left`, `top` and `bottom`.

--- a/packages/components/drawer/src/Drawer.stories.tsx
+++ b/packages/components/drawer/src/Drawer.stories.tsx
@@ -125,6 +125,41 @@ export const Sizes = () => {
   )
 }
 
+export const Inset: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <Drawer.Trigger asChild>
+        <Button>Open drawer</Button>
+      </Drawer.Trigger>
+
+      <Drawer.Portal>
+        <Drawer.Overlay />
+
+        <Drawer.Content size="sm">
+          <Drawer.Header>
+            <Drawer.Title>Edit inset</Drawer.Title>
+          </Drawer.Header>
+
+          <Drawer.Body inset>
+            <img src="https://placehold.co/480x800" alt="" />
+          </Drawer.Body>
+
+          <Drawer.Footer className="flex justify-end gap-md">
+            <Button intent="neutral" design="outlined" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button>Submit</Button>
+          </Drawer.Footer>
+
+          <Drawer.CloseButton aria-label="Close edit profile" />
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer>
+  )
+}
+
 export const Side = () => {
   const [side, setSide] = useState<ExcludeNull<DrawerContentProps>['side']>('right')
   const [open, setOpen] = useState(false)

--- a/packages/components/drawer/src/Drawer.test.tsx
+++ b/packages/components/drawer/src/Drawer.test.tsx
@@ -16,12 +16,13 @@ describe('Drawer', () => {
         <Drawer.Portal>
           <Drawer.Overlay />
           <Drawer.Content>
-            <Drawer.Title>Edit profile</Drawer.Title>
-            <Drawer.Description>
-              Make changes to your profile here. Click save when you are done.
-            </Drawer.Description>
+            <Drawer.Header>
+              <Drawer.Title>Edit profile</Drawer.Title>
+            </Drawer.Header>
 
-            <p>Drawer contents</p>
+            <Drawer.Body>
+              <p>Drawer contents</p>
+            </Drawer.Body>
 
             <Drawer.CloseButton aria-label="Close edit profile" />
           </Drawer.Content>
@@ -34,5 +35,31 @@ describe('Drawer', () => {
     await user.click(screen.getByText('Edit profile'))
 
     expect(screen.getByText('Drawer contents')).toBeInTheDocument()
+  })
+
+  it('should handle the inset prop', () => {
+    render(
+      <Drawer defaultOpen>
+        <Drawer.Trigger asChild>
+          <button>Edit profile</button>
+        </Drawer.Trigger>
+
+        <Drawer.Portal>
+          <Drawer.Overlay />
+          <Drawer.Content>
+            <Drawer.Header>
+              <Drawer.Title>Edit profile</Drawer.Title>
+            </Drawer.Header>
+
+            <Drawer.Body inset>
+              <p>Drawer contents</p>
+            </Drawer.Body>
+            <Drawer.CloseButton aria-label="Close edit profile" />
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer>
+    )
+
+    expect(screen.getByText(/Drawer contents/i).parentElement).not.toHaveClass('px-xl py-lg')
   })
 })

--- a/packages/components/drawer/src/DrawerBody.styles.ts
+++ b/packages/components/drawer/src/DrawerBody.styles.ts
@@ -1,0 +1,18 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const drawerBodyStyles = cva(
+  ['grow', 'overflow-y-auto', 'outline-none', 'focus-visible:u-ring'],
+  {
+    variants: {
+      inset: {
+        true: '',
+        false: 'px-xl py-lg',
+      },
+    },
+    defaultVariants: {
+      inset: false,
+    },
+  }
+)
+
+export type DrawerBodyStylesProps = VariantProps<typeof drawerBodyStyles>

--- a/packages/components/drawer/src/DrawerBody.tsx
+++ b/packages/components/drawer/src/DrawerBody.tsx
@@ -1,22 +1,15 @@
-import { cx } from 'class-variance-authority'
 import { forwardRef, type ReactNode, type Ref } from 'react'
 
-export interface DrawerBodyProps {
+import { drawerBodyStyles, type DrawerBodyStylesProps } from './DrawerBody.styles'
+
+export interface DrawerBodyProps extends DrawerBodyStylesProps {
   children: ReactNode
   className?: string
 }
 
 export const DrawerBody = forwardRef(
-  ({ children, className, ...rest }: DrawerBodyProps, ref: Ref<HTMLDivElement>) => (
-    <div
-      ref={ref}
-      className={cx(
-        ['px-xl', 'py-lg', 'flex-grow', 'overflow-y-auto'],
-        ['outline-none', 'focus-visible:u-ring'],
-        className
-      )}
-      {...rest}
-    >
+  ({ children, inset = false, className, ...rest }: DrawerBodyProps, ref: Ref<HTMLDivElement>) => (
+    <div ref={ref} className={drawerBodyStyles({ inset, className })} {...rest}>
       {children}
     </div>
   )


### PR DESCRIPTION
**TASK**: #1654 

### Description, Motivation and Context
There is a common use case in Polaris where users want to have elements within the Drawer component that takes up the full width.

Currently, achieving this requires overriding the internal padding of the component. To prop would make this use case easier and more intuitive.

When set to true, this prop will remove the internal padding of the component, allowing for a full-width image or content.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
![Capture d’écran du 2023-11-21 15-49-04](https://github.com/adevinta/spark/assets/66770550/2c45a204-0c5e-4793-83a3-d78c2a785456)


