### PR TITLE
fix(checkbox): remove the required attribute from individual checkboxes as soon as 1 checkbox is checked

### DIFF
--- a/packages/components/checkbox/src/Checkbox.test.tsx
+++ b/packages/components/checkbox/src/Checkbox.test.tsx
@@ -322,5 +322,37 @@ describe('CheckboxGroup', () => {
         })
       ).toBeInTheDocument()
     })
+
+    it('should remove the required attribute from individual checkboxes when at least one checkbox is checked', async () => {
+      render(
+        <FormField name="sports" isRequired>
+          <FormField.Label>Sports</FormField.Label>
+
+          <CheckboxGroup>
+            <Checkbox value="soccer">Soccer</Checkbox>
+            <Checkbox value="baseball">Baseball</Checkbox>
+          </CheckboxGroup>
+        </FormField>
+      )
+
+      const checkboxEls = within(screen.getByRole('group', { name: 'Sports' })).getAllByRole(
+        'checkbox'
+      )
+
+      expect(checkboxEls[0]).toHaveAttribute('aria-required', 'true')
+      expect(checkboxEls[1]).toHaveAttribute('aria-required', 'true')
+
+      await userEvent.click(
+        screen.getByRole('checkbox', {
+          name: 'Baseball',
+        })
+      )
+
+      expect(checkboxEls[0]).toHaveAttribute('aria-required', 'false')
+      expect(checkboxEls[0]).not.toBeRequired()
+
+      expect(checkboxEls[1]).toHaveAttribute('aria-required', 'false')
+      expect(checkboxEls[1]).not.toBeRequired()
+    })
   })
 })

--- a/packages/components/checkbox/src/Checkbox.tsx
+++ b/packages/components/checkbox/src/Checkbox.tsx
@@ -2,7 +2,7 @@
 import { useFormFieldControl } from '@spark-ui/form-field'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
-import { forwardRef, useId, useRef } from 'react'
+import { forwardRef, useId, useMemo, useRef } from 'react'
 
 import { CheckboxGroupContextState, useCheckboxGroup } from './CheckboxGroupContext'
 import { CheckboxInput, CheckboxInputProps } from './CheckboxInput'
@@ -73,11 +73,24 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
       }
     }
 
-    const { id, name, isInvalid, isRequired, description, intent } = getCheckboxAttributes({
+    const {
+      id,
+      name,
+      isInvalid,
+      description,
+      intent,
+      isRequired: isRequiredAttr,
+    } = getCheckboxAttributes({
       fieldState: field,
       groupState: group,
       checkboxIntent: intentProp,
     })
+
+    const isRequired = useMemo(() => {
+      if (!group) return isRequiredAttr
+
+      return isRequiredAttr ? !group.value?.length : false
+    }, [group, isRequiredAttr])
 
     const checkboxLabel = children && (
       <CheckboxLabel disabled={disabled} htmlFor={id || innerId} id={innerLabelId}>


### PR DESCRIPTION
**TASK**:#2205

### Description, Motivation and Context
When a `CheckboxGroup` is marked as required, we should remove the required attribute from individual checkboxes as soon as one checkbox is checked.

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
