### PR TITLE
feat(link-box): added Linkbox.Link to raised components inside the box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,6 +2302,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/link-box/src/LinkBox.doc.mdx
+++ b/packages/components/link-box/src/LinkBox.doc.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
-import { ArgTypes } from '@storybook/blocks';
+import { ArgTypes } from '@storybook/blocks'
 
 import { LinkBox } from '.'
 
@@ -20,7 +20,7 @@ npm install @spark-ui/link-box
 ## Import
 
 ```tsx
-import { LinkBox } from "@spark-ui/link-box"
+import { LinkBox } from '@spark-ui/link-box'
 ```
 
 ## Props
@@ -37,6 +37,8 @@ Simply wrapping an entire component in an `a` tag may seem convenient for linkin
 
 ### Nesting
 
-Any nested links and buttons inside `LinkBox` are elevated to the top using `z-index` to ensure proper navigation between links.
+If your linkbox contains interactive elements inside of it, wrap them with `LinkBox.Raised`.
+
+It will raise their `z-index` to stay above the main link of your `LinkBox`.
 
 <Canvas of={stories.Nesting} />

--- a/packages/components/link-box/src/LinkBox.stories.tsx
+++ b/packages/components/link-box/src/LinkBox.stories.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@spark-ui/icon'
 import { IconButton } from '@spark-ui/icon-button'
 import { FavoriteOutline } from '@spark-ui/icons/dist/icons/FavoriteOutline'
+import { TextLink } from '@spark-ui/text-link'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { LinkBox } from '.'
@@ -22,9 +23,9 @@ export const Default: StoryFn = _args => (
 
         <div className="space-y-none">
           <h2>
-            <LinkBox.Overlay className="line-clamp-1 text-headline-2" href="#">
+            <LinkBox.Link className="line-clamp-1 text-headline-2" href="#">
               Title
-            </LinkBox.Overlay>
+            </LinkBox.Link>
           </h2>
 
           <p className="line-clamp-2 text-body-1">Description</p>
@@ -36,32 +37,42 @@ export const Default: StoryFn = _args => (
 
 export const Nesting: StoryFn = _args => (
   <div className="max-w-sz-256">
-    <LinkBox className="space-y-md" asChild>
-      <article>
+    <LinkBox asChild>
+      <article className="space-y-md">
         <div className="relative aspect-square w-full overflow-hidden rounded-md bg-neutral shadow-md">
           <img className="size-full" src="https://picsum.photos/200/200" alt="Card image" />
 
-          <div className="absolute bottom-md right-md z-raised">
-            <IconButton shape="pill" aria-label="Like">
+          <LinkBox.Raised>
+            <IconButton shape="pill" aria-label="Like" className="!absolute bottom-md right-md">
               <Icon>
                 <FavoriteOutline />
               </Icon>
             </IconButton>
-          </div>
+          </LinkBox.Raised>
         </div>
 
         <div className="space-y-none">
           <h2>
-            <LinkBox.Overlay className="line-clamp-1 text-headline-2" href="#">
+            <LinkBox.Link className="line-clamp-1 text-headline-2" href="#">
               Title
-            </LinkBox.Overlay>
+            </LinkBox.Link>
           </h2>
 
-          <p className="line-clamp-2 text-body-1">Description</p>
-
-          <a className="text-body-2" href="/">
-            Read more
-          </a>
+          <p className="text-body-1">
+            <span>Read about </span>
+            <LinkBox.Raised>
+              <TextLink href="https://en.wikipedia.org/wiki/Kitten" target="_blank">
+                kittens
+              </TextLink>
+            </LinkBox.Raised>
+            <span> and </span>
+            <LinkBox.Raised>
+              <TextLink href="https://en.wikipedia.org/wiki/Puppy" target="_blank">
+                puppies
+              </TextLink>
+            </LinkBox.Raised>
+            <span>. </span>
+          </p>
         </div>
       </article>
     </LinkBox>

--- a/packages/components/link-box/src/LinkBox.test.tsx
+++ b/packages/components/link-box/src/LinkBox.test.tsx
@@ -9,7 +9,7 @@ describe('LinkOverlay', () => {
       <LinkBox asChild>
         <article>
           <h2>
-            <LinkBox.Overlay href="#">Title</LinkBox.Overlay>
+            <LinkBox.Link href="#">Title</LinkBox.Link>
           </h2>
         </article>
       </LinkBox>

--- a/packages/components/link-box/src/LinkBox.tsx
+++ b/packages/components/link-box/src/LinkBox.tsx
@@ -14,10 +14,7 @@ export const LinkBox = forwardRef<HTMLDivElement, LinkBoxProps>(
       <Component
         ref={ref}
         data-spark-component="link-box"
-        className={cx(
-          'relative [&_a[href]:not([data-spark-component="link-overlay"])]:relative [&_a[href]:not([data-spark-component="link-overlay"])]:z-raised [&_button]:relative [&_button]:z-raised',
-          className
-        )}
+        className={cx('relative', className)}
         {...props}
       />
     )

--- a/packages/components/link-box/src/LinkBoxLink.tsx
+++ b/packages/components/link-box/src/LinkBoxLink.tsx
@@ -2,18 +2,18 @@ import { Slot } from '@spark-ui/slot'
 import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
-export interface LinkOverlayProps extends ComponentPropsWithoutRef<'a'> {
+export interface LinkBoxLinkProps extends ComponentPropsWithoutRef<'a'> {
   asChild?: boolean
 }
 
-export const LinkOverlay = forwardRef<HTMLAnchorElement, LinkOverlayProps>(
+export const LinkBoxLink = forwardRef<HTMLAnchorElement, LinkBoxLinkProps>(
   ({ className, asChild, ...props }, ref) => {
     const Component = asChild ? Slot : 'a'
 
     return (
       <Component
         ref={ref}
-        data-spark-component="link-overlay"
+        data-spark-component="link-box-link"
         className={cx(
           "static before:absolute before:left-none before:top-none before:z-base before:block before:size-full before:content-['']",
           className
@@ -24,4 +24,4 @@ export const LinkOverlay = forwardRef<HTMLAnchorElement, LinkOverlayProps>(
   }
 )
 
-LinkOverlay.displayName = 'LinkBox.Overlay'
+LinkBoxLink.displayName = 'LinkBox.Link'

--- a/packages/components/link-box/src/LinkBoxRaised.tsx
+++ b/packages/components/link-box/src/LinkBoxRaised.tsx
@@ -1,0 +1,14 @@
+import { Slot } from '@spark-ui/slot'
+import { cx } from 'class-variance-authority'
+import { ReactNode } from 'react'
+
+export interface LinkBoxRaisedProps {
+  className?: string
+  children: ReactNode
+}
+
+export const LinkBoxRaised = ({ className, ...props }: LinkBoxRaisedProps) => {
+  return <Slot className={cx('relative z-raised', className)} {...props} />
+}
+
+LinkBoxRaised.displayName = 'LinkBox.Raised'

--- a/packages/components/link-box/src/index.ts
+++ b/packages/components/link-box/src/index.ts
@@ -1,14 +1,17 @@
 import type { FC } from 'react'
 
 import { LinkBox as Root, LinkBoxProps } from './LinkBox'
-import { LinkOverlay } from './LinkOverlay'
+import { LinkBoxLink } from './LinkBoxLink'
+import { LinkBoxRaised } from './LinkBoxRaised'
 
 export const LinkBox: FC<LinkBoxProps> & {
-  Overlay: typeof LinkOverlay
-} = Object.assign(Root, { Overlay: LinkOverlay })
+  Link: typeof LinkBoxLink
+  Raised: typeof LinkBoxRaised
+} = Object.assign(Root, { Link: LinkBoxLink, Raised: LinkBoxRaised })
 
 LinkBox.displayName = 'LinkBox'
-LinkBox.Overlay.displayName = 'LinkBox.Overlay'
+LinkBox.Link.displayName = 'LinkBox.Link'
+LinkBox.Raised.displayName = 'LinkBox.Raised'
 
 export { type LinkBoxProps } from './LinkBox'
-export { type LinkOverlayProps } from './LinkOverlay'
+export { type LinkBoxLinkProps } from './LinkBoxLink'


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #2132 

### Description, Motivation and Context

We were not sure about using css selectors to raise nested links/elements on top of the overlay. Instead we introduce `LinkBox.Raised` to explicitely flag which components should remain on top.

### Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality)


