### PR TITLE
fix(dropdown): z-index and focus behaviour issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -247,7 +247,3 @@ Apply `readOnly` to the wrapping `FormField` to indicate the dropdown is only re
 Set the `state` prop of the `FormField` to `error` to indicate that the dropdown is invalid. Optionally use the `FormField.ErrorMessage` to describe why the dropdown is invalid.
 
 <Canvas of={stories.FormFieldValidation} />
-
-## Inside dialog
-
-<Canvas of={stories.InsideDialog} />

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -247,3 +247,7 @@ Apply `readOnly` to the wrapping `FormField` to indicate the dropdown is only re
 Set the `state` prop of the `FormField` to `error` to indicate that the dropdown is invalid. Optionally use the `FormField.ErrorMessage` to describe why the dropdown is invalid.
 
 <Canvas of={stories.FormFieldValidation} />
+
+## Inside dialog
+
+<Canvas of={stories.InsideDialog} />

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines */
 import { Button } from '@spark-ui/button'
-import { Dialog } from '@spark-ui/dialog'
 import { FormField } from '@spark-ui/form-field'
-// import { Popover } from '@spark-ui/popover'
 import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { Tag } from '@spark-ui/tag'
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
@@ -554,64 +552,5 @@ export const FormFieldValidation: StoryFn = () => {
         <FormField.ErrorMessage>The field is invalid</FormField.ErrorMessage>
       </FormField>
     </div>
-  )
-}
-
-export const InsideDialog: StoryFn = () => {
-  return (
-    <Dialog>
-      <Dialog.Trigger asChild>
-        <Button>Edit profile</Button>
-      </Dialog.Trigger>
-
-      <Dialog.Portal>
-        <Dialog.Overlay />
-
-        <Dialog.Content>
-          <Dialog.Header>
-            <Dialog.Title>Edit profile</Dialog.Title>
-          </Dialog.Header>
-
-          <Dialog.Body>
-            <Dialog.Description>
-              Make changes to your profile here. Click save when you are done.
-            </Dialog.Description>
-
-            <p>Lorem ipsum dolor sit amet</p>
-            <div>
-              <Dropdown>
-                <Dropdown.Trigger>
-                  <Dropdown.Value placeholder="Pick a state" />
-                </Dropdown.Trigger>
-                <Dropdown.Popover>
-                  <Dropdown.Items>
-                    <Dropdown.Item value="default">default</Dropdown.Item>
-                    <Dropdown.Item value="success">success</Dropdown.Item>
-                    <Dropdown.Item value="alert">alert</Dropdown.Item>
-                    <Dropdown.Item value="error">error</Dropdown.Item>
-                  </Dropdown.Items>
-                </Dropdown.Popover>
-              </Dropdown>
-            </div>
-            <p>toto</p>
-
-            {/* <Popover>
-              <Popover.Trigger asChild>
-                <Button>click me</Button>
-              </Popover.Trigger>
-              <Popover.Content>HEY</Popover.Content>
-            </Popover> */}
-          </Dialog.Body>
-
-          <Dialog.Footer className="flex justify-end gap-md">
-            <Dialog.Close asChild>
-              <Button>Close</Button>
-            </Dialog.Close>
-          </Dialog.Footer>
-
-          <Dialog.CloseButton aria-label="Close edit profile" />
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog>
   )
 }

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable max-lines */
 import { Button } from '@spark-ui/button'
+import { Dialog } from '@spark-ui/dialog'
 import { FormField } from '@spark-ui/form-field'
+// import { Popover } from '@spark-ui/popover'
 import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { Tag } from '@spark-ui/tag'
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
@@ -519,6 +521,7 @@ export const FormFieldRequired: StoryFn = _args => {
     </div>
   )
 }
+
 export const FormFieldValidation: StoryFn = () => {
   const [state, setState] = useState<undefined | 'success' | 'alert' | 'error'>('error')
 
@@ -532,7 +535,7 @@ export const FormFieldValidation: StoryFn = () => {
           }}
         >
           <Dropdown.Trigger>
-            <Dropdown.Value placeholder="Pick an state" />
+            <Dropdown.Value placeholder="Pick a state" />
           </Dropdown.Trigger>
           <Dropdown.Popover>
             <Dropdown.Items>
@@ -551,5 +554,64 @@ export const FormFieldValidation: StoryFn = () => {
         <FormField.ErrorMessage>The field is invalid</FormField.ErrorMessage>
       </FormField>
     </div>
+  )
+}
+
+export const InsideDialog: StoryFn = () => {
+  return (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button>Edit profile</Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay />
+
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Edit profile</Dialog.Title>
+          </Dialog.Header>
+
+          <Dialog.Body>
+            <Dialog.Description>
+              Make changes to your profile here. Click save when you are done.
+            </Dialog.Description>
+
+            <p>Lorem ipsum dolor sit amet</p>
+            <div>
+              <Dropdown>
+                <Dropdown.Trigger>
+                  <Dropdown.Value placeholder="Pick a state" />
+                </Dropdown.Trigger>
+                <Dropdown.Popover>
+                  <Dropdown.Items>
+                    <Dropdown.Item value="default">default</Dropdown.Item>
+                    <Dropdown.Item value="success">success</Dropdown.Item>
+                    <Dropdown.Item value="alert">alert</Dropdown.Item>
+                    <Dropdown.Item value="error">error</Dropdown.Item>
+                  </Dropdown.Items>
+                </Dropdown.Popover>
+              </Dropdown>
+            </div>
+            <p>toto</p>
+
+            {/* <Popover>
+              <Popover.Trigger asChild>
+                <Button>click me</Button>
+              </Popover.Trigger>
+              <Popover.Content>HEY</Popover.Content>
+            </Popover> */}
+          </Dialog.Body>
+
+          <Dialog.Footer className="flex justify-end gap-md">
+            <Dialog.Close asChild>
+              <Button>Close</Button>
+            </Dialog.Close>
+          </Dialog.Footer>
+
+          <Dialog.CloseButton aria-label="Close edit profile" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
   )
 }

--- a/packages/components/dropdown/src/Dropdown.test.tsx
+++ b/packages/components/dropdown/src/Dropdown.test.tsx
@@ -90,6 +90,41 @@ describe('Dropdown', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
     })
 
+    it('should open/close the items list when interacting with its trigger (no popover)', async () => {
+      const user = userEvent.setup()
+
+      // Given a close dropdown without a popover(default state)
+      render(
+        <Dropdown>
+          <Dropdown.Trigger aria-label="Book">
+            <Dropdown.Value placeholder="Pick a book" />
+          </Dropdown.Trigger>
+
+          <Dropdown.Items>
+            <Dropdown.Item value="book-1">War and Peace</Dropdown.Item>
+            <Dropdown.Item value="book-2">1984</Dropdown.Item>
+            <Dropdown.Item value="book-3">Pride and Prejudice</Dropdown.Item>
+          </Dropdown.Items>
+        </Dropdown>
+      )
+
+      const trigger = getTrigger('Book')
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+      // When the user interact with the trigger
+      await user.click(trigger)
+
+      // Then the dropdown has expanded
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+      // When the user interact with the trigger while expanded
+      await user.click(trigger)
+
+      // Then the dropdown is closed again
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
     it('should remain forced opened', async () => {
       const user = userEvent.setup()
 

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -14,7 +14,7 @@ import {
 
 import { type DownshiftState, type DropdownItem, type ItemsMap } from './types'
 import { useDropdown } from './useDropdown'
-import { getElementByIndex, getItemsFromChildren } from './utils'
+import { getElementByIndex, getItemsFromChildren, hasChildComponent } from './utils'
 
 export interface DropdownContextState extends DownshiftState {
   itemsMap: ItemsMap
@@ -113,7 +113,9 @@ export const DropdownProvider = ({
   state: stateProp,
 }: DropdownContextProps) => {
   const [itemsMap, setItemsMap] = useState<ItemsMap>(getItemsFromChildren(children))
-  const [hasPopover, setHasPopover] = useState<boolean>(false)
+  const [hasPopover, setHasPopover] = useState<boolean>(
+    hasChildComponent(children, 'Dropdown.Popover')
+  )
   const [lastInteractionType, setLastInteractionType] = useState<'mouse' | 'keyboard'>('mouse')
 
   const field = useFormFieldControl()

--- a/packages/components/dropdown/src/DropdownItem.tsx
+++ b/packages/components/dropdown/src/DropdownItem.tsx
@@ -1,10 +1,11 @@
+import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cva, cx } from 'class-variance-authority'
-import { forwardRef, ReactNode, type Ref } from 'react'
+import { forwardRef, HTMLAttributes, ReactNode, type Ref } from 'react'
 
 import { useDropdownContext } from './DropdownContext'
 import { DropdownItemProvider, useDropdownItemContext } from './DropdownItemContext'
 
-export interface ItemProps {
+export interface ItemProps extends HTMLAttributes<HTMLLIElement> {
   disabled?: boolean
   value: string
   children: ReactNode
@@ -62,14 +63,16 @@ const ItemContent = forwardRef(
     forwardedRef: Ref<HTMLLIElement>
   ) => {
     const { getItemProps, highlightedItem, lastInteractionType } = useDropdownContext()
-
     const { textId, index, itemData, isSelected } = useDropdownItemContext()
 
     const isHighlighted = highlightedItem?.value === value
 
+    const { ref: downshiftRef, ...downshiftItemProps } = getItemProps({ item: itemData, index })
+    const ref = useMergeRefs(forwardedRef, downshiftRef)
+
     return (
       <li
-        ref={forwardedRef}
+        ref={ref}
         className={cx(
           styles({
             selected: isSelected,
@@ -80,7 +83,7 @@ const ItemContent = forwardRef(
           })
         )}
         key={value}
-        {...getItemProps({ item: itemData, index })}
+        {...downshiftItemProps}
         aria-selected={isSelected}
         aria-labelledby={textId}
       >

--- a/packages/components/dropdown/src/DropdownItem.tsx
+++ b/packages/components/dropdown/src/DropdownItem.tsx
@@ -1,6 +1,6 @@
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cva, cx } from 'class-variance-authority'
-import { forwardRef, HTMLAttributes, ReactNode, type Ref } from 'react'
+import { forwardRef, type HTMLAttributes, type ReactNode, type Ref } from 'react'
 
 import { useDropdownContext } from './DropdownContext'
 import { DropdownItemProvider, useDropdownItemContext } from './DropdownItemContext'

--- a/packages/components/dropdown/src/DropdownItems.tsx
+++ b/packages/components/dropdown/src/DropdownItems.tsx
@@ -1,3 +1,4 @@
+import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
 import { forwardRef, ReactNode, type Ref } from 'react'
 
@@ -12,15 +13,17 @@ export const Items = forwardRef(
   ({ children, className, ...props }: ItemsProps, forwardedRef: Ref<HTMLUListElement>) => {
     const { isOpen, getMenuProps, hasPopover, setLastInteractionType } = useDropdownContext()
 
-    const downshiftProps = getMenuProps({
+    const { ref: downshiftRef, ...downshiftMenuProps } = getMenuProps({
       onMouseMove: () => {
         setLastInteractionType('mouse')
       },
     })
 
+    const ref = useMergeRefs(forwardedRef, downshiftRef)
+
     return (
       <ul
-        ref={forwardedRef}
+        ref={ref}
         className={cx(
           className,
           'flex flex-col',
@@ -28,7 +31,7 @@ export const Items = forwardRef(
           hasPopover && 'p-lg'
         )}
         {...props}
-        {...downshiftProps}
+        {...downshiftMenuProps}
         data-spark-component="dropdown-items"
       >
         {children}

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -10,11 +10,12 @@ export const Popover = forwardRef(
       children,
       matchTriggerWidth = true,
       sideOffset = 4,
+      className,
       ...props
     }: ComponentProps<typeof SparkPopover.Content>,
     forwardedRef: Ref<HTMLDivElement>
   ) => {
-    const { isOpen, hasPopover, setHasPopover } = useDropdownContext()
+    const { isOpen, setHasPopover } = useDropdownContext()
 
     useEffect(() => {
       setHasPopover(true)
@@ -22,15 +23,13 @@ export const Popover = forwardRef(
       return () => setHasPopover(false)
     }, [])
 
-    if (!hasPopover) return children
-
     return (
       <SparkPopover.Content
         ref={forwardedRef}
         inset
         asChild
         matchTriggerWidth={matchTriggerWidth}
-        className={cx(!isOpen && 'hidden', '!z-dropdown')}
+        className={cx('!z-dropdown', !isOpen && 'hidden', className)}
         sideOffset={sideOffset}
         {...props}
         data-spark-component="dropdown-popover"

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -20,7 +20,7 @@ export const Popover = forwardRef(
       setHasPopover(true)
 
       return () => setHasPopover(false)
-    }, [setHasPopover])
+    }, [])
 
     if (!hasPopover) return children
 

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -31,6 +31,13 @@ export const Popover = forwardRef(
         matchTriggerWidth={matchTriggerWidth}
         className={cx('!z-dropdown', !isOpen && 'hidden', className)}
         sideOffset={sideOffset}
+        onOpenAutoFocus={e => {
+          /**
+           * With a combobox pattern, the focus should remain on the trigger at all times.
+           * Passing the focus to the dropdown popover would break keyboard navigation.
+           */
+          e.preventDefault()
+        }}
         {...props}
         data-spark-component="dropdown-popover"
       >

--- a/packages/components/dropdown/src/DropdownTrigger.tsx
+++ b/packages/components/dropdown/src/DropdownTrigger.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@spark-ui/icon'
 import { ArrowHorizontalDown } from '@spark-ui/icons/dist/icons/ArrowHorizontalDown'
 import { Popover } from '@spark-ui/popover'
+import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { VisuallyHidden } from '@spark-ui/visually-hidden'
 import { forwardRef, Fragment, ReactNode, type Ref } from 'react'
 
@@ -34,6 +35,15 @@ export const Trigger = forwardRef(
       ? [Popover.Trigger, { asChild: true }]
       : [Fragment, {}]
 
+    const { ref: downshiftRef, ...downshiftTriggerProps } = getToggleButtonProps({
+      ...getDropdownProps(),
+      onKeyDown: () => {
+        setLastInteractionType('keyboard')
+      },
+    })
+
+    const ref = useMergeRefs(forwardedRef, downshiftRef)
+
     return (
       <>
         {ariaLabel && (
@@ -44,15 +54,10 @@ export const Trigger = forwardRef(
         <WrapperComponent {...wrapperProps}>
           <button
             type="button"
-            ref={forwardedRef}
+            ref={ref}
             disabled={disabled || readOnly}
             className={styles({ className, state, disabled, readOnly })}
-            {...getToggleButtonProps({
-              ...getDropdownProps(),
-              onKeyDown: () => {
-                setLastInteractionType('keyboard')
-              },
-            })}
+            {...downshiftTriggerProps}
             data-spark-component="dropdown-trigger"
           >
             <span className="flex items-center justify-start gap-md">{children}</span>

--- a/packages/components/dropdown/src/useDropdown.ts
+++ b/packages/components/dropdown/src/useDropdown.ts
@@ -91,7 +91,7 @@ export const useDropdown = ({
     id,
     labelId,
     // Controlled open state
-    isOpen: open,
+    isOpen: open, // undefined must be passed for stateful behaviour (uncontrolled)
     onIsOpenChange: ({ isOpen }) => {
       if (isOpen != null) onOpenChange?.(isOpen)
     },

--- a/packages/components/dropdown/src/utils.ts
+++ b/packages/components/dropdown/src/utils.ts
@@ -93,3 +93,17 @@ export const getItemsFromChildren = (children: ReactNode): ItemsMap => {
 
   return newMap
 }
+
+export const hasChildComponent = (children: ReactNode, displayName: string): boolean => {
+  return React.Children.toArray(children).some(child => {
+    if (!isValidElement(child)) return false
+
+    if (getElementDisplayName(child) === displayName) {
+      return true
+    } else if (child.props.children) {
+      return hasChildComponent(child.props.children, displayName)
+    }
+
+    return false
+  })
+}

--- a/packages/components/popover/src/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent.styles.ts
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 export const styles = cva(
   [
-    'z-popover',
+    'relative z-popover',
     'rounded-md',
     'bg-surface text-on-surface',
     'shadow',

--- a/packages/components/select/src/Select.doc.mdx
+++ b/packages/components/select/src/Select.doc.mdx
@@ -19,13 +19,13 @@ Displays a **closed** list of options for the user to pick triggered by a button
 ## Install
 
 ```sh
-npm install @spark-ui/Select
+npm install @spark-ui/select
 ```
 
 ## Import
 
 ```tsx
-import { Select } from '@spark-ui/Select'
+import { Select } from '@spark-ui/select'
 ```
 
 ## Props


### PR DESCRIPTION
### Description, Motivation and Context

1. fixed bug related to z-index inside popover. Downshift refs should always be merged with our forwarded refs.
2. fixed bug related to focus forwarding. When Dropdown was used inside a Dialog, it was breaking `onOpenAutoFocus` behaviour.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
