### PR TITLE
feat(snackbar): init snackbar data flow logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34026,6 +34026,7 @@
       "license": "MIT",
       "dependencies": {
         "@react-aria/toast": "3.0.0-beta.9",
+        "@react-stately/toast": "3.0.0-beta.1",
         "@spark-ui/icon": "^2.1.0",
         "@spark-ui/icon-button": "^2.2.1",
         "@spark-ui/icons": "^1.21.6",

--- a/packages/components/snackbar/package.json
+++ b/packages/components/snackbar/package.json
@@ -23,6 +23,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@react-stately/toast": "3.0.0-beta.1",
     "@react-aria/toast": "3.0.0-beta.9",
     "@spark-ui/icon": "^2.1.0",
     "@spark-ui/icon-button": "^2.2.1",

--- a/packages/components/snackbar/src/SnackBarItemContext.tsx
+++ b/packages/components/snackbar/src/SnackBarItemContext.tsx
@@ -1,0 +1,13 @@
+import { QueuedToast, ToastState } from '@react-stately/toast'
+import { createContext, useContext } from 'react'
+
+import type { SnackbarItemValue } from './SnackbarItem'
+
+export interface SnackbarItemState<T = SnackbarItemValue> {
+  toast: QueuedToast<T>
+  state: ToastState<T>
+}
+
+export const SnackbarItemContext = createContext<SnackbarItemState>({} as SnackbarItemState)
+
+export const useSnackbarItemContext = () => useContext(SnackbarItemContext)

--- a/packages/components/snackbar/src/Snackbar.doc.mdx
+++ b/packages/components/snackbar/src/Snackbar.doc.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
-import { ArgTypes } from '@storybook/blocks';
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 
 import { Snackbar } from '.'
 
@@ -20,12 +20,24 @@ npm install @spark-ui/snackbar
 ## Import
 
 ```tsx
-import { Snackbar } from "@spark-ui/snackbar"
+import { Snackbar, addSnackbar } from '@spark-ui/snackbar'
 ```
 
 ## Props
 
-<ArgTypes of={Snackbar} />
+<ArgTypes
+  of={Snackbar}
+  description="A container for queued snackbars. It should be placed at the root of the app."
+  subcomponents={{
+    'Snackbar.Item': {
+      of: Snackbar.Item,
+      description: "The component that display each snackbar's content.",
+    },
+  }}
+/>
 
-## Variants
+## Usage
+
+### Default
+
 <Canvas of={stories.Default} />

--- a/packages/components/snackbar/src/Snackbar.stories.tsx
+++ b/packages/components/snackbar/src/Snackbar.stories.tsx
@@ -1,6 +1,7 @@
+import { Button } from '@spark-ui/button'
 import { Meta, StoryFn } from '@storybook/react'
 
-import { Snackbar } from '.'
+import { addSnackbar, Snackbar } from '.'
 
 const meta: Meta<typeof Snackbar> = {
   title: 'Experimental/Snackbar',
@@ -9,4 +10,12 @@ const meta: Meta<typeof Snackbar> = {
 
 export default meta
 
-export const Default: StoryFn = _args => <Snackbar>Hello World!</Snackbar>
+export const Default: StoryFn = _args => {
+  return (
+    <div>
+      <Snackbar />
+
+      <Button onClick={() => addSnackbar({ message: "You're done!" })}>Show me a snackbar</Button>
+    </div>
+  )
+}

--- a/packages/components/snackbar/src/Snackbar.tsx
+++ b/packages/components/snackbar/src/Snackbar.tsx
@@ -1,9 +1,73 @@
-import { ComponentPropsWithoutRef, forwardRef, PropsWithChildren } from 'react'
+import { type AriaToastRegionProps, useToastRegion } from '@react-aria/toast'
+import {
+  type ToastOptions as SnackBarItemOptions,
+  ToastQueue,
+  useToastQueue,
+} from '@react-stately/toast'
+import { cloneElement, forwardRef, type ReactElement, useRef } from 'react'
+import { createPortal } from 'react-dom'
 
-export type SnackbarProps = ComponentPropsWithoutRef<'div'>
+import { SnackbarItem, type SnackbarItemProps, type SnackbarItemValue } from './SnackbarItem'
+import { SnackbarItemContext } from './SnackBarItemContext'
 
-export const Snackbar = forwardRef<HTMLDivElement, PropsWithChildren<SnackbarProps>>(
-  (props, ref) => {
-    return <div ref={ref} {...props} />
+export interface SnackbarProps extends AriaToastRegionProps {
+  /**
+   * The component/template used to display each snackbar from the queue
+   * @default 'Snackbar.Item'
+   */
+  children?: ReactElement<SnackbarItemProps, typeof SnackbarItem>
+}
+
+/**
+ * We define here a global queue thanks to dedicated util from React Spectrum.
+ * It is based on `useSyncExternalStore` and allows us to consume data from
+ * an external data store, and thus preventing use of React context that could
+ * lead to unwanted rerenderings. It also simplifies initial implementation.
+ */
+let GLOBAL_SNACKBAR_QUEUE: ToastQueue<SnackbarItemValue> | null = null
+
+const getGlobalSnackBarQueue = () => {
+  if (!GLOBAL_SNACKBAR_QUEUE) {
+    GLOBAL_SNACKBAR_QUEUE = new ToastQueue({
+      maxVisibleToasts: 5,
+    })
+  }
+
+  return GLOBAL_SNACKBAR_QUEUE
+}
+
+export const clearSnackbarQueue = () => {
+  GLOBAL_SNACKBAR_QUEUE = null
+}
+
+export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(
+  ({ children = <SnackbarItem />, ...rest }, forwardedRef): ReactElement | null => {
+    const innerRef = useRef<HTMLDivElement>(null)
+    const ref = forwardedRef && typeof forwardedRef !== 'function' ? forwardedRef : innerRef
+
+    const state = useToastQueue(getGlobalSnackBarQueue())
+    const { regionProps } = useToastRegion(rest, state, ref)
+
+    return state.visibleToasts.length > 0
+      ? createPortal(
+          <div {...regionProps} ref={ref}>
+            {state.visibleToasts.map(toast => (
+              <SnackbarItemContext.Provider key={toast.key} value={{ toast, state }}>
+                {cloneElement(children, { key: toast.key })}
+              </SnackbarItemContext.Provider>
+            ))}
+          </div>,
+          document.body
+        )
+      : null
   }
 )
+
+Snackbar.displayName = 'Snackbar'
+
+export const addSnackbar = (value: SnackbarItemValue, options: SnackBarItemOptions = {}) => {
+  const timeout = options.timeout ? Math.max(options.timeout, 5000) : 5000
+  const queue = getGlobalSnackBarQueue()
+
+  queue.add(value, { ...options, timeout })
+}

--- a/packages/components/snackbar/src/SnackbarItem.tsx
+++ b/packages/components/snackbar/src/SnackbarItem.tsx
@@ -1,0 +1,57 @@
+import { type AriaToastProps, useToast } from '@react-aria/toast'
+import {
+  type ComponentPropsWithoutRef,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+  useRef,
+} from 'react'
+
+import { useSnackbarItemContext } from './SnackBarItemContext'
+
+export interface SnackbarItemValue {
+  icon?: ReactNode
+  message: ReactNode
+}
+
+export interface SnackbarItemProps
+  extends ComponentPropsWithoutRef<'div'>,
+    Omit<AriaToastProps<SnackbarItemValue>, 'toast'> {}
+
+export const SnackbarItem = ({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  'aria-describedby': ariaDescribedby,
+  'aria-details': ariaDetails,
+  ...rest
+}: SnackbarItemProps): ReactElement => {
+  const ref = useRef(null)
+  const { toast, state } = useSnackbarItemContext()
+
+  const ariaProps = {
+    ariaLabel,
+    ariaLabelledby,
+    ariaDescribedby,
+    ariaDetails,
+  }
+
+  const { toastProps, titleProps, closeButtonProps } = useToast({ toast, ...ariaProps }, state, ref)
+
+  return (
+    <div {...toastProps} ref={ref} {...rest}>
+      <div {...titleProps}>{toast.content.message}</div>
+      <button
+        /**
+         * onPress event is strongly related to React Spectrum internal APIs,
+         * so we need to cast callback type to avoid TS errors.
+         */
+        aria-label={closeButtonProps['aria-label']}
+        onClick={closeButtonProps.onPress as unknown as MouseEventHandler<HTMLButtonElement>}
+      >
+        x
+      </button>
+    </div>
+  )
+}
+
+SnackbarItem.displayName = 'Snackbar.Item'

--- a/packages/components/snackbar/src/index.ts
+++ b/packages/components/snackbar/src/index.ts
@@ -1,1 +1,17 @@
-export { Snackbar } from './Snackbar'
+import { type ToastOptions as SnackBarItemOptions } from '@react-stately/toast'
+import type { FC } from 'react'
+
+import { addSnackbar, clearSnackbarQueue, Snackbar as Root, SnackbarProps } from './Snackbar'
+import { SnackbarItem as Item } from './SnackbarItem'
+
+export const Snackbar: FC<SnackbarProps> & {
+  Item: typeof Item
+} = Object.assign(Root, {
+  Item,
+})
+
+Snackbar.displayName = 'SnackBar'
+Item.displayName = 'SnackBar.Item'
+
+export type { SnackbarProps, SnackBarItemOptions }
+export { addSnackbar, clearSnackbarQueue }


### PR DESCRIPTION
**TASK**: #1893 

### Description, Motivation and Context
In this new PR we want to setup base logic of the Snackbar incoming component. It will be implemented by adding a `<SnackBar />` within the codebase, and then controlling snackbar queue with dedicated methods (such as `addSnackBar`).

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 📷 Demo
- [x] 🧪 Test

![image](https://github.com/adevinta/spark/assets/66770550/78debf3e-7acc-497e-84bb-161212076ec6)
