### PR TITLE
fix(snackbar): update vite config to exclude JSX runtime bundling

### DIFF
--- a/config/component.ts
+++ b/config/component.ts
@@ -14,9 +14,13 @@ const rootPkg = require('../package.json')
 const rootDeps = Object.keys(rootPkg.dependencies || {})
 const rootDevDeps = Object.keys(rootPkg.devDependencies || {})
 
-export function buildComponentConfig(path: string, preserveModules: boolean) {
+export function buildComponentConfig(
+  path: string,
+  preserveModules: boolean,
+  external: string[] = []
+) {
   const pkg = require(join(path, '/package.json'))
-  const deps = Object.keys(pkg.dependencies || {})
+  const deps = [...Object.keys(pkg.dependencies || {}), ...external]
   const devDeps = Object.keys(pkg.devDependencies || {})
 
   return {

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,7 +3,11 @@ import merge from 'deepmerge'
 import { buildComponentConfig } from './component'
 
 export function getComponentConfiguration(path: string, name: string, options: any = {}) {
-  return getConfiguration(buildComponentConfig(path, options.preserveModules), options, name)
+  return getConfiguration(
+    buildComponentConfig(path, options.preserveModules, options.external),
+    options,
+    name
+  )
 }
 
 function getConfiguration(configuration: Record<string, unknown>, options = {}, name?: string) {

--- a/packages/components/snackbar/vite.config.ts
+++ b/packages/components/snackbar/vite.config.ts
@@ -3,4 +3,4 @@ import { getComponentConfiguration } from '../../../config/index'
 
 const { name } = require(path.resolve(__dirname, 'package.json'))
 
-export default getComponentConfiguration(process.cwd(), name)
+export default getComponentConfiguration(process.cwd(), name, { external: ['react/jsx-runtime'] })


### PR DESCRIPTION
For a reason I still don't completely understand, the **JSX runtime** was bundled in our `.js` files from our `dist` folder for the Snackbar component (since v1.1.9). This PR addresses that.