### PR TITLE
fix(combobox): fix combobox highlighted index while typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,6 +2318,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -346,6 +346,7 @@ export const ComboboxProvider = ({
           allowCustomValue,
           setSelectedItems: onInternalSelectedItemsChange,
           triggerAreaRef,
+          items: itemsMap,
         })
       : singleSelectionReducer({
           allowCustomValue,

--- a/packages/components/combobox/src/ComboboxItem.tsx
+++ b/packages/components/combobox/src/ComboboxItem.tsx
@@ -70,6 +70,7 @@ const ItemContent = forwardRef(
       item: itemCtx.itemData,
       index: itemCtx.index,
     })
+
     const ref = useMergeRefs(forwardedRef, downshiftRef)
 
     if (!isVisible) return null


### PR DESCRIPTION
### Description, Motivation and Context

- Selecting an item in multiple selection, then typing to filter it out, then pressing Enter, was selecting the hidden item instead of reseting highlightedIndex to -1 (start of the list)

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
