### PR TITLE
fix(dropdown): release dropdown and select as stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -33398,7 +33399,7 @@
     },
     "packages/components/dropdown": {
       "name": "@spark-ui/dropdown",
-      "version": "0.21.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-id": "1.0.1",
@@ -33688,7 +33689,7 @@
     },
     "packages/components/select": {
       "name": "@spark-ui/select",
-      "version": "0.6.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@spark-ui/form-field": "^1.4.1",

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spark-ui/dropdown",
-  "version": "0.21.5",
+  "version": "1.0.0-0",
   "description": "Displays a list of options for the user to pick from—triggered by a button. Differs from Select in that it offers multiple select and its list is not native.",
   "publishConfig": {
     "access": "public"

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -10,7 +10,7 @@ import React, { ComponentProps, useState } from 'react'
 import { Dropdown } from '.'
 
 const meta: Meta<typeof Dropdown> = {
-  title: 'Experimental/Dropdown',
+  title: 'Components/Dropdown',
   component: Dropdown,
 }
 

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spark-ui/select",
-  "version": "0.6.7",
+  "version": "1.0.0-0",
   "description": "Displays a list of options for the user to pick from—triggered by a button.",
   "publishConfig": {
     "access": "public"

--- a/packages/components/select/src/Select.stories.tsx
+++ b/packages/components/select/src/Select.stories.tsx
@@ -8,7 +8,7 @@ import React, { ComponentProps, useState } from 'react'
 import { Select } from '.'
 
 const meta: Meta<typeof Select> = {
-  title: 'Experimental/Select',
+  title: 'Components/Select',
   component: Select,
 }
 


### PR DESCRIPTION
### Description, Motivation and Context

- Releasing `@spark-ui/dropdown` as stable
- Releasing `@spark-ui/select` as stable

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
