### PR TITLE
docs: status icons are not longer managed inside components

### DIFF
--- a/packages/components/combobox/src/Combobox.doc.mdx
+++ b/packages/components/combobox/src/Combobox.doc.mdx
@@ -201,7 +201,7 @@ This will prepend a spinner inside the items-list.
 
 ### Status
 
-Use `state` prop to assign a specific state to the combobox, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a status indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the combobox, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
 
 You could also wrap `Combobox` with a `FormField` and pass the prop to `Formfield` instead.
 

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -53,7 +53,7 @@ export type ComboboxContextCommonProps = PropsWithChildren<{
    */
   defaultOpen?: boolean
   /**
-   * Use `state` prop to assign a specific state to the combobox, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+   * Use `state` prop to assign a specific state to the combobox, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
    */
   state?: 'error' | 'alert' | 'success'
   /**

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -174,7 +174,7 @@ Use `readOnly` prop to indicate the dropdown is only readable.
 
 ### Status
 
-Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a status indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
 
 You could also wrap `Dropdown` with a `FormField` and pass the prop to `Formfield` instead.
 

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -43,7 +43,7 @@ export type DropdownContextCommonProps = PropsWithChildren<{
    */
   defaultOpen?: boolean
   /**
-   * Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+   * Use `state` prop to assign a specific state to the dropdown, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
    */
   state?: 'error' | 'alert' | 'success'
   /**

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -109,7 +109,7 @@ Use `readOnly` prop to indicate the input is only readable.
 
 ### State
 
-Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
 
 <Canvas of={stories.State} />
 

--- a/packages/components/input/src/InputGroup.tsx
+++ b/packages/components/input/src/InputGroup.tsx
@@ -27,7 +27,7 @@ import { InputGroupContext } from './InputGroupContext'
 
 export interface InputGroupProps extends ComponentPropsWithoutRef<'div'>, InputGroupStylesProps {
   /**
-   * Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+   * Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
    */
   state?: 'error' | 'alert' | 'success'
   /**

--- a/packages/components/select/src/Select.doc.mdx
+++ b/packages/components/select/src/Select.doc.mdx
@@ -105,7 +105,7 @@ Use `readOnly` prop to indicate the Select is only readable.
 
 ### Status
 
-Use `state` prop to assign a specific state to the Select, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a status indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the Select, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
 
 You could also wrap `Select` with a `FormField` and pass the prop to `Formfield` instead.
 

--- a/packages/components/select/src/SelectContext.tsx
+++ b/packages/components/select/src/SelectContext.tsx
@@ -37,7 +37,7 @@ export interface SelectContextState {
 
 export type SelectContextProps = PropsWithChildren<{
   /**
-   * Use `state` prop to assign a specific state to the select, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+   * Use `state` prop to assign a specific state to the select, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
    */
   state?: 'error' | 'alert' | 'success'
   /**

--- a/packages/components/textarea/src/Textarea.doc.mdx
+++ b/packages/components/textarea/src/Textarea.doc.mdx
@@ -88,7 +88,7 @@ To improve the appearance of the scrollbar, one can use the `scrollbar-color` CS
 
 ### State
 
-Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated, and a state indicator will be displayed accordingly.
+Use `state` prop to assign a specific state to the group, choosing from: `error`, `alert` and `success`. By doing so, the outline styles will be updated.
 
 <Canvas of={stories.State} />
 


### PR DESCRIPTION

### Description, Motivation and Context
- status icons are no longer part of components and have been moved to FormField messages.

### Types of changes
- [x] 🧾 Documentation
