### PR TITLE
fix(dropdown): z-index conflict between dialog and dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,6 +2382,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -81,11 +81,14 @@ import { Dropdown } from '@spark-ui/dropdown'
       of: Dropdown.LeadingIcon,
       description: 'Prepend a decorative icon inside the input (to the left).',
     },
+    'Dropdown.Portal': {
+      of: Dropdown.Portal,
+      description: 'When used, portals the content part into the body.',
+    },
     'Dropdown.Popover': {
       of: Dropdown.Popover,
       description: 'The part that is toggled and portaled when the trigger element is clicked.',
     },
-
     'Dropdown.Items': {
       of: Dropdown.Items,
       description: 'The wrapper which contains all the options.',

--- a/packages/components/dropdown/src/DropdownPopover.tsx
+++ b/packages/components/dropdown/src/DropdownPopover.tsx
@@ -15,36 +15,36 @@ export const Popover = forwardRef(
     }: ComponentProps<typeof SparkPopover.Content>,
     forwardedRef: Ref<HTMLDivElement>
   ) => {
-    const { setHasPopover } = useDropdownContext()
+    const ctx = useDropdownContext()
 
     useEffect(() => {
-      setHasPopover(true)
+      ctx.setHasPopover(true)
 
-      return () => setHasPopover(false)
+      return () => ctx.setHasPopover(false)
     }, [])
 
-    return (
-      <SparkPopover.Portal>
-        <SparkPopover.Content
-          ref={forwardedRef}
-          inset
-          asChild
-          matchTriggerWidth={matchTriggerWidth}
-          className={cx('!z-dropdown', className)}
-          sideOffset={sideOffset}
-          onOpenAutoFocus={e => {
-            /**
-             * With a combobox pattern, the focus should remain on the trigger at all times.
-             * Passing the focus to the dropdown popover would break keyboard navigation.
-             */
-            e.preventDefault()
-          }}
-          {...props}
-          data-spark-component="dropdown-popover"
-        >
-          {children}
-        </SparkPopover.Content>
-      </SparkPopover.Portal>
+    return ctx.isOpen ? (
+      <SparkPopover.Content
+        ref={forwardedRef}
+        inset
+        asChild
+        matchTriggerWidth={matchTriggerWidth}
+        className={cx('relative !z-dropdown', className)}
+        sideOffset={sideOffset}
+        onOpenAutoFocus={e => {
+          /**
+           * With a combobox pattern, the focus should remain on the trigger at all times.
+           * Passing the focus to the dropdown popover would break keyboard navigation.
+           */
+          e.preventDefault()
+        }}
+        {...props}
+        data-spark-component="dropdown-popover"
+      >
+        {children}
+      </SparkPopover.Content>
+    ) : (
+      children
     )
   }
 )

--- a/packages/components/dropdown/src/DropdownPortal.tsx
+++ b/packages/components/dropdown/src/DropdownPortal.tsx
@@ -1,0 +1,8 @@
+import { Popover as SparkPopover } from '@spark-ui/popover'
+import { ReactElement } from 'react'
+
+export const Portal: typeof SparkPopover.Portal = ({ children, ...rest }): ReactElement => (
+  <SparkPopover.Portal {...rest}>{children}</SparkPopover.Portal>
+)
+
+Portal.displayName = 'Dropdown.Portal'

--- a/packages/components/dropdown/src/index.ts
+++ b/packages/components/dropdown/src/index.ts
@@ -11,6 +11,7 @@ import { ItemText } from './DropdownItemText'
 import { Label } from './DropdownLabel'
 import { LeadingIcon } from './DropdownLeadingIcon'
 import { Popover } from './DropdownPopover'
+import { Portal } from './DropdownPortal'
 import { Trigger } from './DropdownTrigger'
 import { Value } from './DropdownValue'
 
@@ -28,6 +29,7 @@ export const Dropdown: FC<DropdownProps> & {
   Trigger: typeof Trigger
   Value: typeof Value
   LeadingIcon: typeof LeadingIcon
+  Portal: typeof Portal
 } = Object.assign(Root, {
   Group,
   Item,
@@ -40,6 +42,7 @@ export const Dropdown: FC<DropdownProps> & {
   Trigger,
   Value,
   LeadingIcon,
+  Portal,
 })
 
 Dropdown.displayName = 'Dropdown'
@@ -54,3 +57,4 @@ Divider.displayName = 'Dropdown.Divider'
 Trigger.displayName = 'Dropdown.Trigger'
 Value.displayName = 'Dropdown.Value'
 LeadingIcon.displayName = 'Dropdown.LeadingIcon'
+Portal.displayName = 'Dropdown.Portal'


### PR DESCRIPTION
### Description, Motivation and Context

We portalled `Dropdown.Popover` to fix a bug, but it introduced another bug: Dropdowns are now rendered portalled like `Dialog` so they share the same stacking context.

This is bad because their z-index are:
```
dropdown: '1000',
modal: '1400',
```

So now, a Dropdown inside a dialog is visually hidden behind it.

Instead of hard-coding the wrapping of `Dropdown.Popover` with a `Portal`, I added `Dropown.Portal` as part of the compound to make it optional. That way by default a dropdown is not portalled and inherits the closest stacking context.

A dropdown inside a dialog has a z-index of `1000` INSIDE a stacking context of `1400`.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
