### PR TITLE
fix(icon): fix icon shrinking inside flex containers

### DIFF
--- a/packages/components/icon/src/Icon.styles.tsx
+++ b/packages/components/icon/src/Icon.styles.tsx
@@ -1,7 +1,7 @@
 import { makeVariants } from '@spark-ui/internal-utils'
 import { cva, VariantProps } from 'class-variance-authority'
 
-export const iconStyles = cva(['fill-current'], {
+export const iconStyles = cva(['fill-current shrink-0'], {
   variants: {
     /**
      * Color scheme of the icon.


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #2233 

### Description, Motivation and Context

When icons are before/after a long text inside a flex container, they shrink (unwanted behaviour).

For example inside a `FormField` helper/error message, or inside an `Accordion` trigger.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

