### PR TITLE
fix(select): remove code causing excessive calls to the onValueChange prop

### DIFF
--- a/packages/components/select/src/Select.test.tsx
+++ b/packages/components/select/src/Select.test.tsx
@@ -4,7 +4,7 @@ import { BookmarkFill } from '@spark-ui/icons/dist/icons/BookmarkFill'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vitest } from 'vitest'
 
 import { Select } from '.'
 
@@ -275,6 +275,52 @@ describe('Select', () => {
 
       // Then the selected value has been updated
       expect(getFakeTrigger()).toHaveTextContent('Pride and Prejudice')
+    })
+  })
+
+  describe('onValueChange', () => {
+    beforeEach(vitest.clearAllMocks)
+
+    const onValueChangeSpy = vitest.fn()
+
+    const ControlledImplementation = () => {
+      const [value, setValue] = useState('book-1')
+
+      return (
+        <Select
+          value={value}
+          onValueChange={newValue => {
+            setValue(newValue)
+            onValueChangeSpy()
+          }}
+        >
+          <Select.Trigger aria-label="Book">
+            <Select.Value placeholder="Pick a book" />
+          </Select.Trigger>
+
+          <Select.Items>
+            <Select.Placeholder>--Pick a book--</Select.Placeholder>
+            <Select.Item value="book-1">War and Peace</Select.Item>
+            <Select.Item value="book-2">1984</Select.Item>
+            <Select.Item value="book-3">Pride and Prejudice</Select.Item>
+          </Select.Items>
+        </Select>
+      )
+    }
+
+    it('should only call the onValueChange prop once when value changes', async () => {
+      const user = userEvent.setup()
+
+      render(<ControlledImplementation />)
+
+      await user.selectOptions(getSelect('Book'), 'Pride and Prejudice')
+      expect(onValueChangeSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should only call the onValueChange prop when value changes', async () => {
+      render(<ControlledImplementation />)
+
+      expect(onValueChangeSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/components/select/src/SelectContext.tsx
+++ b/packages/components/select/src/SelectContext.tsx
@@ -111,10 +111,6 @@ export const SelectProvider = ({
   const name = field.name ?? nameProp
   const required = !!(field.isRequired ?? requiredProp)
 
-  useEffect(() => {
-    if (valueProp) setValue(valueProp)
-  }, [valueProp])
-
   /**
    * Indices in a Map are set when an element is added to the Map.
    * If for some reason, in the Select:


### PR DESCRIPTION
**TASK**: #2062 

### Description, Motivation and Context
While using the `Select` component in controlled mode, two issues have been observed:
1. The `onValueChange` prop is executed on initial render, even though the value has not been changed.
2. Each time the value changes, the `onValueChange` prop is executed twice.

Repro ➡ https://stackblitz.com/edit/stackblitz-starters-ulfsq2?file=pagesContent%2Findex.tsx

The problem seems to originate from `packages/components/select/src/SelectContext.tsx`, specifically this piece of code:
```tsx
useEffect(() => {
  if (valueProp) setValue(valueProp)
}, [valueProp, setValue])
```

The weird thing is, when we comment out what's inside the `useEffect`, all the tests still pass. And even when we interact with the component in the browser (in both controlled and uncontrolled modes), it doesn't seem to break anything

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
