### PR TITLE
feat(dropdown): enable custom jsx in DropdownItem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,6 +2402,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -1,4 +1,5 @@
 import { Switch } from '@spark-ui/switch'
+import { Tag } from '@spark-ui/tag'
 import { Meta, StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
@@ -33,9 +34,17 @@ export const Default: StoryFn = _args => {
           <Dropdown.Item value="book-7">Meditations</Dropdown.Item>
           <Dropdown.Item value="book-8">The Brothers Karamazov</Dropdown.Item>
           <Dropdown.Item value="book-9">Anna Karenina</Dropdown.Item>
-          <Dropdown.Item value="book-10">Crime and Punishment</Dropdown.Item>
+          <Dropdown.Item value="book-10" className="gap-md">
+            <Dropdown.ItemText>Crime and Punishment</Dropdown.ItemText>
+            <Tag>New</Tag>
+          </Dropdown.Item>
         </Dropdown.Items>
       </Dropdown>
+      <p>some content, etc...</p>
+      <p>some content, etc...</p>
+      <p>some content, etc...</p>
+      <p>some content, etc...</p>
+      <p>some content, etc...</p>
     </div>
   )
 }

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -61,12 +61,8 @@ export const DropdownProvider = ({ children }: DropdownContextProps) => {
   const syncItems = () => {
     const newMap: ItemsMap = new Map()
 
-    getOrderedItems(children).forEach(({ value, disabled, children }) => {
-      newMap.set(value, {
-        value,
-        disabled: !!disabled,
-        text: children,
-      })
+    getOrderedItems(children).forEach(itemData => {
+      newMap.set(itemData.value, itemData)
     })
 
     setComputedItems(newMap)

--- a/packages/components/dropdown/src/DropdownItem.tsx
+++ b/packages/components/dropdown/src/DropdownItem.tsx
@@ -1,15 +1,19 @@
 import { cx } from 'class-variance-authority'
+import { ReactNode } from 'react'
 
 import { useDropdown } from './DropdownContext'
-import { getIndexByKey } from './utils'
+import { DropdownItem } from './types'
+import { getIndexByKey, getItemText } from './utils'
 
 export interface ItemProps {
   disabled?: boolean
   value: string
-  children: string
+  children: ReactNode
+  className?: string
 }
 
 export const Item = ({
+  className,
   disabled = false,
   value,
   children, // TODO: allow more than string and implement Dropdown.ItemText
@@ -17,7 +21,7 @@ export const Item = ({
   const { computedItems, selectedItem, getItemProps, higlightedItem } = useDropdown()
 
   const index = getIndexByKey(computedItems, value)
-  const itemData = { disabled, value, text: children }
+  const itemData: DropdownItem = { disabled, value, text: getItemText(children) }
 
   return (
     <li
@@ -25,12 +29,13 @@ export const Item = ({
         higlightedItem?.value === value && 'bg-basic-container',
         selectedItem?.value === value && 'font-bold',
         disabled && 'opacity-dim-3',
-        'flex flex-col px-sm py-sm'
+        'flex px-sm py-sm',
+        className
       )}
       key={value}
       {...getItemProps({ item: itemData, index })}
     >
-      <span>{children}</span>
+      {children}
     </li>
   )
 }

--- a/packages/components/dropdown/src/DropdownItemText.tsx
+++ b/packages/components/dropdown/src/DropdownItemText.tsx
@@ -1,0 +1,12 @@
+import { cx } from 'class-variance-authority'
+
+export interface ItemProps {
+  children: string
+}
+
+export const ItemText = ({ children }: ItemProps) => {
+  return <span className={cx('inline')}>{children}</span>
+}
+
+ItemText.id = 'ItemText'
+ItemText.displayName = 'Dropdown.ItemText'

--- a/packages/components/dropdown/src/index.ts
+++ b/packages/components/dropdown/src/index.ts
@@ -4,6 +4,7 @@ import { Dropdown as Root, type DropdownProps } from './Dropdown'
 import { DropdownProvider, useDropdown } from './DropdownContext'
 import { Item } from './DropdownItem'
 import { Items } from './DropdownItems'
+import { ItemText } from './DropdownItemText'
 import { Trigger } from './DropdownTrigger'
 
 export { useDropdown, DropdownProvider }
@@ -12,13 +13,16 @@ export const Dropdown: FC<DropdownProps> & {
   Trigger: typeof Trigger
   Items: typeof Items
   Item: typeof Item
+  ItemText: typeof ItemText
 } = Object.assign(Root, {
   Trigger,
   Items,
   Item,
+  ItemText,
 })
 
 Dropdown.displayName = 'Dropdown'
 Trigger.displayName = 'Dropdown.Trigger'
 Items.displayName = 'Dropdown.Items'
 Item.displayName = 'Dropdown.Item'
+ItemText.displayName = 'Dropdown.ItemText'


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1670 

### Description, Motivation and Context

`downshift` need each item to have a raw string as a label for autocompletion/highlighting of items.

If `children` is a string
```
<Dropdown.Item value="book-9">Anna Karenina</Dropdown.Item>
```
=> Then downshift will use `children` as a value for autocompletion/highlighting.

But if `children` is custom markup, for example:
```
<Dropdown.Item value="book-10" className="gap-md">
    <Dropdown.ItemText>Crime and Punishment</Dropdown.ItemText>
    <Tag>New</Tag>
</Dropdown.Item>
```
=> Then we use `Dropdown.ItemText` to tell `downshift` "This is where the raw text value that you need is located".

### Types of changes


- [x] ✨ New feature (non-breaking change which adds functionality)

