### PR TITLE
feat(select): associate label and select elements

### DIFF
--- a/packages/components/select/src/Select.test.tsx
+++ b/packages/components/select/src/Select.test.tsx
@@ -185,6 +185,32 @@ describe('Select', () => {
     })
   })
 
+  describe('usage with FormField', () => {
+    it('should associate label and select element correctly', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <FormField>
+          <FormField.Label>Book</FormField.Label>
+          <Select>
+            <Select.Trigger>
+              <Select.Value placeholder="Pick a book" />
+            </Select.Trigger>
+
+            <Select.Items>
+              <Select.Placeholder>--Pick a book--</Select.Placeholder>
+              <Select.Item value="book-1">War and Peace</Select.Item>
+            </Select.Items>
+          </Select>
+          <FormField.ErrorMessage>You forgot to select a book</FormField.ErrorMessage>
+        </FormField>
+      )
+
+      await user.click(screen.getByText('Book'))
+      expect(getSelect('Book')).toHaveFocus()
+    })
+  })
+
   describe('single selection', () => {
     it('should select item', async () => {
       const user = userEvent.setup()

--- a/packages/components/select/src/SelectItems.tsx
+++ b/packages/components/select/src/SelectItems.tsx
@@ -5,7 +5,7 @@ import { useSelectContext } from './SelectContext'
 
 export const styles = cva(
   [
-    'absolute left-none top-none h-full w-full rounded-lg opacity-0',
+    'absolute left-none top-none size-full rounded-lg opacity-0',
     'min-h-sz-44',
     // outline styles
     'ring-1 outline-none ring-inset focus:ring-2',
@@ -52,6 +52,7 @@ export const Items = forwardRef(
       setValue,
       name,
       required,
+      fieldId,
     } = useSelectContext()
 
     const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -75,6 +76,7 @@ export const Items = forwardRef(
         className={styles({ className, state, disabled, readOnly })}
         value={selectedItem?.value}
         onChange={handleChange}
+        id={fieldId}
         {...rest}
       >
         {children}


### PR DESCRIPTION
### Description, Motivation and Context
Associate `label` and `select` elements, so that when a user clicks on the label associated with a `Select`, the `Select` will receive focus.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Captures
![Kapture 2024-04-23 at 18 13 26](https://github.com/adevinta/spark/assets/51230231/9afd9f53-adb5-425e-9a41-217850a8d6bc)
