### PR TITLE
feat(popover): dynamic height management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2384,6 +2384,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/DropdownItems.tsx
+++ b/packages/components/dropdown/src/DropdownItems.tsx
@@ -1,32 +1,37 @@
 import { cx } from 'class-variance-authority'
-import { ReactNode } from 'react'
+import React, { ReactNode } from 'react'
 
 import { useDropdownContext } from './DropdownContext'
 
 interface ItemsProps {
   children: ReactNode
+  className?: string
 }
 
-export const Items = ({ children }: ItemsProps) => {
+export const Items = React.forwardRef(({ children, className, ...props }: ItemsProps, ref) => {
   const { isOpen, getMenuProps, hasPopover, setLastInteractionType } = useDropdownContext()
+
+  const downshiftProps = getMenuProps({
+    onMouseMove: () => {
+      setLastInteractionType('mouse')
+    },
+  })
 
   return (
     <ul
-      {...getMenuProps({
-        onMouseMove: () => {
-          setLastInteractionType('mouse')
-        },
-      })}
+      ref={ref}
       className={cx(
-        'flex  flex-col',
+        className,
+        'flex flex-col',
         isOpen ? 'block' : 'pointer-events-none opacity-0',
-        hasPopover ? 'max-h-sz-320 overflow-y-auto p-lg' : ''
+        hasPopover && 'p-lg'
       )}
+      {...props}
+      {...downshiftProps}
     >
       {children}
     </ul>
   )
-}
+})
 
-Items.id = 'Items'
 Items.displayName = 'Dropdown.Items'

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -23,8 +23,8 @@ export const Popover = ({
   return (
     <SparkPopover.Content
       inset
+      asChild
       matchTriggerWidth={matchTriggerWidth}
-      onOpenAutoFocus={e => e.preventDefault()}
       className={cx(!isOpen && 'hidden', '!z-dropdown')}
       sideOffset={sideOffset}
       {...props}

--- a/packages/components/dropdown/src/DropdownTrigger.tsx
+++ b/packages/components/dropdown/src/DropdownTrigger.tsx
@@ -17,7 +17,7 @@ interface TriggerProps {
 const styles = cva(
   [
     'flex w-full cursor-pointer items-center justify-between',
-    'min-h-sz-44 rounded-lg bg-surface px-lg',
+    'min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg',
     // outline styles
     'ring-1 outline-none ring-inset focus:ring-2',
   ],

--- a/packages/components/popover/src/Popover.doc.mdx
+++ b/packages/components/popover/src/Popover.doc.mdx
@@ -113,8 +113,6 @@ When using `Popover.Anchor`, you can have multiple `Popover.Trigger` to trigger 
 You can restrict the popover to stay inside a container (ref).
 In this example, the Popover remains inside the grey container.
 
-**Please note that it applies only to the width of the popover, to prevent the popover content from overflowing.**
-
 <Canvas of={stories.Boundaries} />
 
 ### Match trigger width

--- a/packages/components/popover/src/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent.styles.ts
@@ -7,6 +7,7 @@ export const styles = cva(
     'bg-surface text-on-surface',
     'shadow',
     'focus-visible:outline-none focus-visible:u-ring',
+    'max-h-[--radix-popper-available-height] overflow-y-auto',
   ],
   {
     variants: {


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1771 

Dynamic height resizing on Popover.

It allows `Dropdown.Popover` to optimize height dynamically and display as many items as possible.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧠 Refactor
- [x] 💄 Styles



https://github.com/adevinta/spark/assets/2033710/50491560-d2b8-4e86-b847-833ed44ad920


