### PR TITLE
fix(combobox): address pointerEvents related bug

### DIFF
--- a/packages/components/dropdown/src/Dropdown.stories.tsx
+++ b/packages/components/dropdown/src/Dropdown.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import { Button } from '@spark-ui/button'
+import { Dialog } from '@spark-ui/dialog'
 import { FormField } from '@spark-ui/form-field'
 import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { Tag } from '@spark-ui/tag'
@@ -585,5 +586,43 @@ export const QAWithButtons: StoryFn = _args => {
         there
       </Button>
     </div>
+  )
+}
+
+export const QAWithDialog: StoryFn = _args => {
+  return (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button>Open</Button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Content size="md">
+          <Dialog.Body className="pb-[200px]">
+            <FormField>
+              <FormField.Label>Some Label</FormField.Label>
+              <Dropdown>
+                <Dropdown.Trigger aria-label="Book">
+                  <Dropdown.Value placeholder="Pick a book" />
+                </Dropdown.Trigger>
+
+                <Dropdown.Popover>
+                  <Dropdown.Items>
+                    <Dropdown.Item value="book-1">To Kill a Mockingbird</Dropdown.Item>
+                    <Dropdown.Item value="book-2">War and Peace</Dropdown.Item>
+                    <Dropdown.Item value="book-3">The Idiot</Dropdown.Item>
+                    <Dropdown.Item value="book-4">A Picture of Dorian Gray</Dropdown.Item>
+                    <Dropdown.Item value="book-5">1984</Dropdown.Item>
+                    <Dropdown.Item value="book-6">Pride and Prejudice</Dropdown.Item>
+                  </Dropdown.Items>
+                </Dropdown.Popover>
+              </Dropdown>
+            </FormField>
+            <Button className="my-md" onClick={() => console.log('hello')}>
+              hello
+            </Button>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
   )
 }

--- a/packages/components/dropdown/src/DropdownItems.tsx
+++ b/packages/components/dropdown/src/DropdownItems.tsx
@@ -9,6 +9,17 @@ interface ItemsProps {
   className?: string
 }
 
+/**
+ * BUGFIX
+ *
+ * 1. The !pointer-events-auto class is needed to prevent a bug
+ *    which cannot be reproduced when running Storybook locally,
+ *    in scenarios such as when a Dropdown is nested within a Dialog,
+ *    the "props" object, containing styles computed by Radix
+ *    may erroneously contain "pointerEvents = 'none'", while the Dropdown is open,
+ *    making it impossible to select a value using a pointer device
+ */
+
 export const Items = forwardRef(
   ({ children, className, ...props }: ItemsProps, forwardedRef: Ref<HTMLUListElement>) => {
     const { isOpen, getMenuProps, hasPopover, setLastInteractionType } = useDropdownContext()
@@ -25,8 +36,9 @@ export const Items = forwardRef(
 
     useLayoutEffect(() => {
       if (!hasPopover) return
+      if (!innerRef.current) return
 
-      if (innerRef.current?.parentElement) {
+      if (innerRef.current.parentElement) {
         innerRef.current.parentElement.style.pointerEvents = isOpen ? '' : 'none'
       }
     }, [isOpen, hasPopover])
@@ -37,7 +49,9 @@ export const Items = forwardRef(
         className={cx(
           className,
           'flex flex-col',
-          isOpen ? 'block' : 'pointer-events-none invisible absolute opacity-0',
+          isOpen
+            ? '!pointer-events-auto block' /* 1 */
+            : 'pointer-events-none invisible absolute opacity-0',
           hasPopover && 'p-lg'
         )}
         {...props}


### PR DESCRIPTION
### Description, Motivation and Context
This PR addresses a bug:
Which cannot be reproduced when running Storybook locally, in scenarios such as when a Dropdown is nested within a Dialog, the "props" object, containing styles computed by Radix may erroneously contain "pointerEvents = 'none'", while the Dropdown is open, making it impossible to select a value using a pointer device