### PR TITLE
fix(dialog): ensure the activeElement is an HTMLElement before trying to call the focus method on it

### DIFF
--- a/packages/components/dialog/src/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog.tsx
@@ -28,7 +28,7 @@ export interface DialogProps {
 
 export const Dialog = ({ children, ...rest }: DialogProps): ReactElement => {
   const open = rest.open
-  const activeElementRef = useRef<HTMLElement>()
+  const activeElementRef = useRef<Element>()
 
   /**
    * This function captures the active element when the Dialog is opened
@@ -36,12 +36,13 @@ export const Dialog = ({ children, ...rest }: DialogProps): ReactElement => {
    */
   function handleActiveElementFocus() {
     if (open && document.activeElement) {
-      activeElementRef.current = document.activeElement as HTMLElement
+      activeElementRef.current = document.activeElement
     }
 
     if (!open) {
       setTimeout(() => {
-        activeElementRef.current?.focus()
+        if (!(activeElementRef.current instanceof HTMLElement)) return
+        activeElementRef.current.focus()
       }, 0)
     }
   }


### PR DESCRIPTION
### Description, Motivation and Context
Ensure the activeElement is an HTMLElement before trying to call the focus method on it, to prevent runtime errors

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
