### PR TITLE
fix(combobox): clear internal input value on escape

### DIFF
--- a/packages/components/combobox/src/useCombobox/singleSelectionReducer.ts
+++ b/packages/components/combobox/src/useCombobox/singleSelectionReducer.ts
@@ -19,6 +19,12 @@ export const singleSelectionReducer = ({
     )
 
     switch (type) {
+      case useCombobox.stateChangeTypes.InputKeyDownEscape:
+        if (!changes.selectedItem) {
+          setSelectedItem(null)
+        }
+
+        return changes
       case useCombobox.stateChangeTypes.ItemClick:
       case useCombobox.stateChangeTypes.InputKeyDownEnter:
         if (changes.selectedItem) {


### PR DESCRIPTION
### Description, Motivation and Context

Pressing escape once closes the combobox menu.
Pressing it once more clears the input.

When clearing the input, it is important we also clear the internal state of the input value (if not, focusing back in the input later will restore its value to that of the internal state)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
