### PR TITLE
fix(dropdown): fixing empty value items selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -54,6 +54,7 @@ export const Controlled: StoryFn = () => {
 
         <Dropdown.Popover>
           <Dropdown.Items>
+            <Dropdown.Item value="">-- Pick a book --</Dropdown.Item>
             <Dropdown.Item value="book-1">To Kill a Mockingbird</Dropdown.Item>
             <Dropdown.Item value="book-2">War and Peace</Dropdown.Item>
             <Dropdown.Item value="book-3">The Idiot</Dropdown.Item>

--- a/packages/components/dropdown/src/useDropdown.ts
+++ b/packages/components/dropdown/src/useDropdown.ts
@@ -35,16 +35,18 @@ export const useDropdown = ({
   const items = [...itemsMap.values()]
 
   const downshiftMultipleSelection = useMultipleSelection<DropdownItem>({
-    selectedItems: value
-      ? items.filter(item =>
-          multiple ? (value as string[]).includes(item.value) : value === item.value
-        )
-      : undefined,
-    initialSelectedItems: defaultValue
-      ? items.filter(item =>
-          multiple ? (defaultValue as string[]).includes(item.value) : defaultValue === item.value
-        )
-      : undefined,
+    selectedItems:
+      value != null
+        ? items.filter(item =>
+            multiple ? (value as string[]).includes(item.value) : value === item.value
+          )
+        : undefined,
+    initialSelectedItems:
+      defaultValue != null
+        ? items.filter(item =>
+            multiple ? (defaultValue as string[]).includes(item.value) : defaultValue === item.value
+          )
+        : undefined,
 
     onSelectedItemsChange: ({ selectedItems }) => {
       if (selectedItems != null && multiple) {
@@ -102,10 +104,10 @@ export const useDropdown = ({
     initialIsOpen: defaultOpen ?? false,
     stateReducer,
     // Controlled mode (single selection)
-    selectedItem: value ? itemsMap.get(value as string) : undefined,
+    selectedItem: value != null ? itemsMap.get(value as string) : undefined,
     initialSelectedItem: defaultValue ? itemsMap.get(defaultValue as string) : undefined,
     onSelectedItemChange: ({ selectedItem }) => {
-      if (selectedItem?.value && !multiple) {
+      if (selectedItem?.value != null && !multiple) {
         onValueChange?.(selectedItem?.value as OnChangeValueType)
       }
     },


### PR DESCRIPTION
### Description, Motivation and Context

It was impossible to select an item with value `""` (empty string) in controlled mode inside `Dropdown`.

The reason is an empty string is considered `falsy`. By checking `!= null` instead we only exclude items whose value is `null` or `undefined`.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)