### PR TITLE
test(combobox): add additional edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,6 +2307,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35233,6 +35234,9 @@
         "@spark-ui/visually-hidden": "^1.2.3",
         "class-variance-authority": "0.7.0",
         "downshift": "9.0.4"
+      },
+      "devDependencies": {
+        "@spark-ui/dialog": "^1.12.10"
       },
       "peerDependencies": {
         "react": "^18.0 || ^19.0",

--- a/packages/components/combobox/package.json
+++ b/packages/components/combobox/package.json
@@ -27,6 +27,9 @@
     "react-dom": "^18.0 || ^19.0",
     "tailwindcss": "^3.0.0"
   },
+  "devDependencies": {
+    "@spark-ui/dialog": "^1.12.10"
+  },
   "dependencies": {
     "@spark-ui/form-field": "^1.5.11",
     "@spark-ui/icon": "^2.1.8",

--- a/packages/components/combobox/src/tests/edgeCases.test.tsx
+++ b/packages/components/combobox/src/tests/edgeCases.test.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@spark-ui/button'
+import { Dialog } from '@spark-ui/dialog'
+import { FormField } from '@spark-ui/form-field'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+
+import { Combobox } from '..'
+import { getInput, getItem } from './test-utils'
+
+export function ComboboxInsideDialog() {
+  const [open, setOpen] = useState(false)
+
+  const handleOpenChange = (open: boolean) => {
+    setOpen(open)
+  }
+
+  return (
+    <div className="grid h-full place-items-center gap-y-3xl p-lg">
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <Dialog.Trigger asChild>
+          <Button>Create account</Button>
+        </Dialog.Trigger>
+
+        <Dialog.Portal>
+          <Dialog.Overlay />
+
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Create account</Dialog.Title>
+            </Dialog.Header>
+
+            <Dialog.Body className="flex flex-col gap-lg">
+              <FormField name="books">
+                <FormField.Label className="text-body-2">books</FormField.Label>
+                <Combobox>
+                  <Combobox.Trigger>
+                    <Combobox.Input aria-label="Book" placeholder="Pick a book" />
+                    <Combobox.ClearButton aria-label="Clear input" />
+                    <Combobox.Disclosure closedLabel="Open popup" openedLabel="Close popup" />
+                  </Combobox.Trigger>
+                  <Combobox.Popover>
+                    <Combobox.Items>
+                      <Combobox.Empty>No results found</Combobox.Empty>
+                      <Combobox.Item value="book-1">To Kill a Mockingbird</Combobox.Item>
+                      <Combobox.Item value="book-2">War and Peace</Combobox.Item>
+                      <Combobox.Item value="book-3">The Idiot</Combobox.Item>
+                      <Combobox.Item value="book-4">A Picture of Dorian Gray</Combobox.Item>
+                      <Combobox.Item value="book-5">1984</Combobox.Item>
+                      <Combobox.Item value="book-6">Pride and Prejudice</Combobox.Item>
+                    </Combobox.Items>
+                  </Combobox.Popover>
+                </Combobox>
+              </FormField>
+            </Dialog.Body>
+
+            <Dialog.CloseButton aria-label="Close dialog" />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    </div>
+  )
+}
+
+describe('Combobox inside a Dialog', () => {
+  it('should be able to select item', async () => {
+    const user = userEvent.setup()
+
+    render(<ComboboxInsideDialog />)
+
+    // open dialog
+    await user.click(screen.getByRole('button', { name: 'Create account' }))
+
+    // open combobox
+    await user.click(getInput('books'))
+
+    // select item
+    await user.click(getItem('Pride and Prejudice'))
+
+    expect(screen.getByDisplayValue('Pride and Prejudice')).toBeInTheDocument()
+    expect(getItem('Pride and Prejudice')).toHaveAttribute('aria-selected', 'true')
+  })
+})


### PR DESCRIPTION
### Description, Motivation and Context
We recently encountered a situation where one of our users was unable to interact with our **Combobox** (with a pointer device) when it was placed inside a **Spark Dialog**.

After investigating, we discovered that the issue was with the **Spark Dialog**, not the Combobox itself.
To catch when similar bugs occur in the future, we are adding test cases to test our Combobox within a Spark Dialog as part of the Combobox tests.


### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
