### PR TITLE
feat(combobox): improved UX of default combobox filtering behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/combobox/src/Combobox.doc.mdx
+++ b/packages/components/combobox/src/Combobox.doc.mdx
@@ -138,14 +138,6 @@ Use `open` and `onOpenChange` props to control the opened state of the combobox 
 
 <Canvas of={stories.Controlled} />
 
-### Custom filtering
-
-Disable `autoFilter` to implement your own logic to filter out items depending on the inputValue (or some external logic).
-
-This example showcases case-sensitive filtering.
-
-<Canvas of={stories.FilteringManual} />
-
 ### Custom value entry
 
 Combobox can be configured to allow typing custom values that aren’t included in the list of options.
@@ -163,6 +155,16 @@ Use `disabled` on the root component to disable the combobox entirely.
 Use `disabled` on individual `Combobox.Item` to disable them.
 
 <Canvas of={stories.DisabledItem} />
+
+### Filtering
+
+By default, `filtering` is set to `auto` and will only filter items when the user is typing.
+
+Set it to `none` to disabled item filtering (you can then implement your own filtering logic).
+
+Set it to `strict` to filter items based on the input value, even when the user is not typing.
+
+<Canvas of={stories.Filtering} />
 
 ### Groups
 

--- a/packages/components/combobox/src/Combobox.stories.tsx
+++ b/packages/components/combobox/src/Combobox.stories.tsx
@@ -106,7 +106,7 @@ export const Controlled: StoryFn = () => {
         onOpenChange={setOpen}
         value={value}
         onValueChange={setValue}
-        autoFilter={false}
+        filtering="none"
       >
         <Combobox.Trigger className="grow">
           <Combobox.LeadingIcon>
@@ -230,47 +230,36 @@ export const Disabled: StoryFn = _args => {
   )
 }
 
-export const FilteringManual: StoryFn = () => {
-  const items = {
-    'book-1': 'To Kill a Mockingbird',
-    'book-2': 'War and Peace',
-    'book-3': 'The Idiot',
-    'book-4': 'A Picture of Dorian Gray',
-    'book-5': '1984',
-    'book-6': 'Pride and Prejudice',
-  } as const
-
-  const [inputValue, setInputValue] = useState('')
-
-  const filteredItems = Object.keys(items).reduce((acc: Record<string, string>, key: string) => {
-    const text: string = items[key as keyof typeof items]
-    const match = text.includes(inputValue)
-
-    return match ? { ...acc, [key]: text } : acc
-  }, {})
+export const Filtering: StoryFn = () => {
+  const [filtering, setFiltering] = useState<'auto' | 'none' | 'strict'>('auto')
 
   return (
     <div className="pb-[300px]">
-      <Combobox autoFilter={false}>
+      <RadioGroup
+        orientation="horizontal"
+        defaultValue="auto"
+        onValueChange={value => setFiltering(value as typeof filtering)}
+        className="mb-lg"
+      >
+        <RadioGroup.Radio value="auto">Auto (default)</RadioGroup.Radio>
+        <RadioGroup.Radio value="none">None</RadioGroup.Radio>
+        <RadioGroup.Radio value="strict">Strict</RadioGroup.Radio>
+      </RadioGroup>
+
+      <Combobox filtering={filtering}>
         <Combobox.Trigger>
-          <Combobox.Input
-            aria-label="Book"
-            placeholder="Pick a book"
-            value={inputValue}
-            onValueChange={setInputValue}
-          />
+          <Combobox.Input aria-label="Book" placeholder="Pick a book" />
         </Combobox.Trigger>
 
         <Combobox.Popover>
           <Combobox.Items>
             <Combobox.Empty>No results found</Combobox.Empty>
-            {Object.entries(filteredItems).map(([value, text]) => {
-              return (
-                <Combobox.Item value={value} key={value}>
-                  {text}
-                </Combobox.Item>
-              )
-            })}
+            <Combobox.Item value="book-1">To Kill a Mockingbird</Combobox.Item>
+            <Combobox.Item value="book-2">War and Peace</Combobox.Item>
+            <Combobox.Item value="book-3">The Idiot</Combobox.Item>
+            <Combobox.Item value="book-4">A Picture of Dorian Gray</Combobox.Item>
+            <Combobox.Item value="book-5">1984</Combobox.Item>
+            <Combobox.Item value="book-6">Pride and Prejudice</Combobox.Item>
           </Combobox.Items>
         </Combobox.Popover>
       </Combobox>
@@ -534,7 +523,7 @@ export const MultipleSelectionControlled: StoryFn = () => {
 
       <Combobox
         multiple
-        autoFilter={false}
+        filtering="none"
         value={value}
         onValueChange={setValue}
         open={open}

--- a/packages/components/combobox/src/ComboboxInput.tsx
+++ b/packages/components/combobox/src/ComboboxInput.tsx
@@ -62,6 +62,7 @@ export const Input = forwardRef(
       onKeyDown: event => {
         multiselectInputProps.onKeyDown?.(event)
         ctx.setLastInteractionType('keyboard')
+        ctx.setIsTyping(true)
       },
       /**
        *

--- a/packages/components/combobox/src/ComboboxItem.tsx
+++ b/packages/components/combobox/src/ComboboxItem.tsx
@@ -66,6 +66,7 @@ const ItemContent = forwardRef(
     const itemCtx = useComboboxItemContext()
 
     const isVisible = !!ctx.filteredItemsMap.get(value)
+
     const { ref: downshiftRef, ...downshiftItemProps } = ctx.getItemProps({
       item: itemCtx.itemData,
       index: itemCtx.index,

--- a/packages/components/combobox/src/tests/multipleSelection.test.tsx
+++ b/packages/components/combobox/src/tests/multipleSelection.test.tsx
@@ -127,7 +127,7 @@ describe('Combobox', () => {
 
       // Given a combobox that allows custom value and has a selected item
       render(
-        <Combobox multiple allowCustomValue defaultValue={['book-1', 'book-2']} autoFilter={false}>
+        <Combobox multiple allowCustomValue defaultValue={['book-1', 'book-2']} filtering="none">
           <Combobox.Trigger>
             <Combobox.SelectedItems />
             <Combobox.Input aria-label="Book" placeholder="Pick a book" />
@@ -336,7 +336,7 @@ describe('Combobox', () => {
         const [value, setValue] = useState(['book-1'])
 
         return (
-          <Combobox multiple value={value} onValueChange={setValue} autoFilter={false}>
+          <Combobox multiple value={value} onValueChange={setValue} filtering="none">
             <Combobox.Trigger>
               <Combobox.SelectedItems />
               <Combobox.Input aria-label="Book" />

--- a/packages/components/combobox/src/tests/singleSelection.test.tsx
+++ b/packages/components/combobox/src/tests/singleSelection.test.tsx
@@ -14,7 +14,7 @@ describe('Combobox', () => {
 
       // Given a combobox with no selected value yet
       render(
-        <Combobox autoFilter={false}>
+        <Combobox filtering="none">
           <Combobox.Trigger>
             <Combobox.Input aria-label="Book" placeholder="Pick a book" />
           </Combobox.Trigger>
@@ -106,7 +106,7 @@ describe('Combobox', () => {
         const [value, setValue] = useState<string | undefined>('book-1')
 
         return (
-          <Combobox value={value} onValueChange={setValue} autoFilter={false}>
+          <Combobox value={value} onValueChange={setValue} filtering="none">
             <Combobox.Trigger>
               <Combobox.Input aria-label="Book" />
             </Combobox.Trigger>
@@ -137,12 +137,12 @@ describe('Combobox', () => {
       expect(getItem('Pride and Prejudice')).toHaveAttribute('aria-selected', 'true')
     })
 
-    it('should select item using autoFilter (keyboard)', async () => {
+    it('should select item using auto filtering (keyboard)', async () => {
       const user = userEvent.setup()
 
       // Given a combobox with no selected value yet
       render(
-        <Combobox autoFilter>
+        <Combobox filtering="auto">
           <Combobox.Trigger>
             <Combobox.Input aria-label="Book" placeholder="Pick a book" />
           </Combobox.Trigger>
@@ -166,7 +166,42 @@ describe('Combobox', () => {
       // Then placeholder is replaced by the selected value
       expect(screen.getByDisplayValue('Pride and Prejudice')).toBeInTheDocument()
 
-      // Then the proper item is selected
+      // Then the proper item is selected and other items are still rendered
+      expect(queryItem('War and Peace')).toBeInTheDocument()
+      expect(queryItem('1984')).toBeInTheDocument()
+      expect(getItem('Pride and Prejudice')).toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('should select item using strict filtering (keyboard)', async () => {
+      const user = userEvent.setup()
+
+      // Given a combobox with no selected value yet
+      render(
+        <Combobox filtering="strict">
+          <Combobox.Trigger>
+            <Combobox.Input aria-label="Book" placeholder="Pick a book" />
+          </Combobox.Trigger>
+          <Combobox.Popover>
+            <Combobox.Items>
+              <Combobox.Item value="book-1">War and Peace</Combobox.Item>
+              <Combobox.Item value="book-2">1984</Combobox.Item>
+              <Combobox.Item value="book-3">Pride and Prejudice</Combobox.Item>
+            </Combobox.Items>
+          </Combobox.Popover>
+        </Combobox>
+      )
+
+      // Then placeholder should be displayed
+      expect(getInput('Book').getAttribute('placeholder')).toBe('Pick a book')
+
+      // When the user type "pri" to filter first item matching, then select it
+      await user.click(getInput('Book'))
+      await user.keyboard('{p}{r}{i}{ArrowDown}{Enter}')
+
+      // Then placeholder is replaced by the selected value
+      expect(screen.getByDisplayValue('Pride and Prejudice')).toBeInTheDocument()
+
+      // Then the proper item is selected and other items are filtered out
       expect(queryItem('War and Peace')).not.toBeInTheDocument()
       expect(queryItem('1984')).not.toBeInTheDocument()
       expect(getItem('Pride and Prejudice')).toHaveAttribute('aria-selected', 'true')
@@ -276,7 +311,7 @@ describe('Combobox', () => {
 
         // Given a combobox that does not allow custom input value
         render(
-          <Combobox defaultValue="book-2" autoFilter={false}>
+          <Combobox defaultValue="book-2" filtering="none">
             <Combobox.Trigger>
               <Combobox.Input aria-label="Book" placeholder="Pick a book" />
             </Combobox.Trigger>
@@ -311,7 +346,7 @@ describe('Combobox', () => {
 
         // Given a combobox that does not allow custom input value
         render(
-          <Combobox defaultValue="book-2" autoFilter={false}>
+          <Combobox defaultValue="book-2" filtering="none">
             <Combobox.Trigger>
               <Combobox.Input aria-label="Book" placeholder="Pick a book" />
             </Combobox.Trigger>
@@ -347,7 +382,7 @@ describe('Combobox', () => {
 
         // Given a combobox that allows custom value and has a selected item
         render(
-          <Combobox allowCustomValue defaultValue="book-2" autoFilter={false}>
+          <Combobox allowCustomValue defaultValue="book-2" filtering="none">
             <Combobox.Trigger>
               <Combobox.SelectedItems />
               <Combobox.Input aria-label="Book" placeholder="Pick a book" />


### PR DESCRIPTION
**TASK**: #2183 

### Description, Motivation and Context

1. Read attached issue.
2. Proposal is to replace `autoFilter` (boolean), by `filtering: "auto" | "none" | "strict"`

`strict` matches the previous default behaviour, `auto` is the new/improved way for filtering, where the filtering only applies once the user starts typing.

For example, if the user selects a value in the list, it will reset/cancel the filtering so they can explore the full list of values.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

