### PR TITLE
feat(dialog): implement focus capture and restoration in dialog component

### DIFF
--- a/packages/components/dialog/src/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog.tsx
@@ -1,5 +1,5 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
-import { type ReactElement } from 'react'
+import { type ReactElement, useEffect, useRef } from 'react'
 
 import { DialogProvider } from './DialogContext'
 
@@ -26,10 +26,33 @@ export interface DialogProps {
   modal?: RadixDialog.DialogProps['modal']
 }
 
-export const Dialog = ({ children, ...rest }: DialogProps): ReactElement => (
-  <DialogProvider>
-    <RadixDialog.Root {...rest}>{children}</RadixDialog.Root>
-  </DialogProvider>
-)
+export const Dialog = ({ children, ...rest }: DialogProps): ReactElement => {
+  const open = rest.open
+  const activeElementRef = useRef<HTMLElement>()
+
+  /**
+   * This function captures the active element when the Dialog is opened
+   * and sets focus back to it when the Dialog is closed.
+   */
+  function handleActiveElementFocus() {
+    if (open && document.activeElement) {
+      activeElementRef.current = document.activeElement as HTMLElement
+    }
+
+    if (!open) {
+      setTimeout(() => {
+        activeElementRef.current?.focus()
+      }, 0)
+    }
+  }
+
+  useEffect(handleActiveElementFocus, [open])
+
+  return (
+    <DialogProvider>
+      <RadixDialog.Root {...rest}>{children}</RadixDialog.Root>
+    </DialogProvider>
+  )
+}
 
 Dialog.displayName = 'Dialog.Root'


### PR DESCRIPTION
**TASK**: #1930

### Description, Motivation and Context
When the Dialog is closed, ensure that the focus is restored to the element that was previously active when the Dialog was opened.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
