### PR TITLE
feat(snackbar): use external store to ensure single snackbar container

### DIFF
--- a/packages/components/snackbar/src/Snackbar.test.tsx
+++ b/packages/components/snackbar/src/Snackbar.test.tsx
@@ -13,22 +13,15 @@ import {
 
 interface ImplProps extends SnackbarProps, SnackBarItemOptions {}
 
-const SnackbarImplementation = ({ children, ...options }: ImplProps): ReactElement => {
-  const opts: Parameters<typeof addSnackbar>[1] = {
-    timeout: 2000,
-    ...options,
-  }
+const SnackbarImplementation = ({ children, ...options }: ImplProps): ReactElement => (
+  <div>
+    <Snackbar>{children}</Snackbar>
 
-  return (
-    <div>
-      <Snackbar>{children}</Snackbar>
-
-      <button onClick={() => addSnackbar({ message: 'You did it!' }, opts)}>
-        Show me a snackbar
-      </button>
-    </div>
-  )
-}
+    <button onClick={() => addSnackbar({ message: 'You did it!' }, options)}>
+      Show me a snackbar
+    </button>
+  </div>
+)
 
 describe('Snackbar', () => {
   beforeEach(() => clearSnackbarQueue())
@@ -41,6 +34,23 @@ describe('Snackbar', () => {
     await user.click(screen.getByText('Show me a snackbar'))
 
     expect(screen.getByText('You did it!')).toBeInTheDocument()
+  })
+
+  it('should only render one snackbar container', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <div>
+        <Snackbar />
+        <Snackbar />
+
+        <button onClick={() => addSnackbar({ message: 'You did it!' })}>Show me a snackbar</button>
+      </div>
+    )
+
+    await user.click(screen.getByText('Show me a snackbar'))
+
+    expect(screen.getAllByRole('region')).toHaveLength(1)
   })
 
   it('should handle optionnal callback on snackbar closure', async () => {

--- a/packages/components/snackbar/src/useSnackbarGlobalStore.ts
+++ b/packages/components/snackbar/src/useSnackbarGlobalStore.ts
@@ -1,0 +1,69 @@
+import { type RefObject, useCallback, useSyncExternalStore } from 'react'
+
+interface UseSnackbarGlobalStoreArgs<T> {
+  providers: Set<T>
+  subscriptions: Set<() => void>
+}
+
+interface UseSnackbarGlobalStoreReturn<T> {
+  provider: T
+  addProvider: (ref: T) => void
+  deleteProvider: (ref: T) => void
+}
+
+/**
+ * This hook is a basic abstraction of useSyncExternalStore hook which allows us
+ * to consume data from an external data store.
+ *
+ * Cf. https://react.dev/reference/react/useSyncExternalStore#subscribing-to-an-external-store
+ */
+
+export const useSnackbarGlobalStore = <T = RefObject<HTMLDivElement>>({
+  providers,
+  subscriptions,
+}: UseSnackbarGlobalStoreArgs<T>): UseSnackbarGlobalStoreReturn<T> => {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      subscriptions.add(listener)
+
+      return () => subscriptions.delete(listener)
+    },
+    [subscriptions]
+  )
+
+  const getActiveSnackbarProvider = useCallback(() => providers.values().next().value, [providers])
+
+  const addProvider = useCallback(
+    (provider: T) => {
+      providers.add(provider)
+
+      for (const subscribeFn of subscriptions) {
+        subscribeFn()
+      }
+    },
+    [providers, subscriptions]
+  )
+
+  const deleteProvider = useCallback(
+    (provider: T) => {
+      providers.delete(provider)
+
+      for (const subscribeFn of subscriptions) {
+        subscribeFn()
+      }
+    },
+    [providers, subscriptions]
+  )
+
+  const provider = useSyncExternalStore(
+    subscribe,
+    getActiveSnackbarProvider,
+    getActiveSnackbarProvider
+  )
+
+  return {
+    provider,
+    addProvider,
+    deleteProvider,
+  }
+}


### PR DESCRIPTION
**TASK**: #1893 

### Description, Motivation and Context
To avoid duplicate markup that could bring some W3C and/or a11y issues we want to ensure that one application will only have one snackbar container, thanks to `useSyncExternalStore` React hook.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧠 Refactor
