### PR TITLE
fix(combobox): combobox content overflow on smaller screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,6 +2318,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/combobox/src/ComboboxInput.tsx
+++ b/packages/components/combobox/src/ComboboxInput.tsx
@@ -79,7 +79,8 @@ export const Input = forwardRef(
             type="text"
             placeholder={placeholder}
             className={cx(
-              'h-sz-28 shrink-0 flex-grow basis-[80px] text-ellipsis bg-surface px-sm text-body-1 outline-none',
+              'max-w-full shrink-0 grow basis-[80px]',
+              'h-sz-28 text-ellipsis bg-surface px-sm text-body-1 outline-none',
               'disabled:cursor-not-allowed disabled:bg-transparent disabled:text-on-surface/dim-3',
               'read-only:cursor-default read-only:bg-transparent read-only:text-on-surface',
               className

--- a/packages/components/combobox/src/ComboboxTrigger.tsx
+++ b/packages/components/combobox/src/ComboboxTrigger.tsx
@@ -92,14 +92,16 @@ export const Trigger = forwardRef(
             <div
               ref={scrollableAreaRef}
               className={cx(
-                'inline-flex grow items-start gap-sm py-md',
+                'inline-flex min-w-none grow items-start gap-sm py-md',
                 ctx.wrap ? 'flex-wrap' : 'overflow-x-auto p-[2px] u-no-scrollbar'
               )}
             >
               {selectedItems}
               {input}
             </div>
+
             {hasClearButton && clearButton}
+
             {disclosure}
           </div>
         </PopoverAnchor>


### PR DESCRIPTION
### Description, Motivation and Context

It has been reported that on smaller screens, the clear button and/or disclosure button were overflowing the Combobox to the right side.


### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)

### Screenshots - Animations
BEFORE
![Capture d’écran 2024-05-03 à 12 29 17](https://github.com/adevinta/spark/assets/2033710/2344bdb3-6e87-4370-83ce-1a1b2554b62e)

AFTER
![Capture d’écran 2024-05-03 à 12 29 22](https://github.com/adevinta/spark/assets/2033710/8aefe820-ee6f-4395-ad69-ca5b3b23c24e)

