### PR TITLE
fix(drawer): fix vh issue on drawer

### DIFF
--- a/packages/components/drawer/src/DrawerContent.styles.tsx
+++ b/packages/components/drawer/src/DrawerContent.styles.tsx
@@ -15,29 +15,23 @@ export const drawerContentStyles = cva(
       },
       side: {
         right: [
-          'top-none',
-          'right-none',
-          'h-screen',
+          'inset-y-none right-none',
           'data-[state=open]:animate-slide-in-right',
           'data-[state=closed]:animate-slide-out-right',
         ],
         left: [
-          'top-none',
-          'left-none',
-          'h-screen',
+          'inset-y-none left-none',
           'data-[state=open]:animate-slide-in-left',
           'data-[state=closed]:animate-slide-out-left',
         ],
         top: [
-          'top-none',
-          'left-none',
+          'top-none left-none',
           'w-screen',
           'data-[state=open]:animate-slide-in-top',
           'data-[state=closed]:animate-slide-out-top',
         ],
         bottom: [
-          'bottom-none',
-          'left-none',
+          'bottom-none left-none',
           'w-screen',
           'data-[state=open]:animate-slide-in-bottom',
           'data-[state=closed]:animate-slide-out-bottom',


### PR DESCRIPTION
**TASK**: #1840 

### Description, Motivation and Context
On Android and iOS, Drawer had some issues due to `vh` usage. So we replace it with classic top/bottom positionning.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
**BEFORE/AFTER:**
<img src="https://github.com/adevinta/spark/assets/66770550/8a7ceb37-30c8-4c91-8fe6-a51ead97d606" width="300" height="auto" /> <img src="https://github.com/adevinta/spark/assets/66770550/abb7156c-8dab-48ef-88d9-6bec8d13ff61" width="300" height="auto" />