### PR TITLE
fix(combobox): removed unnecessary undefined type for combobox onValu…

### DIFF
--- a/packages/components/combobox/src/Combobox.stories.tsx
+++ b/packages/components/combobox/src/Combobox.stories.tsx
@@ -922,16 +922,12 @@ export const ModalSearch: StoryFn = () => {
           <Dialog.Content size="sm">
             <Combobox
               onValueChange={value => {
-                if (value === undefined) {
-                  setValue(value)
-                } else {
-                  const [_, id] = value.split('-')
-                  const book = books.find(({ id: bookId }) => `${bookId}` === id)
+                const [_, id] = value.split('-')
+                const book = books.find(({ id: bookId }) => `${bookId}` === id)
 
-                  if (book) {
-                    setValue(book?.name)
-                    setIsOpen(false)
-                  }
+                if (book) {
+                  setValue(book.name)
+                  setIsOpen(false)
                 }
               }}
               defaultValue={value}

--- a/packages/components/combobox/src/ComboboxContext.tsx
+++ b/packages/components/combobox/src/ComboboxContext.tsx
@@ -103,7 +103,7 @@ interface ComboboxPropsSingle {
   /**
    * Event handler called when the value changes.
    */
-  onValueChange?: (value: string | undefined) => void
+  onValueChange?: (value: string) => void
 }
 
 interface ComboboxPropsMultiple {


### PR DESCRIPTION
…eChange

**TASK**: #2208 

### Description, Motivation and Context

`onValueChange` accepted `string | undefined` as a first parameter in its callback (single selection mode only).

It means that our consumer are forced to check the type:
```
<Combobox value={value} onValueChange={(value)  => {
  if (value !== undefined) setValue(value)
}}
```

But I think such a case can't happen. Once a Combobox is controlled, its `value` must remain a `string`.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
