### PR TITLE
docs(combobox): fixed typos and invalid props in combobox stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20641,6 +20641,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/packages/components/combobox/src/Combobox.doc.mdx
+++ b/packages/components/combobox/src/Combobox.doc.mdx
@@ -148,7 +148,7 @@ This example showcases case-sensitive filtering.
 
 ### Custom value entry
 
-Combo Box can be configured to allow entering custom values that aren’t included in the list of options.
+Combobox can be configured to allow entering custom values that aren’t included in the list of options.
 
 <Canvas of={stories.CustomValueEntry} />
 

--- a/packages/components/combobox/src/Combobox.stories.tsx
+++ b/packages/components/combobox/src/Combobox.stories.tsx
@@ -465,7 +465,7 @@ export const Statuses: StoryFn = () => {
 export const MultipleSelection: StoryFn = _args => {
   return (
     <div className="pb-[300px]">
-      <Combobox allowCustomValue multiple defaultValue={['book-1', 'book-2']}>
+      <Combobox multiple defaultValue={['book-1', 'book-2']}>
         <Combobox.Trigger>
           <Combobox.LeadingIcon>
             <PenOutline />
@@ -573,7 +573,6 @@ export const MultipleSelectionNoWrap: StoryFn = _args => {
     <div className="pb-[300px]">
       <Combobox
         wrap={false}
-        allowCustomValue
         multiple
         defaultValue={['book-1', 'book-2', 'book-3', 'book-4', 'book-5', 'book-6']}
       >


### PR DESCRIPTION
### Description, Motivation and Context
- fixed "Combo Box" typo in doc.
- removed `allowCustomValue` prop from stories where it was unnecessary.

### Types of changes
- [x] 🧾 Documentation

