### PR TITLE
fix(accordion): move padding to first element of AccordionItemContent to fix animation shifts

### DIFF
--- a/packages/components/accordion/src/AccordionItemContent.tsx
+++ b/packages/components/accordion/src/AccordionItemContent.tsx
@@ -22,11 +22,7 @@ export const ItemContent = forwardRef<HTMLDivElement, AccordionItemContentProps>
     const accordionItem = useAccordionItemContext()
 
     const localProps = {
-      className: cx(
-        'p-lg duration-50 transition-all text-body-1 text-on-surface',
-        'data-[state=closed]:py-none',
-        className
-      ),
+      className: cx('[&>:first-child]:p-lg', 'text-body-1 text-on-surface', className),
       asChild,
       ...props,
     }


### PR DESCRIPTION
### Description, Motivation and Context
Resolve animation issues by moving padding to the first child of AccordionItemContent, preventing vertical layout shifts

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations

**before:**
![before](https://github.com/user-attachments/assets/f68f2458-8575-4c84-adbc-621daa95b63c)

___

**after:**
![after](https://github.com/user-attachments/assets/daab002c-7d91-4feb-9caf-533e3db36e78)
