### PR TITLE
feat(dropdown): dropdown states

### DIFF
--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -128,6 +128,8 @@ You can style this element directly, or you can use it as a wrapper to put an ic
 
 Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a status indicator will be displayed accordingly.
 
+You could also wrap `Dropdown` with a `FormField` and pass the prop to `Formfield` instead.
+
 <Canvas of={stories.Statuses} />
 
 ### Read only

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -124,15 +124,21 @@ You can style this element directly, or you can use it as a wrapper to put an ic
 
 <Canvas of={stories.ItemIndicator} />
 
+### States
+
+Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+
+<Canvas of={stories.States} />
+
+### Read only
+
+TODO
+
 ### Trigger leading icon
 
 Use `Dropdown.LeadingIcon` inside `Dropdown.Trigger` to prefix your trigger with an icon.
 
 <Canvas of={stories.LeadingIcon} />
-
-### Read only
-
-TODO
 
 ## Multiple selection
 

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -124,11 +124,11 @@ You can style this element directly, or you can use it as a wrapper to put an ic
 
 <Canvas of={stories.ItemIndicator} />
 
-### States
+### Status
 
-Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a status indicator will be displayed accordingly.
 
-<Canvas of={stories.States} />
+<Canvas of={stories.Statuses} />
 
 ### Read only
 

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -266,16 +266,16 @@ export const ItemIndicator: StoryFn = _args => {
   )
 }
 
-export const States: StoryFn = () => {
-  type State = ComponentProps<typeof Dropdown>['state']
+export const Statuses: StoryFn = () => {
+  type Status = ComponentProps<typeof Dropdown>['state']
 
-  const states: State[] = ['error', 'alert', 'success']
+  const statuses: Status[] = ['error', 'alert', 'success']
 
   return (
     <div className="flex flex-col gap-lg pb-[300px]">
-      {states.map(state => {
+      {statuses.map(status => {
         return (
-          <Dropdown state={state}>
+          <Dropdown state={status}>
             <Dropdown.Trigger aria-label="Book">
               <Dropdown.Value placeholder="Pick a book" />
             </Dropdown.Trigger>

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -4,7 +4,7 @@ import { FormField } from '@spark-ui/form-field'
 import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { Tag } from '@spark-ui/tag'
 import { Meta, StoryFn } from '@storybook/react'
-import { useState } from 'react'
+import { ComponentProps, useState } from 'react'
 
 import { Dropdown } from '.'
 
@@ -262,6 +262,37 @@ export const ItemIndicator: StoryFn = _args => {
           </Dropdown.Items>
         </Dropdown.Popover>
       </Dropdown>
+    </div>
+  )
+}
+
+export const States: StoryFn = () => {
+  type State = ComponentProps<typeof Dropdown>['state']
+
+  const states: State[] = ['error', 'alert', 'success']
+
+  return (
+    <div className="flex flex-col gap-lg pb-[300px]">
+      {states.map(state => {
+        return (
+          <Dropdown state={state}>
+            <Dropdown.Trigger aria-label="Book">
+              <Dropdown.Value placeholder="Pick a book" />
+            </Dropdown.Trigger>
+
+            <Dropdown.Popover>
+              <Dropdown.Items>
+                <Dropdown.Item value="book-1">To Kill a Mockingbird</Dropdown.Item>
+                <Dropdown.Item value="book-2">War and Peace</Dropdown.Item>
+                <Dropdown.Item value="book-3">The Idiot</Dropdown.Item>
+                <Dropdown.Item value="book-4">A Picture of Dorian Gray</Dropdown.Item>
+                <Dropdown.Item value="book-5">1984</Dropdown.Item>
+                <Dropdown.Item value="book-6">Pride and Prejudice</Dropdown.Item>
+              </Dropdown.Items>
+            </Dropdown.Popover>
+          </Dropdown>
+        )
+      })}
     </div>
   )
 }

--- a/packages/components/dropdown/src/Dropdown.test.tsx
+++ b/packages/components/dropdown/src/Dropdown.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { FormField } from '@spark-ui/form-field'
 import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -293,6 +294,33 @@ describe('Dropdown', () => {
 
       // Then placeholder text should be updated
       expect(getTrigger('Book')).toHaveTextContent(updatedSelectedItemText)
+    })
+  })
+
+  describe('statuses (combined with FormField', () => {
+    it('should render error message when field is in error', () => {
+      render(
+        <FormField state="error">
+          <FormField.Label>Book</FormField.Label>
+          <Dropdown>
+            <Dropdown.Trigger>
+              <Dropdown.Value placeholder="Pick a book" />
+            </Dropdown.Trigger>
+            <Dropdown.Popover>
+              <Dropdown.Items>
+                <Dropdown.Item value="book-1">War and Peace</Dropdown.Item>
+                <Dropdown.Item value="book-2">1984</Dropdown.Item>
+                <Dropdown.Item value="book-3">Pride and Prejudice</Dropdown.Item>
+              </Dropdown.Items>
+            </Dropdown.Popover>
+          </Dropdown>
+          <FormField.ErrorMessage>You forgot to select a book</FormField.ErrorMessage>
+        </FormField>
+      )
+
+      expect(getTrigger('Book')).toBeInTheDocument()
+
+      expect(screen.getByText('You forgot to select a book')).toBeInTheDocument()
     })
   })
 

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -22,6 +22,8 @@ export interface DropdownContextState extends DownshiftState {
   setHasPopover: Dispatch<SetStateAction<boolean>>
   multiple: boolean
   state?: 'error' | 'alert' | 'success'
+  lastInteractionType: 'mouse' | 'keyboard'
+  setLastInteractionType: (type: 'mouse' | 'keyboard') => void
 }
 
 export type DropdownContextCommonProps = PropsWithChildren<{
@@ -101,6 +103,7 @@ export const DropdownProvider = ({
 }: DropdownContextProps) => {
   const [itemsMap, setItemsMap] = useState<ItemsMap>(getItemsFromChildren(children))
   const [hasPopover, setHasPopover] = useState<boolean>(false)
+  const [lastInteractionType, setLastInteractionType] = useState<'mouse' | 'keyboard'>('mouse')
 
   const field = useFormFieldControl()
   const items = [...itemsMap.values()]
@@ -233,6 +236,8 @@ export const DropdownProvider = ({
         hasPopover,
         setHasPopover,
         state,
+        lastInteractionType,
+        setLastInteractionType,
       }}
     >
       <WrapperComponent {...wrapperProps}>{children}</WrapperComponent>

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -21,6 +21,7 @@ export interface DropdownContextState extends DownshiftState {
   hasPopover: boolean
   setHasPopover: Dispatch<SetStateAction<boolean>>
   multiple: boolean
+  state?: 'error' | 'alert' | 'success'
 }
 
 export type DropdownContextCommonProps = PropsWithChildren<{
@@ -36,6 +37,10 @@ export type DropdownContextCommonProps = PropsWithChildren<{
    * The open state of the select when it is initially rendered. Use when you do not need to control its open state.
    */
   defaultOpen?: boolean
+  /**
+   * Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+   */
+  state?: 'error' | 'alert' | 'success'
 }>
 
 interface DropdownPropsSingle {
@@ -92,6 +97,7 @@ export const DropdownProvider = ({
   onOpenChange,
   defaultOpen,
   multiple = false,
+  state,
 }: DropdownContextProps) => {
   const [itemsMap, setItemsMap] = useState<ItemsMap>(getItemsFromChildren(children))
   const [hasPopover, setHasPopover] = useState<boolean>(false)
@@ -226,6 +232,7 @@ export const DropdownProvider = ({
         highlightedItem: getElementByIndex(itemsMap, downshift.highlightedIndex),
         hasPopover,
         setHasPopover,
+        state,
       }}
     >
       <WrapperComponent {...wrapperProps}>{children}</WrapperComponent>

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -99,13 +99,14 @@ export const DropdownProvider = ({
   onOpenChange,
   defaultOpen,
   multiple = false,
-  state,
+  state: stateProp,
 }: DropdownContextProps) => {
   const [itemsMap, setItemsMap] = useState<ItemsMap>(getItemsFromChildren(children))
   const [hasPopover, setHasPopover] = useState<boolean>(false)
   const [lastInteractionType, setLastInteractionType] = useState<'mouse' | 'keyboard'>('mouse')
 
   const field = useFormFieldControl()
+  const state = field.state || stateProp
   const items = [...itemsMap.values()]
 
   const id = useId(field.id)

--- a/packages/components/dropdown/src/DropdownItem.tsx
+++ b/packages/components/dropdown/src/DropdownItem.tsx
@@ -22,14 +22,16 @@ export const Item = ({ children, ...props }: ItemProps) => {
 }
 
 const ItemContent = ({ className, disabled = false, value, children }: ItemProps) => {
-  const { getItemProps, highlightedItem } = useDropdownContext()
+  const { getItemProps, highlightedItem, lastInteractionType } = useDropdownContext()
 
   const { textId, index, itemData, isSelected } = useDropdownItemContext()
+
+  const isHighlighted = highlightedItem?.value === value
 
   return (
     <li
       className={cx(
-        highlightedItem?.value === value && 'bg-surface-hovered',
+        isHighlighted && (lastInteractionType === 'mouse' ? 'bg-surface-hovered' : 'u-ring'),
         isSelected && 'font-bold',
         disabled && 'opacity-dim-3',
         'px-lg py-md text-body-1',

--- a/packages/components/dropdown/src/DropdownItems.tsx
+++ b/packages/components/dropdown/src/DropdownItems.tsx
@@ -8,11 +8,15 @@ interface ItemsProps {
 }
 
 export const Items = ({ children }: ItemsProps) => {
-  const { isOpen, getMenuProps, hasPopover } = useDropdownContext()
+  const { isOpen, getMenuProps, hasPopover, setLastInteractionType } = useDropdownContext()
 
   return (
     <ul
-      {...getMenuProps()}
+      {...getMenuProps({
+        onMouseMove: () => {
+          setLastInteractionType('mouse')
+        },
+      })}
       className={cx(
         'flex  flex-col',
         isOpen ? 'block' : 'pointer-events-none opacity-0',

--- a/packages/components/dropdown/src/DropdownStateIndicator.tsx
+++ b/packages/components/dropdown/src/DropdownStateIndicator.tsx
@@ -1,0 +1,28 @@
+import { Icon } from '@spark-ui/icon'
+import { AlertOutline } from '@spark-ui/icons/dist/icons/AlertOutline'
+import { Check } from '@spark-ui/icons/dist/icons/Check'
+import { WarningOutline } from '@spark-ui/icons/dist/icons/WarningOutline'
+import { cx } from 'class-variance-authority'
+
+import { useDropdownContext } from './DropdownContext'
+
+const icons = {
+  error: <AlertOutline />,
+  alert: <WarningOutline />,
+  success: <Check />,
+}
+
+export const DropdownStateIndicator = () => {
+  const { state } = useDropdownContext()
+
+  if (!state) return null
+
+  return (
+    <Icon intent={state} className={cx('pointer-events-none text-body-1')}>
+      {icons[state]}
+    </Icon>
+  )
+}
+
+DropdownStateIndicator.id = 'StateIndicator'
+DropdownStateIndicator.displayName = 'Dropdown.StateIndicator'

--- a/packages/components/dropdown/src/DropdownTrigger.tsx
+++ b/packages/components/dropdown/src/DropdownTrigger.tsx
@@ -34,8 +34,14 @@ const styles = cva(
 )
 
 export const Trigger = ({ 'aria-label': ariaLabel, children, className }: TriggerProps) => {
-  const { getToggleButtonProps, getDropdownProps, getLabelProps, hasPopover, state } =
-    useDropdownContext()
+  const {
+    getToggleButtonProps,
+    getDropdownProps,
+    getLabelProps,
+    hasPopover,
+    state,
+    setLastInteractionType,
+  } = useDropdownContext()
 
   const [WrapperComponent, wrapperProps] = hasPopover
     ? [Popover.Trigger, { asChild: true }]
@@ -52,7 +58,12 @@ export const Trigger = ({ 'aria-label': ariaLabel, children, className }: Trigge
         <button
           type="button"
           className={styles({ className, state })}
-          {...getToggleButtonProps(getDropdownProps())}
+          {...getToggleButtonProps({
+            ...getDropdownProps(),
+            onKeyDown: () => {
+              setLastInteractionType('keyboard')
+            },
+          })}
         >
           <span className="flex items-center justify-start gap-md">{children}</span>
 

--- a/packages/components/dropdown/src/DropdownTrigger.tsx
+++ b/packages/components/dropdown/src/DropdownTrigger.tsx
@@ -2,10 +2,11 @@ import { Icon } from '@spark-ui/icon'
 import { ArrowHorizontalDown } from '@spark-ui/icons/dist/icons/ArrowHorizontalDown'
 import { Popover } from '@spark-ui/popover'
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
-import { cx } from 'class-variance-authority'
+import { cva } from 'class-variance-authority'
 import { Fragment, ReactNode } from 'react'
 
 import { useDropdownContext } from './DropdownContext'
+import { DropdownStateIndicator } from './DropdownStateIndicator'
 
 interface TriggerProps {
   'aria-label'?: string
@@ -13,8 +14,28 @@ interface TriggerProps {
   className?: string
 }
 
+const styles = cva(
+  [
+    'flex w-full cursor-pointer items-center justify-between',
+    'min-h-sz-44 rounded-lg bg-surface px-lg',
+    // outline styles
+    'ring-1 outline-none ring-inset focus:ring-2',
+  ],
+  {
+    variants: {
+      state: {
+        undefined: 'ring-outline focus:ring-outline-high hover:ring-outline-high',
+        error: 'ring-error',
+        alert: 'ring-alert',
+        success: 'ring-success',
+      },
+    },
+  }
+)
+
 export const Trigger = ({ 'aria-label': ariaLabel, children, className }: TriggerProps) => {
-  const { getToggleButtonProps, getDropdownProps, getLabelProps, hasPopover } = useDropdownContext()
+  const { getToggleButtonProps, getDropdownProps, getLabelProps, hasPopover, state } =
+    useDropdownContext()
 
   const [WrapperComponent, wrapperProps] = hasPopover
     ? [Popover.Trigger, { asChild: true }]
@@ -30,18 +51,17 @@ export const Trigger = ({ 'aria-label': ariaLabel, children, className }: Trigge
       <WrapperComponent {...wrapperProps}>
         <button
           type="button"
-          className={cx(
-            'flex w-full cursor-pointer items-center justify-between',
-            'min-h-sz-44 rounded-lg border-sm border-outline bg-surface px-lg',
-            className
-          )}
+          className={styles({ className, state })}
           {...getToggleButtonProps(getDropdownProps())}
         >
           <span className="flex items-center justify-start gap-md">{children}</span>
 
-          <Icon className="ml-md shrink-0" size="sm">
-            <ArrowHorizontalDown />
-          </Icon>
+          <div className="ml-md flex gap-lg">
+            <DropdownStateIndicator />
+            <Icon className="shrink-0" size="sm">
+              <ArrowHorizontalDown />
+            </Icon>
+          </div>
         </button>
       </WrapperComponent>
     </>


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1752 

### Description, Motivation and Context

Implementing states for dropdown trigger:
- error, alert and success states.
- a state indicator is displayed (icon) for colorblind people who can't see the outline color.
- Focus styles have been updated to match the Figma specs

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 💄 Styles


![Capture d’écran 2023-12-14 à 17 42 19](https://github.com/adevinta/spark/assets/2033710/dda6f945-4710-4e1b-890c-df54abda3827)
