### PR TITLE
fix(combobox): missing key attribute on selected items

### DIFF
--- a/packages/components/combobox/src/ComboboxSelectedItems.tsx
+++ b/packages/components/combobox/src/ComboboxSelectedItems.tsx
@@ -90,7 +90,7 @@ export const SelectedItems = () => {
   return ctx.multiple && ctx.selectedItems.length ? (
     <>
       {ctx.selectedItems.map((item, index) => (
-        <SelectedItem item={item} index={index} />
+        <SelectedItem key={item.value} item={item} index={index} />
       ))}
     </>
   ) : null


### PR DESCRIPTION
### Description, Motivation and Context

Missing `key` attribute on `Combobox.SelectedItems` loop triggers a warning in the console.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
