### PR TITLE
docs(icons): hide icons list from public documentation

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -9,5 +9,8 @@ addons.setConfig({
   sidebar: {
     showRoots: true,
     collapsedRoots: ['using-spark', 'hooks', 'contributing', 'experimental', 'utils'],
+    filters: {
+      hidden: item => !item.tags?.includes('hidden'),
+    },
   },
 })

--- a/packages/components/icons/src/index.doc.mdx
+++ b/packages/components/icons/src/index.doc.mdx
@@ -1,0 +1,10 @@
+import { Meta, Canvas } from '@storybook/addon-docs'
+import * as IconsStories from './index.stories'
+
+<Meta of={IconsStories} />
+
+# Icons
+
+A set of icons for Spark-ui.
+
+<Canvas of={IconsStories.List} />

--- a/packages/components/icons/src/index.stories.tsx
+++ b/packages/components/icons/src/index.stories.tsx
@@ -9,17 +9,10 @@ import { Check as IconCheck } from './icons/Check'
 const meta: Meta = {
   title: 'Components/Icons',
   component: IconCheck,
+  tags: ['hidden'],
 }
 
 export default meta
-
-export const Default: StoryFn = _args => {
-  return (
-    <Icon size="lg">
-      <IconCheck />
-    </Icon>
-  )
-}
 
 export const List: StoryFn = _args => {
   const [icons, setIcons] = useState<[originalName: string, lowercaseName: string, iconElm: FC][]>(


### PR DESCRIPTION
### Description, Motivation and Context
Spark icons list should not be publicly visible. The UI listing is only made available for internal purpose.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations
![image](https://github.com/user-attachments/assets/51f4220d-c2b7-4993-8a8d-2e0e4153ef4d)
