### PR TITLE
fix(combobox): apply focus styled to combobox selected items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,6 +2302,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/combobox/src/ComboboxSelectedItems.tsx
+++ b/packages/components/combobox/src/ComboboxSelectedItems.tsx
@@ -4,13 +4,10 @@ import { cx } from 'class-variance-authority'
 import { FocusEvent } from 'react'
 
 import { useComboboxContext } from './ComboboxContext'
+import { ComboboxItem } from './types'
 
-export const SelectedItems = () => {
+const SelectedItem = ({ item: selectedItem, index }: { item: ComboboxItem; index: number }) => {
   const ctx = useComboboxContext()
-
-  if (!ctx.selectedItems.length || !ctx.multiple) {
-    return null
-  }
 
   const isCleanable = !ctx.disabled && !ctx.readOnly
 
@@ -25,72 +22,78 @@ export const SelectedItems = () => {
     }
   }
 
+  const { disabled, ...selectedItemProps } = ctx.getSelectedItemProps({
+    disabled: ctx.disabled || ctx.readOnly,
+    selectedItem,
+    index,
+  })
+
+  const Element = disabled ? 'button' : 'span'
+
   return (
-    <>
-      {ctx.selectedItems.map((selectedItemForRender, index) => {
-        const { disabled, ...selectedItemProps } = ctx.getSelectedItemProps({
-          disabled: ctx.disabled || ctx.readOnly,
-          selectedItem: selectedItemForRender,
-          index,
-        })
+    <Element
+      role="presentation"
+      data-spark-component="combobox-selected-item"
+      key={`selected-item-${index}`}
+      className={cx(
+        'flex h-sz-28 items-center rounded-md bg-neutral-container align-middle',
+        'text-body-2 text-on-neutral-container',
+        'disabled:cursor-not-allowed disabled:opacity-dim-3',
+        'outline-none focus-visible:u-ring-inset',
+        { 'px-md': !isCleanable, 'pl-md': isCleanable }
+      )}
+      {...selectedItemProps}
+      tabIndex={-1}
+      {...(disabled && { disabled: true })}
+      onFocus={handleFocus}
+    >
+      <span
+        className={cx('line-clamp-1 overflow-x-hidden text-ellipsis break-all leading-normal', {
+          'w-max': !ctx.wrap,
+        })}
+      >
+        {selectedItem.text}
+      </span>
+      {ctx.disabled}
+      {isCleanable && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-hidden
+          className="h-full cursor-pointer px-md"
+          onClick={e => {
+            e.stopPropagation()
 
-        const Element = disabled ? 'button' : 'span'
+            const updatedSelectedItems = ctx.selectedItems.filter(
+              item => item.value !== selectedItem.value
+            )
 
-        return (
-          <Element
-            role="presentation"
-            data-spark-component="combobox-selected-item"
-            key={`selected-item-${index}`}
-            className={cx(
-              'flex h-sz-28 items-center rounded-md bg-neutral-container align-middle',
-              'text-body-2 text-on-neutral-container',
-              'disabled:cursor-not-allowed disabled:opacity-dim-3',
-              { 'px-md': !isCleanable, 'pl-md': isCleanable }
-            )}
-            {...selectedItemProps}
-            tabIndex={-1}
-            {...(disabled && { disabled: true })}
-            onFocus={handleFocus}
-          >
-            <span
-              className={cx(
-                'line-clamp-1 overflow-x-hidden text-ellipsis break-all leading-normal',
-                { 'w-max': !ctx.wrap }
-              )}
-            >
-              {selectedItemForRender.text}
-            </span>
-            {ctx.disabled}
-            {isCleanable && (
-              <button
-                type="button"
-                tabIndex={-1}
-                aria-hidden
-                className="h-full cursor-pointer px-md"
-                onClick={e => {
-                  e.stopPropagation()
+            ctx.setSelectedItems(updatedSelectedItems)
 
-                  const updatedSelectedItems = ctx.selectedItems.filter(
-                    item => item.value !== selectedItemForRender.value
-                  )
-
-                  ctx.setSelectedItems(updatedSelectedItems)
-
-                  if (ctx.innerInputRef.current) {
-                    ctx.innerInputRef.current.focus({ preventScroll: true })
-                  }
-                }}
-              >
-                <Icon size="sm">
-                  <DeleteOutline />
-                </Icon>
-              </button>
-            )}
-          </Element>
-        )
-      })}
-    </>
+            if (ctx.innerInputRef.current) {
+              ctx.innerInputRef.current.focus({ preventScroll: true })
+            }
+          }}
+        >
+          <Icon size="sm">
+            <DeleteOutline />
+          </Icon>
+        </button>
+      )}
+    </Element>
   )
+}
+
+export const SelectedItems = () => {
+  const ctx = useComboboxContext()
+
+  return ctx.multiple && ctx.selectedItems.length ? (
+    <>
+      {ctx.selectedItems.map((item, index) => (
+        <SelectedItem item={item} index={index} />
+      ))}
+    </>
+  ) : null
 }
 
 SelectedItems.displayName = 'Combobox.SelectedItems'


### PR DESCRIPTION
**TASK**: #2142 

### Description, Motivation and Context

Focus styles for selected items were missing, resulting in different outline styles depending on the browser.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles


### Screenshots - Animations

https://github.com/adevinta/spark/assets/2033710/041eb132-140e-416b-b389-b52502d37689


