### PR TITLE
feat(textarea): add story showcasing customised scrollbar

### DIFF
--- a/packages/components/textarea/src/Textarea.doc.mdx
+++ b/packages/components/textarea/src/Textarea.doc.mdx
@@ -80,6 +80,12 @@ By default, the textarea component is resizable. However, you can set the `isRes
 
 <Canvas of={stories.Resizable} />
 
+### Customized scrollbar
+
+To improve the appearance of the scrollbar, one can use the `scrollbar-color` CSS property.
+
+<Canvas of={stories.CustomizedScrollbar} />
+
 ### State
 
 Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.

--- a/packages/components/textarea/src/Textarea.stories.tsx
+++ b/packages/components/textarea/src/Textarea.stories.tsx
@@ -41,6 +41,15 @@ export const Resizable: StoryFn = () => (
   />
 )
 
+export const CustomizedScrollbar: StoryFn = () => (
+  <Textarea
+    className="[scrollbar-color:blue_transparent]"
+    rows={2}
+    aria-label="Description"
+    defaultValue="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+  />
+)
+
 export const Disabled: StoryFn = _args => (
   <div className="flex flex-col gap-md">
     <Textarea


### PR DESCRIPTION
**TASK**: #2016 

### Description, Motivation and Context
While working on this ticket we realized the complexity that could arise from considering changes in the text area's font size and so forth. It's wise to take a step back and not go any further.

To address the issue of the unappealing scrollbar, we recommend that our consumers use the `scrollbar-color` CSS property to customize scrollbar styles instead. This PR just adds a story showcasing a customised scrollbar

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
