### PR TITLE
fix(dropdown): fix autofocus of dropdown following downshift update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "concurrently": "^8.2.0",
         "copy-to-clipboard": "3.3.3",
         "deepmerge": "4.3.1",
-        "downshift": "^8.2.3",
+        "downshift": "8.3.3",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-config-standard": "17.1.0",
@@ -2399,6 +2399,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -16024,9 +16025,9 @@
       }
     },
     "node_modules/downshift": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.3.2.tgz",
-      "integrity": "sha512-kO5mnwMbWB1OIPgIO4wxK0HtSJbaPzx3XTOcnN36I6i08iVc4C2Fftye3UZYVN+W03b13o1kEmN2118G5vcgeQ==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.3.3.tgz",
+      "integrity": "sha512-f9znQFYF/3AWBkFiEc4H05Vdh41XFgJ80IatLBKIFoA3p86mAXc/iM9/XJ24loF9djtABD5NBEYL7b1b7xh2pw==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "compute-scroll-into-view": "^3.0.3",
@@ -33611,7 +33612,7 @@
         "@spark-ui/popover": "^1.5.2",
         "@spark-ui/visually-hidden": "^1.2.0",
         "class-variance-authority": "0.7.0",
-        "downshift": "^8.2.3"
+        "downshift": "8.3.3"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -33682,7 +33683,7 @@
         "@spark-ui/use-merge-refs": "^0.4.0",
         "@spark-ui/visually-hidden": "^1.2.0",
         "class-variance-authority": "0.7.0",
-        "downshift": "^8.3.2"
+        "downshift": "8.3.3"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "concurrently": "^8.2.0",
     "copy-to-clipboard": "3.3.3",
     "deepmerge": "4.3.1",
-    "downshift": "^8.2.3",
+    "downshift": "8.3.3",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-config-standard": "17.1.0",

--- a/packages/components/combobox/package.json
+++ b/packages/components/combobox/package.json
@@ -35,7 +35,7 @@
     "@spark-ui/popover": "^1.5.2",
     "@spark-ui/visually-hidden": "^1.2.0",
     "class-variance-authority": "0.7.0",
-    "downshift": "^8.2.3"
+    "downshift": "8.3.3"
   },
   "repository": {
     "type": "git",

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -36,7 +36,7 @@
     "@spark-ui/use-merge-refs": "^0.4.0",
     "@spark-ui/visually-hidden": "^1.2.0",
     "class-variance-authority": "0.7.0",
-    "downshift": "^8.3.2"
+    "downshift": "8.3.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description, Motivation and Context

Downshift `8.3.2` introduced a focus issue where the last dropdown on the page gets focus on first rerender.

It has been fixed today with `8.3.3`: https://github.com/downshift-js/downshift/pull/1575

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
