### PR TITLE
fix(combobox): onValueChange was triggered even when selected item ha…

### DIFF
--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -189,11 +189,14 @@ export const ComboboxProvider = ({
   )
 
   const onInternalSelectedItemChange = (item: ComboboxItem | null) => {
-    setSelectedItem(item)
     setIsTyping(false)
-    setTimeout(() => {
-      onValueChange?.(item?.value as string & string[])
-    }, 0)
+
+    if (item?.value !== selectedItem?.value) {
+      setSelectedItem(item)
+      setTimeout(() => {
+        onValueChange?.(item?.value as string & string[])
+      }, 0)
+    }
   }
 
   const onInternalSelectedItemsChange = (items: ComboboxItem[]) => {


### PR DESCRIPTION

### Description, Motivation and Context

In the `singleSelectionReducer`, when blur event is triggered or disclosureButton is clicked, it calls `setSelectedItem` to reset it, which in return triggers `onValueChange` prop (callback).

I added an optimization to check that the selected item (or none item selected) has changed before triggering the callback, which was called too many times.

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
