### PR TITLE
feat: add "reverse" prop to have label placed on the left side of the input

### DIFF
--- a/packages/components/checkbox/src/Checkbox.doc.mdx
+++ b/packages/components/checkbox/src/Checkbox.doc.mdx
@@ -85,6 +85,20 @@ Use the `disabled` prop to indicate that the checkbox is disabled.
 
 <Canvas of={stories.Disabled} />
 
+### Reverse
+
+<StoryLabel>Standalone</StoryLabel>
+
+Use the `reverse` prop if you want the label to be placed on the left side of the Checkbox
+
+<Canvas of={stories.Reverse} />
+
+<StoryLabel>Group</StoryLabel>
+
+Use the `reverse` prop if you want the label to be placed on the left side of the Checkbox
+
+<Canvas of={stories.ReverseGroup} />
+
 ### Icon
 
 Use `icon` prop to change the default checked icon.

--- a/packages/components/checkbox/src/Checkbox.stories.tsx
+++ b/packages/components/checkbox/src/Checkbox.stories.tsx
@@ -101,6 +101,21 @@ export const ControlledGroup: StoryFn = () => {
 
 export const Disabled: StoryFn = _args => <Checkbox disabled>Accept terms and conditions</Checkbox>
 
+export const Reverse: StoryFn = _args => (
+  <Checkbox reverse className="max-w-sz-432">
+    Refuse terms and conditions, because you are so unhappy with it. There is no reason to accept
+    that, it’s unfair!
+  </Checkbox>
+)
+
+export const ReverseGroup: StoryFn = _args => (
+  <CheckboxGroup className="max-w-sz-144" reverse name="sport">
+    <Checkbox value="soccer">Soccer</Checkbox>
+    <Checkbox value="tennis">Tennis</Checkbox>
+    <Checkbox value="baseball">Baseball</Checkbox>
+  </CheckboxGroup>
+)
+
 const intent = [
   'main',
   'support',

--- a/packages/components/checkbox/src/Checkbox.test.tsx
+++ b/packages/components/checkbox/src/Checkbox.test.tsx
@@ -118,14 +118,22 @@ describe('Checkbox', () => {
   })
 
   it('should handle the reverse prop', () => {
-    const { container, rerender } = render(<Checkbox>hello</Checkbox>)
+    const { rerender } = render(<Checkbox>hello</Checkbox>)
     const label = screen.getByText('hello')
-    const getFirstRelevantElement = () => container.firstChild?.firstChild
+    const checkboxInput = screen.getByRole('checkbox', {
+      name: 'hello',
+    })
 
-    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+    // checkbox input should be before label in the DOM
+    expect(
+      checkboxInput.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
 
     rerender(<Checkbox reverse>hello</Checkbox>)
-    expect(getFirstRelevantElement()).toStrictEqual(label)
+    // label should be before checkbox input in the DOM
+    expect(
+      label.compareDocumentPosition(checkboxInput) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 })
 
@@ -241,23 +249,30 @@ describe('CheckboxGroup', () => {
   })
 
   it('should handle the reverse prop', () => {
-    const { container, rerender } = render(
+    const { rerender } = render(
       <CheckboxGroup>
         <Checkbox value="hello">hello</Checkbox>
       </CheckboxGroup>
     )
     const label = screen.getByText('hello')
+    const checkboxInput = screen.getByRole('checkbox', {
+      name: 'hello',
+    })
 
-    const getFirstRelevantElement = () => container.firstChild?.firstChild?.firstChild
-
-    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+    // checkbox input should be before label in the DOM
+    expect(
+      checkboxInput.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
 
     rerender(
       <CheckboxGroup reverse>
         <Checkbox value="hello">hello</Checkbox>
       </CheckboxGroup>
     )
-    expect(getFirstRelevantElement()).toStrictEqual(label)
+    // label should be before checkbox input in the DOM
+    expect(
+      label.compareDocumentPosition(checkboxInput) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   describe('with FormField', () => {

--- a/packages/components/checkbox/src/Checkbox.test.tsx
+++ b/packages/components/checkbox/src/Checkbox.test.tsx
@@ -116,6 +116,17 @@ describe('Checkbox', () => {
     expect(checkboxEl).not.toBeChecked()
     expect(onCheckedChange).toHaveBeenCalledTimes(0)
   })
+
+  it('should handle the reverse prop', () => {
+    const { container, rerender } = render(<Checkbox>hello</Checkbox>)
+    const label = screen.getByText('hello')
+    const getFirstRelevantElement = () => container.firstChild?.firstChild
+
+    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+
+    rerender(<Checkbox reverse>hello</Checkbox>)
+    expect(getFirstRelevantElement()).toStrictEqual(label)
+  })
 })
 
 describe('CheckboxGroup', () => {
@@ -227,6 +238,26 @@ describe('CheckboxGroup', () => {
     )
 
     expect(screen.getByRole('checkbox', { name: 'My accessible field label' })).toBeInTheDocument()
+  })
+
+  it('should handle the reverse prop', () => {
+    const { container, rerender } = render(
+      <CheckboxGroup>
+        <Checkbox value="hello">hello</Checkbox>
+      </CheckboxGroup>
+    )
+    const label = screen.getByText('hello')
+
+    const getFirstRelevantElement = () => container.firstChild?.firstChild?.firstChild
+
+    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+
+    rerender(
+      <CheckboxGroup reverse>
+        <Checkbox value="hello">hello</Checkbox>
+      </CheckboxGroup>
+    )
+    expect(getFirstRelevantElement()).toStrictEqual(label)
   })
 
   describe('with FormField', () => {

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -6,11 +6,11 @@ import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
 import { forwardRef, useRef } from 'react'
 
-import { useCheckboxGroup } from './CheckboxGroupContext'
+import { CheckboxGroupContextState, useCheckboxGroup } from './CheckboxGroupContext'
 import { CheckboxInput, CheckboxInputProps } from './CheckboxInput'
 import { CheckboxLabel } from './CheckboxLabel'
 
-export type CheckboxProps = CheckboxInputProps
+export type CheckboxProps = CheckboxInputProps & Pick<CheckboxGroupContextState, 'reverse'>
 
 export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
   (
@@ -21,6 +21,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
       checked: checkedProp,
       value,
       disabled,
+      reverse,
       onCheckedChange,
       children,
       ...others
@@ -76,32 +77,49 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
       checkboxIntent: intentProp,
     })
 
+    const checkboxLabel = children && (
+      <CheckboxLabel disabled={disabled} htmlFor={id || innerId} id={innerLabelId}>
+        {children}
+      </CheckboxLabel>
+    )
+
+    const checkboxInput = (
+      <CheckboxInput
+        ref={ref}
+        id={id || innerId}
+        name={name}
+        value={value}
+        intent={intent}
+        checked={checked}
+        disabled={disabled}
+        required={isRequired}
+        aria-describedby={description}
+        aria-invalid={isInvalid}
+        onCheckedChange={handleCheckedChange}
+        aria-labelledby={children ? innerLabelId : field.labelId}
+        {...others}
+      />
+    )
+
+    const content =
+      group.reverse || reverse ? (
+        <>
+          {checkboxLabel}
+          {checkboxInput}
+        </>
+      ) : (
+        <>
+          {checkboxInput}
+          {checkboxLabel}
+        </>
+      )
+
     return (
       <div
         data-spark-component="checkbox"
         className={cx('relative flex items-start gap-md text-body-1', className)}
       >
-        <CheckboxInput
-          ref={ref}
-          id={id || innerId}
-          name={name}
-          value={value}
-          intent={intent}
-          checked={checked}
-          disabled={disabled}
-          required={isRequired}
-          aria-describedby={description}
-          aria-invalid={isInvalid}
-          onCheckedChange={handleCheckedChange}
-          aria-labelledby={children ? innerLabelId : field.labelId}
-          {...others}
-        />
-
-        {children && (
-          <CheckboxLabel disabled={disabled} htmlFor={id || innerId} id={innerLabelId}>
-            {children}
-          </CheckboxLabel>
-        )}
+        {content}
       </div>
     )
   }

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -21,7 +21,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
       checked: checkedProp,
       value,
       disabled,
-      reverse,
+      reverse = false,
       onCheckedChange,
       children,
       ...others

--- a/packages/components/checkbox/src/CheckboxGroup.tsx
+++ b/packages/components/checkbox/src/CheckboxGroup.tsx
@@ -8,7 +8,7 @@ import { CheckboxGroupContext, CheckboxGroupContextState } from './CheckboxGroup
 export interface CheckboxGroupProps
   extends Omit<ComponentPropsWithoutRef<'div'>, 'value' | 'defaultValue' | 'onChange'>,
     CheckboxGroupStylesProps,
-    Pick<CheckboxGroupContextState, 'intent' | 'name' | 'value'> {
+    Pick<CheckboxGroupContextState, 'intent' | 'name' | 'value' | 'reverse'> {
   /**
    * The initial value of the checkbox group
    */
@@ -29,6 +29,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
       intent,
       orientation = 'vertical',
       onCheckedChange: onCheckedChangeProp,
+      reverse,
       children,
       ...others
     },
@@ -62,9 +63,10 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
         isInvalid,
         description,
         isRequired,
+        reverse,
         onCheckedChange: handleCheckedChange,
       }
-    }, [id, name, value, intent, state, isInvalid, description, isRequired, setValue])
+    }, [id, name, value, intent, state, isInvalid, description, isRequired, setValue, reverse])
 
     useEffect(() => {
       onCheckedChangeRef.current = onCheckedChangeProp

--- a/packages/components/checkbox/src/CheckboxGroup.tsx
+++ b/packages/components/checkbox/src/CheckboxGroup.tsx
@@ -29,7 +29,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
       intent,
       orientation = 'vertical',
       onCheckedChange: onCheckedChangeProp,
-      reverse,
+      reverse = false,
       children,
       ...others
     },

--- a/packages/components/checkbox/src/CheckboxGroupContext.tsx
+++ b/packages/components/checkbox/src/CheckboxGroupContext.tsx
@@ -35,6 +35,10 @@ export interface CheckboxGroupContextState extends Pick<CheckboxInputStylesProps
    * Callback used to update or notify the value of the checkbox group.
    */
   onCheckedChange?: (checked: boolean, changed: string) => void
+  /**
+   * When true, the label will be placed on the left side of the Checkbox
+   */
+  reverse?: boolean
 }
 
 export const CheckboxGroupContext = createContext<Partial<CheckboxGroupContextState>>({})

--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -13,26 +13,38 @@ export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
     const innerId = useId()
     const innerLabelId = useId()
 
-    const { intent, disabled } = useRadioGroup()
+    const { intent, disabled, reverse } = useRadioGroup()
 
-    return (
-      <div className={cx('flex items-start gap-md text-body-1', className)}>
-        <RadioInput
-          ref={ref}
-          id={id || innerId}
-          intent={intent}
-          aria-labelledby={children ? innerLabelId : undefined}
-          {...others}
-          disabled={disabledProp}
-        />
-
-        {children && (
-          <RadioLabel disabled={disabledProp || disabled} htmlFor={id || innerId} id={innerLabelId}>
-            {children}
-          </RadioLabel>
-        )}
-      </div>
+    const radioLabel = children && (
+      <RadioLabel disabled={disabledProp || disabled} htmlFor={id || innerId} id={innerLabelId}>
+        {children}
+      </RadioLabel>
     )
+
+    const radioInput = (
+      <RadioInput
+        ref={ref}
+        id={id || innerId}
+        intent={intent}
+        aria-labelledby={children ? innerLabelId : undefined}
+        {...others}
+        disabled={disabledProp}
+      />
+    )
+
+    const content = reverse ? (
+      <>
+        {radioLabel}
+        {radioInput}
+      </>
+    ) : (
+      <>
+        {radioInput}
+        {radioLabel}
+      </>
+    )
+
+    return <div className={cx('flex items-start gap-md text-body-1', className)}>{content}</div>
   }
 )
 

--- a/packages/components/radio-group/src/RadioGroup.doc.mdx
+++ b/packages/components/radio-group/src/RadioGroup.doc.mdx
@@ -64,6 +64,12 @@ Use `value` and `onValueChange` props to make the radio group controlled.
 
 <Canvas of={stories.DisabledItem} />
 
+### Reverse
+
+Use the `reverse` prop if you want the label to be placed on the left side of the Radio
+
+<Canvas of={stories.Reverse} />
+
 ### Intent
 
 Use `intent` prop to set the color of every radio inside the group. Optionally, you can set the `intent` in each radio component.

--- a/packages/components/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/components/radio-group/src/RadioGroup.stories.tsx
@@ -65,6 +65,14 @@ export const Controlled: StoryFn = () => {
   )
 }
 
+export const Reverse: StoryFn = _args => (
+  <RadioGroup className="max-w-sz-112" reverse defaultValue="1">
+    <RadioGroup.Radio value="1">First</RadioGroup.Radio>
+    <RadioGroup.Radio value="2">Second</RadioGroup.Radio>
+    <RadioGroup.Radio value="3">Third</RadioGroup.Radio>
+  </RadioGroup>
+)
+
 const intents: RadioGroupProps['intent'][] = [
   'main',
   'support',

--- a/packages/components/radio-group/src/RadioGroup.test.tsx
+++ b/packages/components/radio-group/src/RadioGroup.test.tsx
@@ -118,23 +118,31 @@ describe('RadioGroup', () => {
   })
 
   it('should handle the reverse prop', async () => {
-    const { container, rerender } = render(
+    const { rerender } = render(
       <RadioGroup>
         <RadioGroup.Radio value="1">one</RadioGroup.Radio>
       </RadioGroup>
     )
 
     const label = screen.getByText('one')
-    const getFirstRelevantElement = () => container.firstChild?.firstChild?.firstChild
+    const radioInput = screen.getByRole('radio', {
+      name: 'one',
+    })
 
-    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+    // radio input should be before label in the DOM
+    expect(
+      radioInput.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
 
     rerender(
       <RadioGroup reverse>
         <RadioGroup.Radio value="1">one</RadioGroup.Radio>
       </RadioGroup>
     )
-    expect(getFirstRelevantElement()).toStrictEqual(label)
+    // label should be before radio input in the DOM
+    expect(
+      label.compareDocumentPosition(radioInput) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   describe('with FormField', () => {

--- a/packages/components/radio-group/src/RadioGroup.test.tsx
+++ b/packages/components/radio-group/src/RadioGroup.test.tsx
@@ -117,6 +117,26 @@ describe('RadioGroup', () => {
     expect(screen.getByLabelText('1')).toBeDisabled()
   })
 
+  it('should handle the reverse prop', async () => {
+    const { container, rerender } = render(
+      <RadioGroup>
+        <RadioGroup.Radio value="1">one</RadioGroup.Radio>
+      </RadioGroup>
+    )
+
+    const label = screen.getByText('one')
+    const getFirstRelevantElement = () => container.firstChild?.firstChild?.firstChild
+
+    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+
+    rerender(
+      <RadioGroup reverse>
+        <RadioGroup.Radio value="1">one</RadioGroup.Radio>
+      </RadioGroup>
+    )
+    expect(getFirstRelevantElement()).toStrictEqual(label)
+  })
+
   describe('with FormField', () => {
     it('should render with label', () => {
       render(

--- a/packages/components/radio-group/src/RadioGroup.tsx
+++ b/packages/components/radio-group/src/RadioGroup.tsx
@@ -50,6 +50,10 @@ export interface RadioGroupProps
    * When true, keyboard navigation will loop from last item to first, and vice versa.
    */
   loop?: boolean
+  /**
+   * When true, the label will be placed on the left side of the Radio
+   */
+  reverse?: boolean
 }
 
 export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
@@ -61,6 +65,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       disabled,
       className,
       required: requiredProp,
+      reverse,
       ...others
     },
     ref
@@ -69,7 +74,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
     const required = requiredProp !== undefined ? requiredProp : isRequired
 
     return (
-      <RadioGroupProvider intent={intent} disabled={disabled}>
+      <RadioGroupProvider reverse={reverse} intent={intent} disabled={disabled}>
         <RadioGroupPrimitive
           data-spark-component="radio-group"
           className={radioGroupStyles({ orientation, className })}

--- a/packages/components/radio-group/src/RadioGroup.tsx
+++ b/packages/components/radio-group/src/RadioGroup.tsx
@@ -65,7 +65,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
       disabled,
       className,
       required: requiredProp,
-      reverse,
+      reverse = false,
       ...others
     },
     ref

--- a/packages/components/radio-group/src/RadioGroupContext.tsx
+++ b/packages/components/radio-group/src/RadioGroupContext.tsx
@@ -1,8 +1,10 @@
 import { createContext, useContext } from 'react'
 
+import type { RadioGroupProps } from './RadioGroup'
 import type { RadioInputProps } from './RadioInput'
 
-export type RadioGroupContextState = Pick<RadioInputProps, 'intent' | 'disabled'>
+export type RadioGroupContextState = Pick<RadioInputProps, 'intent' | 'disabled'> &
+  Pick<RadioGroupProps, 'reverse'>
 
 export const RadioGroupContext = createContext<RadioGroupContextState | null>(null)
 

--- a/packages/components/radio-group/src/RadioGroupProvider.tsx
+++ b/packages/components/radio-group/src/RadioGroupProvider.tsx
@@ -1,14 +1,22 @@
 import { ReactNode, useMemo } from 'react'
 
+import type { RadioGroupProps } from './RadioGroup'
 import { RadioGroupContext } from './RadioGroupContext'
 import type { RadioInputProps } from './RadioInput'
 
-export interface RadioGroupProviderProps extends Pick<RadioInputProps, 'intent' | 'disabled'> {
+export interface RadioGroupProviderProps
+  extends Pick<RadioInputProps, 'intent' | 'disabled'>,
+    Pick<RadioGroupProps, 'reverse'> {
   children: ReactNode
 }
 
-export const RadioGroupProvider = ({ intent, disabled, children }: RadioGroupProviderProps) => {
-  const value = useMemo(() => ({ intent, disabled }), [intent, disabled])
+export const RadioGroupProvider = ({
+  intent,
+  disabled,
+  reverse,
+  children,
+}: RadioGroupProviderProps) => {
+  const value = useMemo(() => ({ intent, disabled, reverse }), [intent, disabled, reverse])
 
   return <RadioGroupContext.Provider value={value}>{children}</RadioGroupContext.Provider>
 }

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -48,6 +48,12 @@ Use the `disabled` prop to indicate that the switch is disabled.
 
 <Canvas of={stories.Disabled} />
 
+### Reverse
+
+Use the `reverse` prop if you want the label to be placed on the left side of the Switch
+
+<Canvas of={stories.Reverse} />
+
 ### Icons
 
 Use `checkedIcon` and `uncheckedIcon` props to change the default checked and unchecked icons.

--- a/packages/components/switch/src/Switch.stories.tsx
+++ b/packages/components/switch/src/Switch.stories.tsx
@@ -28,6 +28,8 @@ export const Controlled: StoryFn = () => {
   )
 }
 
+export const Reverse: StoryFn = _args => <Switch reverse>Agreed</Switch>
+
 export const Icons: StoryFn = _args => (
   <Switch checkedIcon={<Sun />} uncheckedIcon={<StarOutline />}>
     Mode

--- a/packages/components/switch/src/Switch.test.tsx
+++ b/packages/components/switch/src/Switch.test.tsx
@@ -53,14 +53,22 @@ describe('Switch', () => {
   })
 
   it('should handle the reverse prop', () => {
-    const { container, rerender } = render(<Switch>hello</Switch>)
+    const { rerender } = render(<Switch>hello</Switch>)
     const label = screen.getByText('hello')
-    const getFirstRelevantElement = () => container.firstChild?.firstChild
+    const switchInput = screen.getByRole('switch', {
+      name: 'hello',
+    })
 
-    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+    // switch input should be before label in the DOM
+    expect(
+      switchInput.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
 
     rerender(<Switch reverse>hello</Switch>)
-    expect(getFirstRelevantElement()).toStrictEqual(label)
+    // label should be before switch input in the DOM
+    expect(
+      label.compareDocumentPosition(switchInput) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   describe('user interactions', () => {

--- a/packages/components/switch/src/Switch.test.tsx
+++ b/packages/components/switch/src/Switch.test.tsx
@@ -52,6 +52,17 @@ describe('Switch', () => {
     expect(screen.getByRole('switch', { name: 'My accessible field label' })).toBeInTheDocument()
   })
 
+  it('should handle the reverse prop', () => {
+    const { container, rerender } = render(<Switch>hello</Switch>)
+    const label = screen.getByText('hello')
+    const getFirstRelevantElement = () => container.firstChild?.firstChild
+
+    expect(getFirstRelevantElement()).not.toStrictEqual(label)
+
+    rerender(<Switch reverse>hello</Switch>)
+    expect(getFirstRelevantElement()).toStrictEqual(label)
+  })
+
   describe('user interactions', () => {
     it('should check/uncheck upon click', async () => {
       const user = userEvent.setup()

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -9,7 +9,7 @@ import { SwitchLabel } from './SwitchLabel'
 export type SwitchProps = SwitchInputProps
 
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ size = 'md', children, className, id, disabled, reverse, ...rest }, ref) => {
+  ({ size = 'md', children, className, id, disabled, reverse = false, ...rest }, ref) => {
     const field = useFormFieldControl()
 
     const innerId = useId(id)

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -9,36 +9,52 @@ import { SwitchLabel } from './SwitchLabel'
 export type SwitchProps = SwitchInputProps
 
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ size = 'md', children, className, id, disabled, ...rest }, ref) => {
+  ({ size = 'md', children, className, id, disabled, reverse, ...rest }, ref) => {
     const field = useFormFieldControl()
 
     const innerId = useId(id)
     const innerLabelId = useId()
+
+    const switchLabel = children && (
+      <SwitchLabel disabled={disabled} htmlFor={field.id || innerId} id={innerLabelId}>
+        {children}
+      </SwitchLabel>
+    )
+
+    const switchInput = (
+      <SwitchInput
+        ref={ref}
+        size={size}
+        id={field.id || innerId}
+        disabled={disabled}
+        /**
+         * If the switch doesn't have any direct label (children) then we should try to
+         * get an eventual alternative label from FormField.
+         * On last resort, we shouldn't forget to define an aria-label attribute.
+         */
+        aria-labelledby={children ? innerLabelId : field.labelId}
+        {...rest}
+      />
+    )
+
+    const content = reverse ? (
+      <>
+        {switchLabel}
+        {switchInput}
+      </>
+    ) : (
+      <>
+        {switchInput}
+        {switchLabel}
+      </>
+    )
 
     return (
       <div
         data-spark-component="switch"
         className={cx('flex items-center gap-md text-body-1', className)}
       >
-        <SwitchInput
-          ref={ref}
-          size={size}
-          id={field.id || innerId}
-          disabled={disabled}
-          /**
-           * If the switch doesn't have any direct label (children) then we should try to
-           * get an eventual alternative label from FormField.
-           * On last resort, we shouldn't forget to define an aria-label attribute.
-           */
-          aria-labelledby={children ? innerLabelId : field.labelId}
-          {...rest}
-        />
-
-        {children && (
-          <SwitchLabel disabled={disabled} htmlFor={field.id || innerId} id={innerLabelId}>
-            {children}
-          </SwitchLabel>
-        )}
+        {content}
       </div>
     )
   }

--- a/packages/components/switch/src/SwitchInput.tsx
+++ b/packages/components/switch/src/SwitchInput.tsx
@@ -56,6 +56,10 @@ export interface SwitchInputProps
    * Icon shown inside the thumb of the Switch whenever it is unchecked
    */
   uncheckedIcon?: ReactNode
+  /**
+   * When true, the label will be placed on the left side of the Switch
+   */
+  reverse?: boolean
 }
 
 export const SwitchInput = forwardRef<HTMLButtonElement, SwitchInputProps>(


### PR DESCRIPTION
### Description, Motivation and Context
Our **Switch**, **Checkbox**, and **RadioGroup** components currently have their labels placed on the right side of the input. This PR introduce a `reverse` prop that, when enabled, will place the label on the left side of the input.

This PR will also address #2005 

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
