### PR TITLE
fix(switch): improved animation performance

### DIFF
--- a/packages/components/switch/src/SwitchInput.styles.ts
+++ b/packages/components/switch/src/SwitchInput.styles.ts
@@ -3,12 +3,12 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const styles = cva(
   tw([
-    'group relative inline-flex flex-shrink-0 items-center self-baseline',
+    'relative flex-shrink-0 self-baseline',
     'cursor-pointer',
     'rounded-full border-transparent',
     'hover:ring-4',
     'transition-colors duration-200 ease-in-out',
-    'spark-disabled:opacity-dim-3 disabled:hover:ring-transparent spark-disabled:cursor-not-allowed',
+    'disabled:hover:ring-transparent spark-disabled:cursor-not-allowed spark-disabled:opacity-dim-3',
     'focus-visible:outline-none focus-visible:u-ring',
     'spark-state-unchecked:bg-on-surface/dim-4',
     'u-shadow-border-transition',
@@ -49,13 +49,25 @@ export const styles = cva(
 
 export type StylesProps = VariantProps<typeof styles>
 
+export const thumbWrapperStyles = cva(
+  [
+    'pointer-events-none absolute inset-none flex items-center',
+    'transition-all duration-200 ease-in-out',
+  ],
+  {
+    variants: {
+      checked: {
+        true: 'translate-x-full',
+        false: 'translate-x-none',
+      },
+    },
+  }
+)
+
 export const thumbStyles = cva(
   [
-    'absolute flex items-center justify-center',
+    'absolute left-none top-none flex items-center justify-center',
     'bg-surface',
-    'group-spark-state-checked:left-full group-spark-state-checked:-translate-x-full',
-    'group-spark-state-unchecked:left-none group-spark-state-unchecked:translate-x-none',
-    'pointer-events-none',
     'rounded-full',
     'ring-0',
     'transition-all duration-200 ease-in-out',
@@ -67,7 +79,8 @@ export const thumbStyles = cva(
         md: ['h-sz-24', 'w-sz-24'],
       }),
       checked: {
-        false: 'text-on-surface/dim-4',
+        true: '-translate-x-full',
+        false: 'translate-x-none text-on-surface/dim-4',
       },
     },
     defaultVariants: {

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -6,7 +6,13 @@ import { Slot } from '@spark-ui/slot'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import React, { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from 'react'
 
-import { styles, type StylesProps, thumbCheckSVGStyles, thumbStyles } from './SwitchInput.styles'
+import {
+  styles,
+  type StylesProps,
+  thumbCheckSVGStyles,
+  thumbStyles,
+  thumbWrapperStyles,
+} from './SwitchInput.styles'
 
 export interface SwitchInputProps
   extends StylesProps,
@@ -92,14 +98,16 @@ export const SwitchInput = forwardRef<HTMLButtonElement, SwitchInputProps>(
         aria-describedby={description}
         {...rest}
       >
-        <SwitchPrimitive.Thumb className={thumbStyles({ size, checked: isChecked })}>
-          {isChecked && checkedIcon && (
-            <Slot className={thumbCheckSVGStyles({ size })}>{checkedIcon}</Slot>
-          )}
-          {!isChecked && uncheckedIcon && (
-            <Slot className={thumbCheckSVGStyles({ size })}>{uncheckedIcon}</Slot>
-          )}
-        </SwitchPrimitive.Thumb>
+        <span className={thumbWrapperStyles({ checked: isChecked })}>
+          <SwitchPrimitive.Thumb className={thumbStyles({ size, checked: isChecked })}>
+            {isChecked && checkedIcon && (
+              <Slot className={thumbCheckSVGStyles({ size })}>{checkedIcon}</Slot>
+            )}
+            {!isChecked && uncheckedIcon && (
+              <Slot className={thumbCheckSVGStyles({ size })}>{uncheckedIcon}</Slot>
+            )}
+          </SwitchPrimitive.Thumb>
+        </span>
       </SwitchPrimitive.Root>
     )
   }


### PR DESCRIPTION
### Description, Motivation and Context

To discuss. Some teams using our Switch component reported that it's toggle animation was lagging when clicking on it trigger heavy computation of their pages.

Heavy computation is an issue on their side, but it seems those styles help makes seems smoother (we tested it).

WDYT ? 

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

