### PR TITLE
feat(dropdown): enabled passing props to dropdown popover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,6 +2402,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -1,10 +1,15 @@
 import { Popover as SparkPopover } from '@spark-ui/popover'
 import { cx } from 'class-variance-authority'
-import { PropsWithChildren, useEffect } from 'react'
+import { ComponentProps, useEffect } from 'react'
 
 import { useDropdownContext } from './DropdownContext'
 
-export const Popover = ({ children }: PropsWithChildren) => {
+export const Popover = ({
+  children,
+  matchTriggerWidth = true,
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof SparkPopover.Content>) => {
   const { isOpen, hasPopover, setHasPopover } = useDropdownContext()
 
   useEffect(() => {
@@ -18,10 +23,11 @@ export const Popover = ({ children }: PropsWithChildren) => {
   return (
     <SparkPopover.Content
       inset
-      matchTriggerWidth
+      matchTriggerWidth={matchTriggerWidth}
       onOpenAutoFocus={e => e.preventDefault()}
       className={cx(!isOpen && 'hidden', '!z-dropdown')}
-      sideOffset={4}
+      sideOffset={sideOffset}
+      {...props}
     >
       {children}
     </SparkPopover.Content>


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1740 

### Description, Motivation and Context

Enabled popover props to work on the dropdown popover.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
