### PR TITLE
docs(link-box): added props tables to linkBox docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/link-box/src/LinkBox.doc.mdx
+++ b/packages/components/link-box/src/LinkBox.doc.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 
 import { LinkBox } from '.'
 
@@ -25,7 +25,22 @@ import { LinkBox } from '@spark-ui/link-box'
 
 ## Props
 
-<ArgTypes of={LinkBox} />
+<ArgTypes
+  of={LinkBox}
+  description="Contains all the parts of a LinkBox."
+  subcomponents={{
+    'LinkBox.Link': {
+      of: LinkBox.Link,
+      description:
+        'Main link of the link box. A single LinkBox must contain only one LinkBox.Link.',
+    },
+    'LinkBox.Raised': {
+      of: LinkBox.Raised,
+      description:
+        'If your LinkBox contains others links or interactive elements, wrap them with LinkBox.Raised to keep them on top of the LinkBox overlay.',
+    },
+  }}
+/>
 
 ## Usage
 


### PR DESCRIPTION
### Description, Motivation and Context
I forgot to add the `LinkBox` compound `ArgTypes` (props table)

### Types of changes
- [x] 🧾 Documentation
