### PR TITLE
fix(checkbox): apply proper color on checkbox ticks per intent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,6 +2402,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/checkbox/src/CheckboxIndicator.tsx
+++ b/packages/components/checkbox/src/CheckboxIndicator.tsx
@@ -10,7 +10,7 @@ export const CheckboxIndicator = forwardRef<HTMLSpanElement, CheckboxIndicatorPr
   (props, ref) => (
     <CheckboxIndicatorPrimitive
       ref={ref}
-      className="flex h-full w-full items-center justify-center text-surface"
+      className="flex h-full w-full items-center justify-center"
       {...props}
     />
   )

--- a/packages/components/checkbox/src/CheckboxInput.styles.ts
+++ b/packages/components/checkbox/src/CheckboxInput.styles.ts
@@ -19,46 +19,55 @@ export const checkboxInputStyles = cva(
         ['main', 'support', 'accent', 'basic', 'success', 'alert', 'error', 'info', 'neutral']
       >({
         main: [
+          'text-on-main',
           'spark-state-unchecked:border-outline',
           'spark-state-indeterminate:border-main spark-state-indeterminate:bg-main',
           'spark-state-checked:border-main spark-state-checked:bg-main',
         ],
         support: [
+          'text-on-support',
           'spark-state-unchecked:border-outline',
           'spark-state-indeterminate:border-support spark-state-indeterminate:bg-support',
           'spark-state-checked:border-support spark-state-checked:bg-support',
         ],
         accent: [
+          'text-on-accent',
           'spark-state-unchecked:border-outline',
           'spark-state-indeterminate:border-accent spark-state-indeterminate:bg-accent',
           'spark-state-checked:border-accent spark-state-checked:bg-accent',
         ],
         basic: [
+          'text-on-basic',
           'spark-state-unchecked:border-outline',
           'spark-state-indeterminate:border-basic spark-state-indeterminate:bg-basic',
           'spark-state-checked:border-basic spark-state-checked:bg-basic',
         ],
         success: [
+          'text-on-success',
           'spark-state-unchecked:border-success',
           'spark-state-indeterminate:border-success spark-state-indeterminate:bg-success',
           'spark-state-checked:border-success spark-state-checked:bg-success',
         ],
         alert: [
+          'text-on-alert',
           'spark-state-unchecked:border-alert',
           'spark-state-indeterminate:border-alert spark-state-indeterminate:bg-alert',
           'spark-state-checked:border-alert spark-state-checked:bg-alert',
         ],
         error: [
+          'text-on-error',
           'spark-state-unchecked:border-error',
           'spark-state-indeterminate:border-error spark-state-indeterminate:bg-error',
           'spark-state-checked:border-error spark-state-checked:bg-error',
         ],
         info: [
+          'text-on-info',
           'spark-state-unchecked:border-info',
           'spark-state-indeterminate:border-info spark-state-indeterminate:bg-info',
           'spark-state-checked:border-info spark-state-checked:bg-info',
         ],
         neutral: [
+          'text-on-neutral',
           'spark-state-unchecked:border-neutral',
           'spark-state-indeterminate:border-neutral spark-state-indeterminate:bg-neutral',
           'spark-state-checked:border-neutral spark-state-checked:bg-neutral',


### PR DESCRIPTION


<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1728 

### Description, Motivation and Context

`text-surface` was applied to the checked checkboxes icons for every intent.

Instead it should have been the `text-on-[INTENT]` for each intent. Otherwise contrast is not consistant on all themes.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

### Screenshots - Animations
![Capture d’écran 2023-12-07 à 09 47 39](https://github.com/adevinta/spark/assets/2033710/ba346c61-eb14-427a-bb17-62e98bcae7e2)

