### PR TITLE
fix(radio-group): properly enable the disabling of individual radio items

### DIFF
--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -23,6 +23,7 @@ export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
           intent={intent}
           aria-labelledby={children ? innerLabelId : undefined}
           {...others}
+          disabled={disabledProp}
         />
 
         {children && (

--- a/packages/components/radio-group/src/RadioGroup.doc.mdx
+++ b/packages/components/radio-group/src/RadioGroup.doc.mdx
@@ -60,6 +60,10 @@ Use `value` and `onValueChange` props to make the radio group controlled.
 
 <Canvas of={stories.Disabled} />
 
+### Disabled specific radio Item
+
+<Canvas of={stories.DisabledItem} />
+
 ### Intent
 
 Use `intent` prop to set the color of every radio inside the group. Optionally, you can set the `intent` in each radio component.

--- a/packages/components/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/components/radio-group/src/RadioGroup.stories.tsx
@@ -121,6 +121,16 @@ export const Disabled: StoryFn = _args => (
   </RadioGroup>
 )
 
+export const DisabledItem: StoryFn = _args => (
+  <RadioGroup>
+    <RadioGroup.Radio value="1">First</RadioGroup.Radio>
+    <RadioGroup.Radio disabled value="2">
+      Second
+    </RadioGroup.Radio>
+    <RadioGroup.Radio value="3">Third</RadioGroup.Radio>
+  </RadioGroup>
+)
+
 export const CustomImplementation: StoryFn = () => {
   const CustomRadio = ({
     children,

--- a/packages/components/radio-group/src/RadioGroup.test.tsx
+++ b/packages/components/radio-group/src/RadioGroup.test.tsx
@@ -101,6 +101,22 @@ describe('RadioGroup', () => {
     expect(props.onValueChange).not.toHaveBeenCalled()
   })
 
+  it('should be possible to disable a specific Radio item within a group', async () => {
+    const props = { value: '2', onValueChange: vi.fn() }
+
+    render(
+      <RadioGroup {...props}>
+        <RadioGroup.Radio disabled value="1">
+          1
+        </RadioGroup.Radio>
+        <RadioGroup.Radio value="2">2</RadioGroup.Radio>
+        <RadioGroup.Radio value="3">3</RadioGroup.Radio>
+      </RadioGroup>
+    )
+
+    expect(screen.getByLabelText('1')).toBeDisabled()
+  })
+
   describe('with FormField', () => {
     it('should render with label', () => {
       render(


### PR DESCRIPTION
### Description, Motivation and Context
Previously, it was possible to pass a `disabled` attribute to our `Radio` items. However, this flag was not properly propagated internally, resulting in a Radio item with a label marked as `disabled` even though it was still interactive.
This PR addresses this issue

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
