### PR TITLE
docs: adds browser support infos in FAQ

### DIFF
--- a/documentation/using-spark/FAQ.mdx
+++ b/documentation/using-spark/FAQ.mdx
@@ -246,4 +246,16 @@ import { FAQ } from '@docs/helpers/FAQ'
     </FAQ.Answer>
 
   </FAQ.Item>
+
+  <FAQ.Item>
+    <FAQ.Question
+      label="How is Spark's browser support?"
+    />
+      <FAQ.Answer>
+        Spark UI is designed for and tested on the latest stable versions of Chrome, Firefox, Edge, and Safari. It does not support any version of IE, including IE 11.
+
+        Detailed browser support is defined in our `package.json`. For a more human readable list please visit related [Browserslist page](https://browsersl.ist/#q=%3E+0.5%25+or+%3E+0.1%25+and+last+2+years%2C+not+dead%2C+not+Firefox+ESR%2C+not+and_qq+%3E+0%2C+not+and_uc+%3E+0%2C+not+and_ff+%3E0%0A).
+      </FAQ.Answer>
+
+  </FAQ.Item>
 </FAQ.Root>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,6 +2301,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
**TASK**: #2263 

### Description, Motivation and Context
Following some questions we want to provide detailed infos about our browser support.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations
![image](https://github.com/adevinta/spark/assets/66770550/ac9556b8-0303-417e-b174-1433a13e088c)
