### PR TITLE
feat(snackbar): add option to force action btn display on new line

### DIFF
--- a/packages/components/snackbar/src/Snackbar.doc.mdx
+++ b/packages/components/snackbar/src/Snackbar.doc.mdx
@@ -99,6 +99,8 @@ For both cases there is a specific `onClose` handler which is called when snackb
 
 To add an action to the snackbar use `onAction` and `actionLabel` options from `addSnackbar`, or use `<Snackbar.ItemAction />` within your custom `<Snackbar.Item />`. After interacting with it the snackbar will close automatically.
 
+This action button can also be forced to display on a new line, using the `forceActionOnNewline` option from `addSnackbar`, or `<Snackbar.Item />` associated prop.
+
 Keep in mind that users might miss snackbar actions and thus these shouldn't concern important things. In such case please use instead the `AlertDialog` component.
 
 For accessibility reasons **snackbars won't dismiss automatically when an action is provided**.

--- a/packages/components/snackbar/src/Snackbar.doc.mdx
+++ b/packages/components/snackbar/src/Snackbar.doc.mdx
@@ -99,7 +99,7 @@ For both cases there is a specific `onClose` handler which is called when snackb
 
 To add an action to the snackbar use `onAction` and `actionLabel` options from `addSnackbar`, or use `<Snackbar.ItemAction />` within your custom `<Snackbar.Item />`. After interacting with it the snackbar will close automatically.
 
-This action button can also be forced to display on a new line, using the `forceActionOnNewline` option from `addSnackbar`, or `<Snackbar.Item />` associated prop.
+This action button can also be forced to display on a new line, using the `actionOnNewline` option from `addSnackbar`, or `<Snackbar.Item />` associated prop.
 
 Keep in mind that users might miss snackbar actions and thus these shouldn't concern important things. In such case please use instead the `AlertDialog` component.
 

--- a/packages/components/snackbar/src/Snackbar.stories.tsx
+++ b/packages/components/snackbar/src/Snackbar.stories.tsx
@@ -217,17 +217,32 @@ export const Action: StoryObj = {
       <div>
         <Snackbar />
 
-        <Button
-          onClick={() =>
-            addSnackbar({
-              message: "You're done!",
-              actionLabel: 'Undo',
-              onAction: () => console.log('Undone'),
-            })
-          }
-        >
-          Display snackbar
-        </Button>
+        <div className="grid grid-cols-1 gap-xl md:grid-cols-2">
+          <Button
+            onClick={() =>
+              addSnackbar({
+                message: "You're done!",
+                actionLabel: 'Undo',
+                onAction: () => console.log('Undone'),
+              })
+            }
+          >
+            Display snackbar with action (default)
+          </Button>
+
+          <Button
+            onClick={() =>
+              addSnackbar({
+                message: "You're done! But maybe you should care about what you just did?",
+                actionLabel: 'Undo',
+                onAction: () => console.log('Undone'),
+                forceActionOnNewline: true,
+              })
+            }
+          >
+            Display snackbar with action on a new line
+          </Button>
+        </div>
       </div>
     )
   },
@@ -239,6 +254,7 @@ const handleClick = () => addSnackbar({
   message: "You're done!",
   actionLabel: 'Undo',
   onAction: () => console.log('Undone'),
+  forceActionOnNewline,
 })\n
 return (
   <div>

--- a/packages/components/snackbar/src/Snackbar.stories.tsx
+++ b/packages/components/snackbar/src/Snackbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@spark-ui/button'
 import { FavoriteFill } from '@spark-ui/icons/dist/icons/FavoriteFill'
-import { Meta, StoryObj } from '@storybook/react'
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
 
 import { addSnackbar, type AddSnackbarArgs, Snackbar } from '.'
 
@@ -211,6 +211,29 @@ return (
   },
 }
 
+export const QAWithNewLineAction: StoryFn = _args => (
+  <div>
+    <Snackbar />
+
+    <Button
+      onClick={() =>
+        addSnackbar({
+          message:
+            'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Tempora voluptatum cupiditate ut natus distinctio illum modi, id mollitia sequi dolorem nostrum autem suscipit eius sapiente vitae ipsum amet doloribus praesentium.',
+          actionLabel: 'Undo',
+          onAction: () => console.log('Undone'),
+          icon: <FavoriteFill />,
+          isClosable: true,
+          actionOnNewline: true,
+          timeout: null,
+        })
+      }
+    >
+      Display snackbar
+    </Button>
+  </div>
+)
+
 export const Action: StoryObj = {
   render: () => {
     return (
@@ -236,7 +259,7 @@ export const Action: StoryObj = {
                 message: "You're done! But maybe you should care about what you just did?",
                 actionLabel: 'Undo',
                 onAction: () => console.log('Undone'),
-                forceActionOnNewline: true,
+                actionOnNewline: true,
               })
             }
           >
@@ -254,7 +277,7 @@ const handleClick = () => addSnackbar({
   message: "You're done!",
   actionLabel: 'Undo',
   onAction: () => console.log('Undone'),
-  forceActionOnNewline,
+  actionOnNewline,
 })\n
 return (
   <div>

--- a/packages/components/snackbar/src/Snackbar.test.tsx
+++ b/packages/components/snackbar/src/Snackbar.test.tsx
@@ -206,7 +206,7 @@ describe('Snackbar', () => {
       const props = {
         onAction: vi.fn(),
         actionLabel: 'Undo',
-        forceActionOnNewline: true,
+        actionOnNewline: true,
       }
 
       render(

--- a/packages/components/snackbar/src/Snackbar.test.tsx
+++ b/packages/components/snackbar/src/Snackbar.test.tsx
@@ -206,6 +206,7 @@ describe('Snackbar', () => {
       const props = {
         onAction: vi.fn(),
         actionLabel: 'Undo',
+        forceActionOnNewline: true,
       }
 
       render(

--- a/packages/components/snackbar/src/SnackbarItem.styles.ts
+++ b/packages/components/snackbar/src/SnackbarItem.styles.ts
@@ -80,11 +80,11 @@ export const snackbarItemVariant = cva(
        * Force action button displaying on a new line
        * @default false
        */
-      forceActionOnNewline: {
+      actionOnNewline: {
         true: [
           'grid-rows-[52px_1fr_52px]',
           'grid-cols-[min-content_1fr_min-content]',
-          "[grid-template-areas:'icon_message_close'_'._message_.'_'._._action']",
+          "[grid-template-areas:'icon_message_close'_'._message_.'_'action_action_action']",
         ],
         false: [
           'grid-rows-[52px_1fr]',
@@ -97,7 +97,7 @@ export const snackbarItemVariant = cva(
     defaultVariants: {
       design: 'filled',
       intent: 'neutral',
-      forceActionOnNewline: false,
+      actionOnNewline: false,
     },
   }
 )

--- a/packages/components/snackbar/src/SnackbarItem.styles.ts
+++ b/packages/components/snackbar/src/SnackbarItem.styles.ts
@@ -5,7 +5,7 @@ import { filledVariants, tintedVariants } from './snackbarVariants'
 export const snackbarItemVariant = cva(
   [
     'col-start-1 row-start-1',
-    'inline-flex items-center gap-md',
+    'inline-grid items-center',
     'px-md',
     'rounded-md shadow',
     'max-w-[600px]',
@@ -76,11 +76,28 @@ export const snackbarItemVariant = cva(
         accent: '',
         inverse: '',
       },
+      /**
+       * Force action button displaying on a new line
+       * @default false
+       */
+      forceActionOnNewline: {
+        true: [
+          'grid-rows-[52px_1fr_52px]',
+          'grid-cols-[min-content_1fr_min-content]',
+          "[grid-template-areas:'icon_message_close'_'._message_.'_'._._action']",
+        ],
+        false: [
+          'grid-rows-[52px_1fr]',
+          'grid-cols-[min-content_1fr_min-content_min-content]',
+          "[grid-template-areas:'icon_message_action_close'_'._message_._.']",
+        ],
+      },
     },
     compoundVariants: [...filledVariants, ...tintedVariants],
     defaultVariants: {
       design: 'filled',
       intent: 'neutral',
+      forceActionOnNewline: false,
     },
   }
 )

--- a/packages/components/snackbar/src/SnackbarItem.tsx
+++ b/packages/components/snackbar/src/SnackbarItem.tsx
@@ -40,6 +40,11 @@ export interface SnackbarItemValue extends SnackbarItemVariantProps {
    * Handler that is called when the action button is pressed.
    */
   onAction?: () => void
+  /**
+   * If `true` the action button will be displayed on a new line.
+   * @default false
+   */
+  forceActionOnNewline?: boolean
 }
 
 export interface SnackbarItemProps
@@ -72,6 +77,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
       'aria-details': ariaDetails,
       design: designProp,
       intent: intentProp,
+      forceActionOnNewline: forceActionOnNewlineProp,
       className,
       children,
       ...rest
@@ -93,6 +99,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
     const { message, icon, isClosable, onAction, actionLabel } = toast.content
     const intent = intentProp ?? toast.content.intent
     const design = designProp ?? toast.content.design
+    const forceActionOnNewline = forceActionOnNewlineProp ?? toast.content.forceActionOnNewline
 
     const ariaProps = {
       ariaLabel,
@@ -136,7 +143,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
           // Remove snackbar when the exiting animation completes
           onAnimationEnd: () => state.remove(toast.key),
         })}
-        className={snackbarItemVariant({ design, intent, className })}
+        className={snackbarItemVariant({ design, intent, forceActionOnNewline, className })}
       >
         {/* 1. ICON */}
         {renderSubComponent(iconFromChildren, icon ? SnackbarItemIcon : null, {
@@ -144,7 +151,11 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
         })}
 
         {/* 2. MESSAGE */}
-        <p className="px-md py-lg text-body-2" {...titleProps}>
+        <p
+          className="row-span-3 px-md py-lg text-body-2"
+          style={{ gridArea: 'message' }}
+          {...titleProps}
+        >
           {message}
         </p>
 

--- a/packages/components/snackbar/src/SnackbarItem.tsx
+++ b/packages/components/snackbar/src/SnackbarItem.tsx
@@ -44,7 +44,7 @@ export interface SnackbarItemValue extends SnackbarItemVariantProps {
    * If `true` the action button will be displayed on a new line.
    * @default false
    */
-  forceActionOnNewline?: boolean
+  actionOnNewline?: boolean
 }
 
 export interface SnackbarItemProps
@@ -77,7 +77,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
       'aria-details': ariaDetails,
       design: designProp,
       intent: intentProp,
-      forceActionOnNewline: forceActionOnNewlineProp,
+      actionOnNewline: actionOnNewlineProp,
       className,
       children,
       ...rest
@@ -99,7 +99,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
     const { message, icon, isClosable, onAction, actionLabel } = toast.content
     const intent = intentProp ?? toast.content.intent
     const design = designProp ?? toast.content.design
-    const forceActionOnNewline = forceActionOnNewlineProp ?? toast.content.forceActionOnNewline
+    const actionOnNewline = actionOnNewlineProp ?? toast.content.actionOnNewline
 
     const ariaProps = {
       ariaLabel,
@@ -143,7 +143,7 @@ export const SnackbarItem = forwardRef<HTMLDivElement, PropsWithChildren<Snackba
           // Remove snackbar when the exiting animation completes
           onAnimationEnd: () => state.remove(toast.key),
         })}
-        className={snackbarItemVariant({ design, intent, forceActionOnNewline, className })}
+        className={snackbarItemVariant({ design, intent, actionOnNewline, className })}
       >
         {/* 1. ICON */}
         {renderSubComponent(iconFromChildren, icon ? SnackbarItemIcon : null, {

--- a/packages/components/snackbar/src/SnackbarItemAction.tsx
+++ b/packages/components/snackbar/src/SnackbarItemAction.tsx
@@ -43,7 +43,8 @@ export const SnackbarItemAction = forwardRef<HTMLButtonElement, SnackbarItemActi
           onClick?.(e)
           state.close(toast.key)
         }}
-        className={cx('flex-none', className)}
+        style={{ gridArea: 'action', ...rest.style }}
+        className={cx('ml-md', className)}
         {...rest}
       >
         {children}

--- a/packages/components/snackbar/src/SnackbarItemAction.tsx
+++ b/packages/components/snackbar/src/SnackbarItemAction.tsx
@@ -44,7 +44,7 @@ export const SnackbarItemAction = forwardRef<HTMLButtonElement, SnackbarItemActi
           state.close(toast.key)
         }}
         style={{ gridArea: 'action', ...rest.style }}
-        className={cx('ml-md', className)}
+        className={cx('ml-md justify-self-end', className)}
         {...rest}
       >
         {children}

--- a/packages/components/snackbar/src/SnackbarItemClose.tsx
+++ b/packages/components/snackbar/src/SnackbarItemClose.tsx
@@ -48,7 +48,8 @@ export const SnackbarItemClose = forwardRef<HTMLButtonElement, SnackbarItemClose
           onClick?.(e)
           state.close(toast.key)
         }}
-        className={cx('flex-none', className)}
+        style={{ gridArea: 'close', ...rest.style }}
+        className={cx('ml-md justify-self-end', className)}
         {...rest}
       >
         <Icon size="sm">

--- a/packages/components/snackbar/src/SnackbarItemIcon.tsx
+++ b/packages/components/snackbar/src/SnackbarItemIcon.tsx
@@ -9,7 +9,12 @@ export const SnackbarItemIcon = ({
   className,
   ...rest
 }: SnackbarItemIconProps): ReactElement => (
-  <Icon size="sm" className={cx('ml-md flex-none', className)} {...rest}>
+  <Icon
+    size="md"
+    className={cx('mx-md', className)}
+    style={{ gridArea: 'icon', ...rest.style }}
+    {...rest}
+  >
     {children}
   </Icon>
 )


### PR DESCRIPTION
**TASK**: #2147 

### Description, Motivation and Context
Following design specs update, we want to improve item layout following way:
![Image](https://github.com/adevinta/spark/assets/66770550/3379fba4-b50d-4920-ac59-283f4ddda4f3)

For more infos: https://www.figma.com/design/0QchRdipAVuvVoDfTjLrgQ/Component-Specs-of-Spark?node-id=43448-28117&t=7KNS8UY1D2Fu3ifo-4

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/40b95906-7111-4eaf-a393-0f7a861260d9)
