### PR TITLE
fix(cli-utils): fix config merge method to allow proper option override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23899,7 +23899,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -35413,7 +35414,7 @@
     },
     "packages/utils/cli": {
       "name": "@spark-ui/cli-utils",
-      "version": "2.14.0-beta.1",
+      "version": "2.14.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "0.7.0",
@@ -35423,7 +35424,6 @@
         "esbuild": "0.21.5",
         "fs-extra": "11.2.0",
         "glob": "8.1.0",
-        "lodash.merge": "4.6.2",
         "pascal-case": "3.1.2",
         "ts-morph": "22.0.0"
       },

--- a/packages/utils/cli/package.json
+++ b/packages/utils/cli/package.json
@@ -39,7 +39,6 @@
     "esbuild": "0.21.5",
     "fs-extra": "11.2.0",
     "glob": "8.1.0",
-    "lodash.merge": "4.6.2",
     "pascal-case": "3.1.2",
     "ts-morph": "22.0.0"
   },

--- a/packages/utils/cli/src/scan/index.mjs
+++ b/packages/utils/cli/src/scan/index.mjs
@@ -3,7 +3,6 @@
 import * as process from 'node:process'
 
 import { existsSync, mkdirSync, writeFileSync } from 'fs'
-import merge from 'lodash.merge'
 import path from 'path'
 
 import { Logger } from '../core/index.mjs'
@@ -19,14 +18,12 @@ export async function adoption(options = {}) {
   let config = await loadConfig(configuration, { logger })
 
   config = {
-    adoption: merge(
-      { ...config.adoption },
-      {
-        ...optionsConfig,
-        imports: optionsConfig.imports || config.imports,
-        extensions: optionsConfig.extensions || config.extensions,
-      }
-    ),
+    adoption: {
+      ...config.adoption,
+      ...optionsConfig,
+      imports: optionsConfig.imports || config.adoption.imports,
+      extensions: optionsConfig.extensions || config.adoption.extensions,
+    },
   }
 
   let importCount = 0

--- a/packages/utils/cli/src/scan/loadConfig.mjs
+++ b/packages/utils/cli/src/scan/loadConfig.mjs
@@ -1,7 +1,6 @@
 import process from 'node:process'
 
 import { existsSync } from 'fs'
-import merge from 'lodash.merge'
 import path from 'path'
 
 import * as defaultConfig from './config.mjs'
@@ -14,11 +13,12 @@ export async function loadConfig(configuration, { logger }) {
       const { default: customConfig } = await import(configFileRoute)
 
       const config = {
-        adoption: merge(defaultConfig, {
+        adoption: {
+          ...defaultConfig,
           ...customConfig.adoption,
-          imports: customConfig.imports || defaultConfig.imports,
-          extensions: customConfig.extensions || defaultConfig.extensions,
-        }),
+          imports: customConfig.adoption.imports || defaultConfig.imports,
+          extensions: customConfig.adoption.extensions || defaultConfig.extensions,
+        },
       }
 
       return config


### PR DESCRIPTION
### Description, Motivation and Context
Initially we used `lodash.merge` to merge config customizations, but it prevented us to override options properly. It finally appears that this util was not relevant.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
