### PR TITLE
docs(combobox): fixed custom filtering story

### DIFF
--- a/packages/components/combobox/src/Combobox.stories.tsx
+++ b/packages/components/combobox/src/Combobox.stories.tsx
@@ -244,7 +244,7 @@ export const FilteringManual: StoryFn = () => {
 
   const filteredItems = Object.keys(items).reduce((acc: Record<string, string>, key: string) => {
     const text: string = items[key as keyof typeof items]
-    const match = text.toLowerCase().includes(inputValue.toLowerCase())
+    const match = text.includes(inputValue)
 
     return match ? { ...acc, [key]: text } : acc
   }, {})


### PR DESCRIPTION
### Description, Motivation and Context

The "non case-sensitive" story was actually doing a case-sensitive check (not matching the description)

### Types of changes
- [x] 🧾 Documentation
