### PR TITLE
style(combobox): missing styles on Combobox.Empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,6 +2307,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/combobox/src/ComboboxEmpty.tsx
+++ b/packages/components/combobox/src/ComboboxEmpty.tsx
@@ -14,7 +14,10 @@ export const Empty = forwardRef(
     const hasNoItemVisible = ctx.filteredItemsMap.size === 0
 
     return hasNoItemVisible ? (
-      <div ref={forwardedRef} className={cx('px-lg py-md', className)}>
+      <div
+        ref={forwardedRef}
+        className={cx('px-lg py-md text-body-1 text-on-surface/dim-1', className)}
+      >
         {children}
       </div>
     ) : null


### PR DESCRIPTION
### Description, Motivation and Context

`Combobox.Empty` styles were not aligned with Figma (font-size and text-color). https://www.figma.com/design/0QchRdipAVuvVoDfTjLrgQ/Component-Specs-of-Spark?node-id=28629-4000&t=GO6qlR8llASgHV9h-1

### Types of changes
- [x] 💄 Styles

### Screenshots - Animations

Before
![Capture d’écran 2024-07-18 à 11 35 54](https://github.com/user-attachments/assets/f7ae95ef-f8e8-41ed-aa7e-04e518163678)


After
![Capture d’écran 2024-07-18 à 11 35 43](https://github.com/user-attachments/assets/0489ceb7-49f6-4cb8-ba23-9a37cbcc2c05)

