### PR TITLE
docs: add experimental banner

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -58,6 +58,17 @@
     color: #35376a !important;
     font-weight: 700 !important;
   }
+
+  #experimental-banner {
+    position: sticky;
+    top: 0;
+    padding: var(--spacing-sm) var(--spacing-xl);
+    z-index: var(--z-index-sticky);
+    font-size: 1rem !important;
+    font-weight: 600;
+    background-color: rgb(var(--colors-alert));
+    color: rgb(var(--colors-on-alert));
+  }
 </style>
 
 <link href="/normalize.css" rel="stylesheet" />

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -8,9 +8,24 @@ import './sb-theming.css'
 import { ToC } from '@docs/helpers/ToC'
 
 const ExampleContainer = ({ children, ...props }) => {
+  const shouldDisplayExperimentalBanner = (() => {
+    const docsPrepared = props.context.channel.data.docsPrepared
+    if (!docsPrepared) return false
+
+    return docsPrepared.some(doc => {
+      if (!doc.id) return false
+      return doc.id.includes('experimental-')
+    })
+  })()
+
   return (
     <DocsContainer {...props}>
-      <div id="spark-doc-container">{children}</div>
+      <div id="spark-doc-container">
+        {shouldDisplayExperimentalBanner && <p id="experimental-banner">
+          This component is still experimental. Avoid usage in production features
+        </p>}
+        {children}
+      </div>
       <ToC />
     </DocsContainer>
   )


### PR DESCRIPTION
### Description, Motivation and Context
This PR ensures a banner is displayed on all components marked as experimental. This banner warns users to proceed with caution when using these components.

### Types of changes
- [x] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
 -->

### Screenshots - Animations
![Kapture 2024-01-30 at 17 56 21](https://github.com/adevinta/spark/assets/51230231/40af47ec-7b3a-4566-af30-3041bba5f0c6)

