### PR TITLE
fix(select): fix disabled and readonly styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/select/src/SelectItems.tsx
+++ b/packages/components/select/src/SelectItems.tsx
@@ -22,7 +22,7 @@ export const styles = cva(
         true: 'cursor-not-allowed',
       },
       readOnly: {
-        true: 'cursor-not-allowed',
+        true: 'cursor-default',
       },
     },
     compoundVariants: [

--- a/packages/components/select/src/SelectTrigger.styles.tsx
+++ b/packages/components/select/src/SelectTrigger.styles.tsx
@@ -3,8 +3,8 @@ import { cva } from 'class-variance-authority'
 export const styles = cva(
   [
     'relative flex w-full items-center justify-between',
-    'min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg',
-    'text-body-1',
+    'min-h-sz-44 rounded-lg px-lg',
+    'text-body-1 bg-surface text-on-surface',
     // outline styles
     'ring-1 outline-none ring-inset',
   ],
@@ -17,11 +17,11 @@ export const styles = cva(
         success: 'ring-success',
       },
       disabled: {
-        true: 'disabled:bg-on-surface/dim-5 cursor-not-allowed text-on-surface/dim-3',
+        true: '!bg-on-surface/dim-5 cursor-not-allowed !text-on-surface/dim-3',
         false: 'focus-within:ring-2',
       },
       readOnly: {
-        true: 'disabled:bg-on-surface/dim-5 cursor-not-allowed text-on-surface/dim-3',
+        true: '!bg-on-surface/dim-5 cursor-default',
       },
     },
     compoundVariants: [

--- a/packages/components/select/src/SelectTrigger.styles.tsx
+++ b/packages/components/select/src/SelectTrigger.styles.tsx
@@ -4,7 +4,7 @@ export const styles = cva(
   [
     'relative flex w-full items-center justify-between',
     'min-h-sz-44 rounded-lg px-lg',
-    'text-body-1 bg-surface text-on-surface',
+    'text-body-1',
     // outline styles
     'ring-1 outline-none ring-inset',
   ],
@@ -17,14 +17,26 @@ export const styles = cva(
         success: 'ring-success',
       },
       disabled: {
-        true: '!bg-on-surface/dim-5 cursor-not-allowed !text-on-surface/dim-3',
         false: 'focus-within:ring-2',
       },
       readOnly: {
-        true: '!bg-on-surface/dim-5 cursor-default',
+        true: '',
       },
     },
     compoundVariants: [
+      {
+        readOnly: false,
+        disabled: false,
+        class: 'bg-surface text-on-surface',
+      },
+      {
+        readOnly: true,
+        class: 'bg-on-surface/dim-5 text-on-surface cursor-default',
+      },
+      {
+        disabled: true,
+        class: ['bg-on-surface/dim-5 text-on-surface/dim-3', 'cursor-not-allowed'],
+      },
       {
         disabled: false,
         state: undefined,

--- a/packages/components/select/src/SelectValue.tsx
+++ b/packages/components/select/src/SelectValue.tsx
@@ -18,7 +18,7 @@ export const Value = forwardRef(
     { children, className, placeholder: customPlaceholder }: ValueProps,
     forwardedRef: Ref<HTMLSpanElement>
   ) => {
-    const { selectedItem, placeholder } = useSelectContext()
+    const { selectedItem, placeholder, disabled } = useSelectContext()
 
     const isPlaceholderSelected = selectedItem?.value == null
     const valuePlaceholder = customPlaceholder || placeholder
@@ -33,7 +33,7 @@ export const Value = forwardRef(
         <span
           className={cx(
             'line-clamp-1 flex-1 overflow-hidden text-ellipsis break-all',
-            isPlaceholderSelected && 'text-on-surface/dim-1'
+            isPlaceholderSelected && !disabled && 'text-on-surface/dim-1'
           )}
         >
           {isPlaceholderSelected ? valuePlaceholder : children || selectedItem?.text}


### PR DESCRIPTION
**TASK**: #2136 

### Description, Motivation and Context
On the `Select` component `disabled` and `readOnly` states seem to be desync with input styles. We want to harmonize and fix this.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/0da8f669-09dd-43d1-9719-50857c84570d)
![image](https://github.com/adevinta/spark/assets/66770550/1d50330a-b167-45f0-9eb9-d667fdf55254)

