### PR TITLE
fix(dialog): use optional chaining operator to safely access node id

### DIFF
--- a/packages/components/dialog/src/DialogContext.tsx
+++ b/packages/components/dialog/src/DialogContext.tsx
@@ -21,7 +21,7 @@ export const DialogProvider = ({ children: childrenProp }: { children: ReactNode
   const [hasCloseButton, setHasCloseButton] = useState(false)
 
   const closeButton = deepFind(childrenProp, node => {
-    const reactElementId = ((node as ReactElement)?.type as { id?: string }).id
+    const reactElementId = ((node as ReactElement)?.type as { id?: string })?.id
 
     return reactElementId === 'CloseButton'
   })


### PR DESCRIPTION
### Description, Motivation and Context
Use optional chaining operator to safely access node id, preventing runtime errors when `node.type` is not present

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
