### PR TITLE
fix(dropdown): conditional portal was moving the dropdown deep in the…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,6 +2382,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -23,30 +23,32 @@ export const Popover = forwardRef(
       return () => setHasPopover(false)
     }, [])
 
-    return isOpen ? (
+    return (
       <SparkPopover.Portal>
-        <SparkPopover.Content
-          ref={forwardedRef}
-          inset
-          asChild
-          matchTriggerWidth={matchTriggerWidth}
-          className={cx('!z-dropdown', className)}
-          sideOffset={sideOffset}
-          onOpenAutoFocus={e => {
-            /**
-             * With a combobox pattern, the focus should remain on the trigger at all times.
-             * Passing the focus to the dropdown popover would break keyboard navigation.
-             */
-            e.preventDefault()
-          }}
-          {...props}
-          data-spark-component="dropdown-popover"
-        >
-          {children}
-        </SparkPopover.Content>
+        {isOpen ? (
+          <SparkPopover.Content
+            ref={forwardedRef}
+            inset
+            asChild
+            matchTriggerWidth={matchTriggerWidth}
+            className={cx('!z-dropdown', className)}
+            sideOffset={sideOffset}
+            onOpenAutoFocus={e => {
+              /**
+               * With a combobox pattern, the focus should remain on the trigger at all times.
+               * Passing the focus to the dropdown popover would break keyboard navigation.
+               */
+              e.preventDefault()
+            }}
+            {...props}
+            data-spark-component="dropdown-popover"
+          >
+            {children}
+          </SparkPopover.Content>
+        ) : (
+          children
+        )}
       </SparkPopover.Portal>
-    ) : (
-      children
     )
   }
 )


### PR DESCRIPTION
### Description, Motivation and Context

Recent changes only wrap the `Dropdown.Popover` with a portal when it is opened. Its bad for two reasons:

1. it moves the content of the popover from next to its trigger to the top of the DOM when it opens.
2. unit tests are very difficult to get right because reference to the combobox trigger and list are lost (unsynced)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
