### PR TITLE
chore: auto assign gh issue templates to project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 name: 'Bug Report'
 description: 'File a bug report'
 labels: ['Needs Triage', 'Type: Bug']
+projects: ['adevinta/4']
 body:
   - type: 'markdown'
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,7 @@
 name: 'Feature Request'
 description: 'Request a feature or enhancement'
 labels: ['Needs Triage', 'Type: Feature Request']
+projects: ['adevinta/4']
 body:
   - type: 'markdown'
     attributes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #2210 

### Description, Motivation and Context

Issues created from issue templates are now attached to `Spark` project (backlog) with the `Needs Triage` label.

Note: I tried to make it assigned to the `Web` team automatically, but this is not possible for now: https://github.com/orgs/community/discussions/86679

=> It means every issue we receive must be manually assigned to `Web` to appear on the Web board. Let's hope GH improves this.

### Types of changes

- [x] 🛠️ Tool




