### PR TITLE
fix(dropdown): fixed missing ItemIndicator on Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/DropdownItemIndicator.tsx
+++ b/packages/components/dropdown/src/DropdownItemIndicator.tsx
@@ -1,8 +1,8 @@
+import { Icon } from '@spark-ui/icon'
 import { Check } from '@spark-ui/icons/dist/icons/Check'
 import { cx } from 'class-variance-authority'
 import { forwardRef, ReactNode, type Ref } from 'react'
 
-import { useDropdownContext } from './DropdownContext'
 import { useDropdownItemContext } from './DropdownItemContext'
 
 export interface ItemIndicatorProps {
@@ -14,9 +14,12 @@ export interface ItemIndicatorProps {
 export const ItemIndicator = forwardRef(
   ({ className, children, label }: ItemIndicatorProps, forwardedRef: Ref<HTMLSpanElement>) => {
     const { disabled, isSelected } = useDropdownItemContext()
-    const { multiple } = useDropdownContext()
-    const childElement =
-      children || (multiple ? <Check aria-label={label} /> : <span aria-label={label}>✓</span>)
+
+    const childElement = children || (
+      <Icon size="sm">
+        <Check aria-label={label} />
+      </Icon>
+    )
 
     return (
       <span


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #1844 

### Description, Motivation and Context

During testing session, we found out that ItemIndicator icon was invisible on safari only.

We forgot to wrap the Check icon with `@spark-ui/icon`. I don't know why it was only broken on Safari, but it fixes the bug.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)


### Screenshots - Animations

<img width="1089" alt="Capture d’écran 2024-01-25 à 16 12 56" src="https://github.com/adevinta/spark/assets/2033710/32e919d9-2c5d-4967-ae47-547ddf100cfb">

