### PR TITLE
fix(internal-utils): update rollup config and include external peer dependencies to avoid potential dependency mismatches at the call site

### DIFF
--- a/packages/utils/internal-utils/package.json
+++ b/packages/utils/internal-utils/package.json
@@ -16,6 +16,10 @@
   "scripts": {
     "build": "vite build"
   },
+  "peerDependencies": {
+    "react": "^18.0 || ^19.0",
+    "react-dom": "^18.0 || ^19.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adevinta/spark.git",

--- a/packages/utils/internal-utils/vite.config.ts
+++ b/packages/utils/internal-utils/vite.config.ts
@@ -2,6 +2,9 @@ import { terser } from 'rollup-plugin-terser'
 import dts from 'vite-plugin-dts'
 import browserslistToEsbuild from 'browserslist-to-esbuild'
 
+const pkg = require('./package.json')
+const peerDeps = Object.keys(pkg.peerDependencies || {})
+
 export default {
   build: {
     target: browserslistToEsbuild(),
@@ -11,7 +14,7 @@ export default {
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['node:path', 'node:fs'],
+      external: ['node:path', 'node:fs', ...peerDeps],
       plugins: [terser()],
     },
   },


### PR DESCRIPTION
Inside the `react-children-utilities` util package, we reference `React`, but we didn't declare it as a dependency in the `package.json`.

We also didn't include it in the rollup config, which could cause some version dependency mismatches at the call site