### PR TITLE
refactor: deprecate radix useId for react one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,6 +2381,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35181,7 +35182,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "1.0.4",
-        "@radix-ui/react-id": "1.0.1",
         "@spark-ui/form-field": "^1.5.0",
         "@spark-ui/icon": "^2.1.2",
         "@spark-ui/icons": "^1.21.6",
@@ -35220,7 +35220,6 @@
       "version": "0.11.6",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@spark-ui/form-field": "^1.5.0",
         "@spark-ui/icon": "^2.1.2",
         "@spark-ui/icon-button": "^2.2.4",
@@ -35294,7 +35293,6 @@
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@spark-ui/form-field": "^1.5.0",
         "@spark-ui/icon": "^2.1.2",
         "@spark-ui/icons": "^1.21.6",
@@ -35315,7 +35313,6 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@spark-ui/icon": "^2.1.2",
         "@spark-ui/icons": "^1.21.6",
         "@spark-ui/label": "^1.7.0",
@@ -35498,7 +35495,6 @@
       "version": "1.5.7",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-popover": "1.0.7",
         "@spark-ui/icon": "^2.1.2",
         "@spark-ui/icon-button": "^2.2.4",
@@ -35534,7 +35530,6 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-progress": "1.0.3",
         "@spark-ui/use-merge-refs": "^0.4.0",
         "class-variance-authority": "0.7.0"
@@ -35567,7 +35562,6 @@
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-label": "2.0.1",
         "@radix-ui/react-radio-group": "1.1.2",
         "@spark-ui/form-field": "^1.5.0",
@@ -35682,7 +35676,6 @@
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-switch": "1.0.3",
         "@spark-ui/form-field": "^1.5.0",
         "@spark-ui/icons": "^1.21.6",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "1.0.4",
-    "@radix-ui/react-id": "1.0.1",
     "@spark-ui/form-field": "^1.5.0",
     "@spark-ui/icon": "^2.1.2",
     "@spark-ui/icons": "^1.21.6",

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable complexity */
-
-import { useId } from '@radix-ui/react-id'
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
-import { forwardRef, useRef } from 'react'
+import { forwardRef, useId, useRef } from 'react'
 
 import { CheckboxGroupContextState, useCheckboxGroup } from './CheckboxGroupContext'
 import { CheckboxInput, CheckboxInputProps } from './CheckboxInput'
@@ -28,7 +26,9 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     },
     forwardedRef
   ) => {
-    const innerId = useId(idProp)
+    const checkboxId = useId()
+    const innerId = idProp || checkboxId
+
     const innerLabelId = useId()
 
     const field = useFormFieldControl()

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -26,10 +26,10 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     },
     forwardedRef
   ) => {
-    const checkboxId = useId()
+    const checkboxId = `:checkbox-${useId()}`
     const innerId = idProp || checkboxId
 
-    const innerLabelId = useId()
+    const innerLabelId = `:checkbox-${useId()}`
 
     const field = useFormFieldControl()
     const group = useCheckboxGroup()

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -10,6 +10,8 @@ import { CheckboxLabel } from './CheckboxLabel'
 
 export type CheckboxProps = CheckboxInputProps & Pick<CheckboxGroupContextState, 'reverse'>
 
+const ID_PREFIX = ':checkbox'
+
 export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
   (
     {
@@ -26,10 +28,10 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
     },
     forwardedRef
   ) => {
-    const checkboxId = `:checkbox-${useId()}`
+    const checkboxId = `${ID_PREFIX}-${useId()}`
     const innerId = idProp || checkboxId
 
-    const innerLabelId = `:checkbox-${useId()}`
+    const innerLabelId = `${ID_PREFIX}-${useId()}`
 
     const field = useFormFieldControl()
     const group = useCheckboxGroup()

--- a/packages/components/combobox/package.json
+++ b/packages/components/combobox/package.json
@@ -28,7 +28,6 @@
     "tailwindcss": "^3.0.0"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@spark-ui/form-field": "^1.5.0",
     "@spark-ui/icon": "^2.1.2",
     "@spark-ui/icon-button": "^2.2.4",

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -136,6 +136,8 @@ const getFilteredItemsMap = (map: ItemsMap, inputValue: string | undefined): Ite
   )
 }
 
+export const ID_PREFIX = ':combobox'
+
 export const ComboboxProvider = ({
   children,
   state: stateProp,
@@ -222,8 +224,8 @@ export const ComboboxProvider = ({
   // Form field state
   const field = useFormFieldControl()
 
-  const internalFieldLabelID = `:combobox-label-${useId()}`
-  const internalFieldID = `:combobox-field-${useId()}`
+  const internalFieldLabelID = `${ID_PREFIX}-label-${useId()}`
+  const internalFieldID = `${ID_PREFIX}-field-${useId()}`
   const id = field.id || internalFieldID
   const labelId = field.labelId || internalFieldLabelID
 

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -1,4 +1,5 @@
-import { useId } from '@radix-ui/react-id'
+/* eslint-disable complexity */
+/* eslint-disable max-lines-per-function */
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { Popover } from '@spark-ui/popover'
 import { useCombinedState } from '@spark-ui/use-combined-state'
@@ -11,6 +12,7 @@ import {
   SetStateAction,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react'
@@ -219,8 +221,12 @@ export const ComboboxProvider = ({
 
   // Form field state
   const field = useFormFieldControl()
-  const id = useId(field.id)
-  const labelId = useId(field.labelId)
+
+  const internalFieldLabelID = useId()
+  const internalFieldID = useId()
+  const id = field.id || internalFieldID
+  const labelId = field.labelId || internalFieldLabelID
+
   const state = field.state || stateProp
   const disabled = field.disabled ?? disabledProp
   const readOnly = field.readOnly ?? readOnlyProp

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -222,8 +222,8 @@ export const ComboboxProvider = ({
   // Form field state
   const field = useFormFieldControl()
 
-  const internalFieldLabelID = useId()
-  const internalFieldID = useId()
+  const internalFieldLabelID = `:combobox-label-${useId()}`
+  const internalFieldID = `:combobox-field-${useId()}`
   const id = field.id || internalFieldID
   const labelId = field.labelId || internalFieldLabelID
 

--- a/packages/components/combobox/src/ComboboxItemText.tsx
+++ b/packages/components/combobox/src/ComboboxItemText.tsx
@@ -1,6 +1,7 @@
 import { cx } from 'class-variance-authority'
 import { forwardRef, type Ref, useEffect, useId } from 'react'
 
+import { ID_PREFIX } from './ComboboxContext'
 import { useComboboxItemContext } from './ComboboxItemContext'
 
 export interface ItemTextProps {
@@ -9,7 +10,7 @@ export interface ItemTextProps {
 
 export const ItemText = forwardRef(
   ({ children }: ItemTextProps, forwardedRef: Ref<HTMLSpanElement>) => {
-    const id = `:combobox-item-text-${useId()}`
+    const id = `${ID_PREFIX}-item-text-${useId()}`
 
     const { setTextId } = useComboboxItemContext()
 

--- a/packages/components/combobox/src/ComboboxItemText.tsx
+++ b/packages/components/combobox/src/ComboboxItemText.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { cx } from 'class-variance-authority'
-import { forwardRef, type Ref, useEffect } from 'react'
+import { forwardRef, type Ref, useEffect, useId } from 'react'
 
 import { useComboboxItemContext } from './ComboboxItemContext'
 

--- a/packages/components/combobox/src/ComboboxItemText.tsx
+++ b/packages/components/combobox/src/ComboboxItemText.tsx
@@ -9,7 +9,7 @@ export interface ItemTextProps {
 
 export const ItemText = forwardRef(
   ({ children }: ItemTextProps, forwardedRef: Ref<HTMLSpanElement>) => {
-    const id = useId()
+    const id = `:combobox-item-text-${useId()}`
 
     const { setTextId } = useComboboxItemContext()
 

--- a/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
+++ b/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
@@ -9,7 +9,7 @@ type ComboboxContextProps = PropsWithChildren
 const ComboboxGroupContext = createContext<ComboboxContextState | null>(null)
 
 export const ComboboxGroupProvider = ({ children }: ComboboxContextProps) => {
-  const groupLabelId = useId()
+  const groupLabelId = `:combobox-group-label-${useId()}`
 
   return (
     <ComboboxGroupContext.Provider value={{ groupLabelId }}>

--- a/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
+++ b/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
@@ -1,5 +1,4 @@
-import { useId } from '@radix-ui/react-id'
-import React, { createContext, type PropsWithChildren, useContext } from 'react'
+import React, { createContext, type PropsWithChildren, useContext, useId } from 'react'
 
 export interface ComboboxContextState {
   groupLabelId: string

--- a/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
+++ b/packages/components/combobox/src/ComboboxItemsGroupContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, type PropsWithChildren, useContext, useId } from 'react'
 
+import { ID_PREFIX } from './ComboboxContext'
+
 export interface ComboboxContextState {
   groupLabelId: string
 }
@@ -9,7 +11,7 @@ type ComboboxContextProps = PropsWithChildren
 const ComboboxGroupContext = createContext<ComboboxContextState | null>(null)
 
 export const ComboboxGroupProvider = ({ children }: ComboboxContextProps) => {
-  const groupLabelId = `:combobox-group-label-${useId()}`
+  const groupLabelId = `${ID_PREFIX}-group-label-${useId()}`
 
   return (
     <ComboboxGroupContext.Provider value={{ groupLabelId }}>

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -28,7 +28,6 @@
     "tailwindcss": "^3.0.0"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@spark-ui/form-field": "^1.5.0",
     "@spark-ui/icon": "^2.1.2",
     "@spark-ui/icons": "^1.21.6",

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -122,8 +122,8 @@ export const DropdownProvider = ({
 
   const state = field.state || stateProp
 
-  const internalFieldLabelID = useId()
-  const internalFieldID = useId()
+  const internalFieldLabelID = `:dropdown-label-${useId()}`
+  const internalFieldID = `:dropdown-input-${useId()}`
   const id = field.id || internalFieldID
   const labelId = field.labelId || internalFieldLabelID
 

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -99,6 +99,8 @@ export type DropdownContextProps = DropdownContextCommonProps &
 
 const DropdownContext = createContext<DropdownContextState | null>(null)
 
+export const ID_PREFIX = ':dropdown'
+
 export const DropdownProvider = ({
   children,
   defaultValue,
@@ -122,8 +124,8 @@ export const DropdownProvider = ({
 
   const state = field.state || stateProp
 
-  const internalFieldLabelID = `:dropdown-label-${useId()}`
-  const internalFieldID = `:dropdown-input-${useId()}`
+  const internalFieldLabelID = `${ID_PREFIX}-label-${useId()}`
+  const internalFieldID = `${ID_PREFIX}-input-${useId()}`
   const id = field.id || internalFieldID
   const labelId = field.labelId || internalFieldLabelID
 

--- a/packages/components/dropdown/src/DropdownContext.tsx
+++ b/packages/components/dropdown/src/DropdownContext.tsx
@@ -1,4 +1,3 @@
-import { useId } from '@radix-ui/react-id'
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { Popover } from '@spark-ui/popover'
 import {
@@ -9,6 +8,7 @@ import {
   SetStateAction,
   useContext,
   useEffect,
+  useId,
   useState,
 } from 'react'
 
@@ -121,8 +121,12 @@ export const DropdownProvider = ({
   const field = useFormFieldControl()
 
   const state = field.state || stateProp
-  const id = useId(field.id)
-  const labelId = useId(field.labelId)
+
+  const internalFieldLabelID = useId()
+  const internalFieldID = useId()
+  const id = field.id || internalFieldID
+  const labelId = field.labelId || internalFieldLabelID
+
   const disabled = field.disabled ?? disabledProp
   const readOnly = field.readOnly ?? readOnlyProp
 

--- a/packages/components/dropdown/src/DropdownItemText.tsx
+++ b/packages/components/dropdown/src/DropdownItemText.tsx
@@ -9,7 +9,7 @@ export interface ItemTextProps {
 
 export const ItemText = forwardRef(
   ({ children }: ItemTextProps, forwardedRef: Ref<HTMLSpanElement>) => {
-    const id = useId()
+    const id = `:dropdown-item-text-${useId()}`
 
     const { setTextId } = useDropdownItemContext()
 

--- a/packages/components/dropdown/src/DropdownItemText.tsx
+++ b/packages/components/dropdown/src/DropdownItemText.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { cx } from 'class-variance-authority'
-import { forwardRef, type Ref, useEffect } from 'react'
+import { forwardRef, type Ref, useEffect, useId } from 'react'
 
 import { useDropdownItemContext } from './DropdownItemContext'
 

--- a/packages/components/dropdown/src/DropdownItemText.tsx
+++ b/packages/components/dropdown/src/DropdownItemText.tsx
@@ -1,6 +1,7 @@
 import { cx } from 'class-variance-authority'
 import { forwardRef, type Ref, useEffect, useId } from 'react'
 
+import { ID_PREFIX } from './DropdownContext'
 import { useDropdownItemContext } from './DropdownItemContext'
 
 export interface ItemTextProps {
@@ -9,7 +10,7 @@ export interface ItemTextProps {
 
 export const ItemText = forwardRef(
   ({ children }: ItemTextProps, forwardedRef: Ref<HTMLSpanElement>) => {
-    const id = `:dropdown-item-text-${useId()}`
+    const id = `${ID_PREFIX}-item-text-${useId()}`
 
     const { setTextId } = useDropdownItemContext()
 

--- a/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
+++ b/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
@@ -1,5 +1,4 @@
-import { useId } from '@radix-ui/react-id'
-import React, { createContext, type PropsWithChildren, useContext } from 'react'
+import React, { createContext, type PropsWithChildren, useContext, useId } from 'react'
 
 export interface DropdownContextState {
   labelId: string

--- a/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
+++ b/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
@@ -9,7 +9,7 @@ type DropdownContextProps = PropsWithChildren
 const DropdownGroupContext = createContext<DropdownContextState | null>(null)
 
 export const DropdownGroupProvider = ({ children }: DropdownContextProps) => {
-  const labelId = useId()
+  const labelId = `:dropdown-group-label-${useId()}`
 
   return (
     <DropdownGroupContext.Provider value={{ labelId }}>{children}</DropdownGroupContext.Provider>

--- a/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
+++ b/packages/components/dropdown/src/DropdownItemsGroupContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, type PropsWithChildren, useContext, useId } from 'react'
 
+import { ID_PREFIX } from './DropdownContext'
+
 export interface DropdownContextState {
   labelId: string
 }
@@ -9,7 +11,7 @@ type DropdownContextProps = PropsWithChildren
 const DropdownGroupContext = createContext<DropdownContextState | null>(null)
 
 export const DropdownGroupProvider = ({ children }: DropdownContextProps) => {
-  const labelId = `:dropdown-group-label-${useId()}`
+  const labelId = `${ID_PREFIX}-group-label-${useId()}`
 
   return (
     <DropdownGroupContext.Provider value={{ labelId }}>{children}</DropdownGroupContext.Provider>

--- a/packages/components/form-field/package.json
+++ b/packages/components/form-field/package.json
@@ -45,7 +45,6 @@
   "homepage": "https://sparkui.vercel.app",
   "license": "MIT",
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@spark-ui/icon": "^2.1.2",
     "@spark-ui/icons": "^1.21.6",
     "@spark-ui/label": "^1.7.0",

--- a/packages/components/form-field/src/FormField.tsx
+++ b/packages/components/form-field/src/FormField.tsx
@@ -1,7 +1,6 @@
-import { useId } from '@radix-ui/react-id'
 import { Slot } from '@spark-ui/slot'
 import { cx } from 'class-variance-authority'
-import { ComponentPropsWithoutRef, forwardRef } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, useId } from 'react'
 
 import { FormFieldContextState } from './FormFieldContext'
 import { FormFieldProvider } from './FormFieldProvider'

--- a/packages/components/form-field/src/FormField.tsx
+++ b/packages/components/form-field/src/FormField.tsx
@@ -36,7 +36,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>(
     },
     ref
   ) => {
-    const id = useId()
+    const id = `:form-field-${useId()}`
     const Component = asChild ? Slot : 'div'
 
     return (

--- a/packages/components/form-field/src/FormField.tsx
+++ b/packages/components/form-field/src/FormField.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@spark-ui/slot'
 import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef, useId } from 'react'
 
-import { FormFieldContextState } from './FormFieldContext'
+import { FormFieldContextState, ID_PREFIX } from './FormFieldContext'
 import { FormFieldProvider } from './FormFieldProvider'
 
 export interface FormFieldProps
@@ -36,7 +36,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>(
     },
     ref
   ) => {
-    const id = `:form-field-${useId()}`
+    const id = `${ID_PREFIX}-${useId()}`
     const Component = asChild ? Slot : 'div'
 
     return (

--- a/packages/components/form-field/src/FormFieldContext.tsx
+++ b/packages/components/form-field/src/FormFieldContext.tsx
@@ -49,6 +49,8 @@ export interface FormFieldContextState {
 
 export const FormFieldContext = createContext<FormFieldContextState | null>(null)
 
+export const ID_PREFIX = ':form-field'
+
 export const useFormField = () => {
   const context = useContext(FormFieldContext)
 

--- a/packages/components/form-field/src/FormFieldMessage.tsx
+++ b/packages/components/form-field/src/FormFieldMessage.tsx
@@ -8,7 +8,7 @@ export type FormFieldMessageProps = ComponentPropsWithoutRef<'span'>
 export const FormFieldMessage = forwardRef<HTMLSpanElement, FormFieldMessageProps>(
   ({ id: idProp, className, ...others }, ref) => {
     const { onMessageIdAdd, onMessageIdRemove } = useFormField()
-    const currentId = useId()
+    const currentId = `:form-field-message-${useId()}`
     const id = idProp || currentId
 
     useEffect(() => {

--- a/packages/components/form-field/src/FormFieldMessage.tsx
+++ b/packages/components/form-field/src/FormFieldMessage.tsx
@@ -1,14 +1,14 @@
 import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef, useEffect, useId } from 'react'
 
-import { useFormField } from './FormFieldContext'
+import { ID_PREFIX, useFormField } from './FormFieldContext'
 
 export type FormFieldMessageProps = ComponentPropsWithoutRef<'span'>
 
 export const FormFieldMessage = forwardRef<HTMLSpanElement, FormFieldMessageProps>(
   ({ id: idProp, className, ...others }, ref) => {
     const { onMessageIdAdd, onMessageIdRemove } = useFormField()
-    const currentId = `:form-field-message-${useId()}`
+    const currentId = `${ID_PREFIX}-message-${useId()}`
     const id = idProp || currentId
 
     useEffect(() => {

--- a/packages/components/form-field/src/FormFieldMessage.tsx
+++ b/packages/components/form-field/src/FormFieldMessage.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { cx } from 'class-variance-authority'
-import { ComponentPropsWithoutRef, forwardRef, useEffect } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, useEffect, useId } from 'react'
 
 import { useFormField } from './FormFieldContext'
 

--- a/packages/components/form-field/src/FormFieldProvider.tsx
+++ b/packages/components/form-field/src/FormFieldProvider.tsx
@@ -19,7 +19,7 @@ export const FormFieldProvider = ({
   isRequired,
   children,
 }: FormFieldProviderProps) => {
-  const labelId = useId()
+  const labelId = `:form-field-label-${useId()}`
   const [messageIds, setMessageIds] = useState<string[]>([])
   const description = messageIds.length > 0 ? messageIds.join(' ') : undefined
 

--- a/packages/components/form-field/src/FormFieldProvider.tsx
+++ b/packages/components/form-field/src/FormFieldProvider.tsx
@@ -1,5 +1,4 @@
-import { useId } from '@radix-ui/react-id'
-import { ReactNode, useCallback, useMemo, useState } from 'react'
+import { ReactNode, useCallback, useId, useMemo, useState } from 'react'
 
 import { FormFieldContext, FormFieldContextState } from './FormFieldContext'
 

--- a/packages/components/form-field/src/FormFieldProvider.tsx
+++ b/packages/components/form-field/src/FormFieldProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useCallback, useId, useMemo, useState } from 'react'
 
-import { FormFieldContext, FormFieldContextState } from './FormFieldContext'
+import { FormFieldContext, FormFieldContextState, ID_PREFIX } from './FormFieldContext'
 
 export interface FormFieldProviderProps
   extends Pick<
@@ -19,7 +19,7 @@ export const FormFieldProvider = ({
   isRequired,
   children,
 }: FormFieldProviderProps) => {
-  const labelId = `:form-field-label-${useId()}`
+  const labelId = `${ID_PREFIX}-label-${useId()}`
   const [messageIds, setMessageIds] = useState<string[]>([])
   const description = messageIds.length > 0 ? messageIds.join(' ') : undefined
 

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -41,7 +41,6 @@
     "url": "https://github.com/adevinta/spark/issues?q=is%3Aopen+label%3Acomponent+label%3Apopover"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-popover": "1.0.7",
     "@spark-ui/icon": "^2.1.2",
     "@spark-ui/icon-button": "^2.2.4",

--- a/packages/components/popover/src/PopoverContext.tsx
+++ b/packages/components/popover/src/PopoverContext.tsx
@@ -10,6 +10,8 @@ export interface PopoverContextState {
 
 const PopoverContext = createContext<PopoverContextState | null>(null)
 
+export const ID_PREFIX = ':popover'
+
 export const PopoverProvider = ({ children }: { children: ReactNode }) => {
   const [hasCloseButton, setHasCloseButton] = useState(false)
   const [headerId, setHeaderId] = useState<HeaderId>(null)

--- a/packages/components/popover/src/PopoverHeader.tsx
+++ b/packages/components/popover/src/PopoverHeader.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { cx } from 'class-variance-authority'
-import { forwardRef, type ReactNode, useLayoutEffect } from 'react'
+import { forwardRef, type ReactNode, useId, useLayoutEffect } from 'react'
 
 import { usePopover } from './PopoverContext'
 

--- a/packages/components/popover/src/PopoverHeader.tsx
+++ b/packages/components/popover/src/PopoverHeader.tsx
@@ -10,7 +10,7 @@ export interface HeaderProps {
 
 export const Header = forwardRef<HTMLDivElement, HeaderProps>(
   ({ children, className, ...rest }, ref) => {
-    const id = useId()
+    const id = `:popover-header-${useId()}`
     const { setHeaderId } = usePopover()
 
     useLayoutEffect(() => {

--- a/packages/components/popover/src/PopoverHeader.tsx
+++ b/packages/components/popover/src/PopoverHeader.tsx
@@ -1,7 +1,7 @@
 import { cx } from 'class-variance-authority'
 import { forwardRef, type ReactNode, useId, useLayoutEffect } from 'react'
 
-import { usePopover } from './PopoverContext'
+import { ID_PREFIX, usePopover } from './PopoverContext'
 
 export interface HeaderProps {
   children: ReactNode
@@ -10,7 +10,7 @@ export interface HeaderProps {
 
 export const Header = forwardRef<HTMLDivElement, HeaderProps>(
   ({ children, className, ...rest }, ref) => {
-    const id = `:popover-header-${useId()}`
+    const id = `${ID_PREFIX}-header-${useId()}`
     const { setHeaderId } = usePopover()
 
     useLayoutEffect(() => {

--- a/packages/components/progress-tracker/src/ProgressTrackerContext.ts
+++ b/packages/components/progress-tracker/src/ProgressTrackerContext.ts
@@ -29,3 +29,5 @@ export const ProgressTrackerStepContext = createContext<ProgressTrackerStepConte
 export const useProgressTrackerContext = () => useContext(ProgressTrackerContext)
 
 export const useProgressTrackerStepContext = () => useContext(ProgressTrackerStepContext)
+
+export const ID_PREFIX = ':progress-tracker'

--- a/packages/components/progress-tracker/src/ProgressTrackerStep.tsx
+++ b/packages/components/progress-tracker/src/ProgressTrackerStep.tsx
@@ -1,6 +1,10 @@
 import { type ComponentPropsWithoutRef, forwardRef, type ReactNode, useEffect, useId } from 'react'
 
-import { ProgressTrackerStepContext, useProgressTrackerContext } from './ProgressTrackerContext'
+import {
+  ID_PREFIX,
+  ProgressTrackerStepContext,
+  useProgressTrackerContext,
+} from './ProgressTrackerContext'
 import { stepButtonVariant, stepItemVariant } from './ProgressTrackerStep.styles'
 import { ProgressTrackerStepIndicator } from './ProgressTrackerStepIndicator'
 
@@ -28,7 +32,7 @@ export const ProgressTrackerStep = forwardRef<HTMLLIElement, ProgressTrackerStep
       readOnly,
     } = useProgressTrackerContext()
 
-    const stepId = `:progress-tracker-step-${useId()}`
+    const stepId = `${ID_PREFIX}-step-${useId()}`
     const stepIndex = [...steps.keys()].indexOf(stepId)
 
     const disabledAfter = (() => {

--- a/packages/components/progress-tracker/src/ProgressTrackerStep.tsx
+++ b/packages/components/progress-tracker/src/ProgressTrackerStep.tsx
@@ -28,8 +28,7 @@ export const ProgressTrackerStep = forwardRef<HTMLLIElement, ProgressTrackerStep
       readOnly,
     } = useProgressTrackerContext()
 
-    const ID = useId()
-    const stepId = `step-${ID}`
+    const stepId = `:progress-tracker-step-${useId()}`
     const stepIndex = [...steps.keys()].indexOf(stepId)
 
     const disabledAfter = (() => {

--- a/packages/components/progress/package.json
+++ b/packages/components/progress/package.json
@@ -23,7 +23,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-progress": "1.0.3",
     "@spark-ui/use-merge-refs": "^0.4.0",
     "class-variance-authority": "0.7.0"

--- a/packages/components/progress/src/ProgressContext.tsx
+++ b/packages/components/progress/src/ProgressContext.tsx
@@ -13,6 +13,8 @@ export interface ProgressContextValue {
 
 export const ProgressContext = createContext<ProgressContextValue | null>(null)
 
+export const ID_PREFIX = ':progress'
+
 export const useProgress = () => {
   const context = useContext(ProgressContext)
 

--- a/packages/components/progress/src/ProgressLabel.tsx
+++ b/packages/components/progress/src/ProgressLabel.tsx
@@ -1,13 +1,13 @@
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { ComponentPropsWithoutRef, forwardRef, useCallback, useId } from 'react'
 
-import { useProgress } from './ProgressContext'
+import { ID_PREFIX, useProgress } from './ProgressContext'
 
 export type ProgressLabelProps = ComponentPropsWithoutRef<'span'>
 
 export const ProgressLabel = forwardRef<HTMLSpanElement, ProgressLabelProps>(
   ({ id: idProp, children, ...others }, forwardedRef) => {
-    const internalID = `:progress-label-${useId()}`
+    const internalID = `${ID_PREFIX}-label-${useId()}`
     const id = idProp || internalID
 
     const { onLabelId } = useProgress()

--- a/packages/components/progress/src/ProgressLabel.tsx
+++ b/packages/components/progress/src/ProgressLabel.tsx
@@ -7,7 +7,7 @@ export type ProgressLabelProps = ComponentPropsWithoutRef<'span'>
 
 export const ProgressLabel = forwardRef<HTMLSpanElement, ProgressLabelProps>(
   ({ id: idProp, children, ...others }, forwardedRef) => {
-    const internalID = useId()
+    const internalID = `:progress-label-${useId()}`
     const id = idProp || internalID
 
     const { onLabelId } = useProgress()

--- a/packages/components/progress/src/ProgressLabel.tsx
+++ b/packages/components/progress/src/ProgressLabel.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
-import { ComponentPropsWithoutRef, forwardRef, useCallback } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, useCallback, useId } from 'react'
 
 import { useProgress } from './ProgressContext'
 
@@ -8,7 +7,9 @@ export type ProgressLabelProps = ComponentPropsWithoutRef<'span'>
 
 export const ProgressLabel = forwardRef<HTMLSpanElement, ProgressLabelProps>(
   ({ id: idProp, children, ...others }, forwardedRef) => {
-    const id = useId(idProp)
+    const internalID = useId()
+    const id = idProp || internalID
+
     const { onLabelId } = useProgress()
     const rootRef = useCallback(
       (el: HTMLSpanElement) => {

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -24,7 +24,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-label": "2.0.1",
     "@radix-ui/react-radio-group": "1.1.2",
     "@spark-ui/form-field": "^1.5.0",

--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -1,6 +1,5 @@
-import { useId } from '@radix-ui/react-id'
 import { cx } from 'class-variance-authority'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 
 import { useRadioGroup } from './RadioGroupContext'
 import { RadioInput, RadioInputProps } from './RadioInput'

--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -9,8 +9,8 @@ export type RadioProps = RadioInputProps
 
 export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
   ({ className, children, id, disabled: disabledProp, ...others }, ref) => {
-    const innerId = useId()
-    const innerLabelId = useId()
+    const innerId = `:radio-input-${useId()}`
+    const innerLabelId = `:radio-label-${useId()}`
 
     const { intent, disabled, reverse } = useRadioGroup()
 

--- a/packages/components/radio-group/src/Radio.tsx
+++ b/packages/components/radio-group/src/Radio.tsx
@@ -7,10 +7,12 @@ import { RadioLabel } from './RadioLabel'
 
 export type RadioProps = RadioInputProps
 
+const ID_PREFIX = ':radio'
+
 export const Radio = forwardRef<HTMLButtonElement, RadioProps>(
   ({ className, children, id, disabled: disabledProp, ...others }, ref) => {
-    const innerId = `:radio-input-${useId()}`
-    const innerLabelId = `:radio-label-${useId()}`
+    const innerId = `${ID_PREFIX}-input-${useId()}`
+    const innerLabelId = `${ID_PREFIX}-label-${useId()}`
 
     const { intent, disabled, reverse } = useRadioGroup()
 

--- a/packages/components/select/src/SelectContext.tsx
+++ b/packages/components/select/src/SelectContext.tsx
@@ -75,6 +75,8 @@ export type SelectContextProps = PropsWithChildren<{
 
 const SelectContext = createContext<SelectContextState | null>(null)
 
+const ID_PREFIX = ':select'
+
 export const SelectProvider = ({
   children,
   defaultValue,
@@ -101,7 +103,7 @@ export const SelectProvider = ({
   const field = useFormFieldControl()
   const state = field.state || stateProp
 
-  const internalFieldID = `:select-field-${useId()}`
+  const internalFieldID = `${ID_PREFIX}-field-${useId()}`
   const fieldId = field.id || internalFieldID
   const fieldLabelId = field.labelId
   const disabled = field.disabled ?? disabledProp

--- a/packages/components/select/src/SelectContext.tsx
+++ b/packages/components/select/src/SelectContext.tsx
@@ -101,7 +101,7 @@ export const SelectProvider = ({
   const field = useFormFieldControl()
   const state = field.state || stateProp
 
-  const internalFieldID = useId()
+  const internalFieldID = `:select-field-${useId()}`
   const fieldId = field.id || internalFieldID
   const fieldLabelId = field.labelId
   const disabled = field.disabled ?? disabledProp

--- a/packages/components/select/src/SelectContext.tsx
+++ b/packages/components/select/src/SelectContext.tsx
@@ -1,4 +1,3 @@
-import { useId } from '@radix-ui/react-id'
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import {
@@ -9,6 +8,7 @@ import {
   SetStateAction,
   useContext,
   useEffect,
+  useId,
   useState,
 } from 'react'
 
@@ -100,7 +100,9 @@ export const SelectProvider = ({
   // Derivated from FormField context
   const field = useFormFieldControl()
   const state = field.state || stateProp
-  const fieldId = useId(field.id)
+
+  const internalFieldID = useId()
+  const fieldId = field.id || internalFieldID
   const fieldLabelId = field.labelId
   const disabled = field.disabled ?? disabledProp
   const readOnly = field.readOnly ?? readOnlyProp

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -23,7 +23,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@radix-ui/react-id": "1.0.1",
     "@radix-ui/react-switch": "1.0.3",
     "@spark-ui/form-field": "^1.5.0",
     "@spark-ui/icons": "^1.21.6",

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -7,12 +7,14 @@ import { SwitchLabel } from './SwitchLabel'
 
 export type SwitchProps = SwitchInputProps
 
+const ID_PREFIX = ':switch'
+
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ size = 'md', children, className, id, disabled, reverse = false, ...rest }, ref) => {
     const field = useFormFieldControl()
 
-    const labelID = `:switch-label-${useId()}`
-    const innerID = `:switch-input-${useId()}`
+    const labelID = `${ID_PREFIX}-label-${useId()}`
+    const innerID = `${ID_PREFIX}-input-${useId()}`
     const fieldID = field.id || id || innerID
 
     const switchLabel = children && (

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -1,7 +1,6 @@
-import { useId } from '@radix-ui/react-id'
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { cx } from 'class-variance-authority'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 
 import { SwitchInput, SwitchInputProps } from './SwitchInput'
 import { SwitchLabel } from './SwitchLabel'
@@ -12,11 +11,12 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ size = 'md', children, className, id, disabled, reverse = false, ...rest }, ref) => {
     const field = useFormFieldControl()
 
-    const innerId = useId(id)
-    const innerLabelId = useId()
+    const LabelID = useId()
+    const innerID = useId()
+    const fieldID = field.id || id || innerID
 
     const switchLabel = children && (
-      <SwitchLabel disabled={disabled} htmlFor={field.id || innerId} id={innerLabelId}>
+      <SwitchLabel disabled={disabled} htmlFor={fieldID} id={LabelID}>
         {children}
       </SwitchLabel>
     )
@@ -25,14 +25,14 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
       <SwitchInput
         ref={ref}
         size={size}
-        id={field.id || innerId}
+        id={fieldID}
         disabled={disabled}
         /**
          * If the switch doesn't have any direct label (children) then we should try to
          * get an eventual alternative label from FormField.
          * On last resort, we shouldn't forget to define an aria-label attribute.
          */
-        aria-labelledby={children ? innerLabelId : field.labelId}
+        aria-labelledby={children ? LabelID : field.labelId}
         {...rest}
       />
     )

--- a/packages/components/switch/src/Switch.tsx
+++ b/packages/components/switch/src/Switch.tsx
@@ -11,12 +11,12 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ size = 'md', children, className, id, disabled, reverse = false, ...rest }, ref) => {
     const field = useFormFieldControl()
 
-    const LabelID = useId()
-    const innerID = useId()
+    const labelID = `:switch-label-${useId()}`
+    const innerID = `:switch-input-${useId()}`
     const fieldID = field.id || id || innerID
 
     const switchLabel = children && (
-      <SwitchLabel disabled={disabled} htmlFor={fieldID} id={LabelID}>
+      <SwitchLabel disabled={disabled} htmlFor={fieldID} id={labelID}>
         {children}
       </SwitchLabel>
     )
@@ -32,7 +32,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
          * get an eventual alternative label from FormField.
          * On last resort, we shouldn't forget to define an aria-label attribute.
          */
-        aria-labelledby={children ? LabelID : field.labelId}
+        aria-labelledby={children ? labelID : field.labelId}
         {...rest}
       />
     )


### PR DESCRIPTION
**TASK**: #2049 

### Description, Motivation and Context
To avoid duplicate ID issues with compound pattern, we want to prefix our generated IDs, and also to use React `useId` instead of Radix custom implementation, which doesn't seem to be relevant to our usage.

### Types of changes
- [x] 🧠 Refactor