### PR TITLE
feat(breadcrumb): new breadcrumb component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36027,6 +36027,13 @@
       "name": "@spark-ui/breadcrumb",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@spark-ui/icon": "^5.0.27",
+        "@spark-ui/icons": "^5.0.27",
+        "@spark-ui/slot": "^5.0.27",
+        "@spark-ui/text-link": "^5.0.27",
+        "class-variance-authority": "0.7.0"
+      },
       "peerDependencies": {
         "@spark-ui/tailwind-plugins": "latest",
         "@spark-ui/theme-utils": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,6 +2330,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9209,6 +9210,10 @@
     },
     "node_modules/@spark-ui/badge": {
       "resolved": "packages/components/badge",
+      "link": true
+    },
+    "node_modules/@spark-ui/breadcrumb": {
+      "resolved": "packages/components/breadcrumb",
       "link": true
     },
     "node_modules/@spark-ui/button": {
@@ -36010,6 +36015,18 @@
         "@spark-ui/internal-utils": "^5.1.2",
         "class-variance-authority": "0.7.0"
       },
+      "peerDependencies": {
+        "@spark-ui/tailwind-plugins": "latest",
+        "@spark-ui/theme-utils": "latest",
+        "react": "^18.0 || ^19.0",
+        "react-dom": "^18.0 || ^19.0",
+        "tailwindcss": "^3.0.0"
+      }
+    },
+    "packages/components/breadcrumb": {
+      "name": "@spark-ui/breadcrumb",
+      "version": "0.0.0",
+      "license": "MIT",
       "peerDependencies": {
         "@spark-ui/tailwind-plugins": "latest",
         "@spark-ui/theme-utils": "latest",

--- a/packages/components/breadcrumb/.npmignore
+++ b/packages/components/breadcrumb/.npmignore
@@ -1,0 +1,2 @@
+src
+**/*.stories.*

--- a/packages/components/breadcrumb/LICENSE.md
+++ b/packages/components/breadcrumb/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Adevinta ASA.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -1,0 +1,13 @@
+# Breadcrumb
+> @spark-ui/breadcrumb
+
+[![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-breadcrumb--docs)
+[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/breadcrumb)
+[![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20breadcrumb)
+[![npm](https://img.shields.io/npm/dt/%40spark-ui/breadcrumb?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/breadcrumb)
+
+
+This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
+
+[![Issues open](https://img.shields.io/github/issues-search/adevinta/spark?query=is%3Aopen%20label%3A%22Component%3A%20breadcrumb%22&logo=openbugbounty&logoColor=red&label=issues%20open&color=red)](https://github.com/adevinta/spark/issues?q=is%3Aopen+label%3AComponent%3A%20breadcrumb)
+[![NPM](https://img.shields.io/npm/l/%40spark-ui%2Fbreadcrumb)](https://github.com/adevinta/spark/blob/main/packages/components/breadcrumb/LICENSE.md)

--- a/packages/components/breadcrumb/package.json
+++ b/packages/components/breadcrumb/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@spark-ui/breadcrumb",
+  "version": "0.0.0",
+  "description": "navigation pattern that helps users understand the hierarchy of a website",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "@spark-ui",
+    "react",
+    "component",
+    "accessible",
+    "accessibility",
+    "wai-aria",
+    "aria",
+    "a11y",
+    "breadcrumb"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "vite build"
+  },
+  "peerDependencies": {
+    "@spark-ui/tailwind-plugins": "latest",
+    "@spark-ui/theme-utils": "latest",
+    "react": "^18.0 || ^19.0",
+    "react-dom": "^18.0 || ^19.0",
+    "tailwindcss": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adevinta/spark.git",
+    "directory": "packages/components/breadcrumb"
+  },
+  "config": {
+    "title": "breadcrumb",
+    "category": "components"
+  },
+  "bugs": {
+    "url": "https://github.com/adevinta/spark/issues?q=is%3Aopen+label%3A%22Component%3A+breadcrumb%22"
+  },
+  "homepage": "https://sparkui.vercel.app",
+  "license": "MIT"
+}

--- a/packages/components/breadcrumb/package.json
+++ b/packages/components/breadcrumb/package.json
@@ -29,6 +29,13 @@
     "react-dom": "^18.0 || ^19.0",
     "tailwindcss": "^3.0.0"
   },
+  "dependencies": {
+    "@spark-ui/slot": "^5.0.27",
+    "@spark-ui/text-link": "^5.0.27",
+    "@spark-ui/icon": "^5.0.27",
+    "@spark-ui/icons": "^5.0.27",
+    "class-variance-authority": "0.7.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adevinta/spark.git",

--- a/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
+++ b/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
@@ -1,5 +1,6 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { Kbd } from '@spark-ui/kbd'
 
 import { Breadcrumb } from '.'
 
@@ -66,3 +67,19 @@ Use the `children` property of `Breadcrumb.Separator` to use a different icon fo
 Apply a maximum width on an element to truncate it automatically.
 
 <Canvas of={stories.Truncate} />
+
+## Accessibility
+
+Adheres to the [Breadcrumb WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/).
+
+### Keyboard Interaction
+
+- <Kbd>Tab</Kbd>: Focuses the next item.
+- <Kbd>Shift</Kbd> + <Kbd>Tab</Kbd>: Focuses the previous item.
+- <Kbd>Enter</Kbd>: Triggers an item link.
+
+### WAI-ARIA Roles, States, and Properties
+
+- Breadcrumb trail is contained within a navigation landmark region.
+- The landmark region is labelled via [aria-label](https://w3c.github.io/aria/#aria-label) or [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby).
+- The link to the current page has [aria-current](https://w3c.github.io/aria/#aria-current) set to `page`. If the element representing the current page is not a link, aria-current is optional.

--- a/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
+++ b/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
@@ -1,0 +1,54 @@
+import { Meta, Canvas } from '@storybook/addon-docs'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
+
+import { Breadcrumb } from '.'
+
+import * as stories from './Breadcrumb.stories'
+
+<Meta of={stories} />
+
+# Breadcrumb
+
+Navigation pattern that helps users understand the hierarchy of a website
+
+## Install
+
+```sh
+npm install @spark-ui/breadcrumb
+```
+
+## Import
+
+```tsx
+import { Breadcrumb } from '@spark-ui/breadcrumb'
+```
+
+## Props
+
+<ArgTypes
+  of={Breadcrumb}
+  description="Contains all the parts of a breakpoint. Navigation area."
+  subcomponents={{
+    'Breadcrumb.Item': {
+      of: Breadcrumb.Item,
+      description: 'List item to use inside of `Breadcrumb` directly.',
+    },
+    'Breadcrumb.Link': {
+      of: Breadcrumb.Link,
+      description: 'Use inside `Breadcrumb.Item` if your item must be a link.',
+    },
+    'Breadcrumb.CurrentPage': {
+      of: Breadcrumb.CurrentPage,
+      description:
+        'Use inside `Breadcrumb.Item` if your item is the current page (non-interactive link).',
+    },
+    'Breadcrumb.Separator': {
+      of: Breadcrumb.Separator,
+      description: 'Separator to use between each `Breadcrumb.Item`. Content can be customized.',
+    },
+  }}
+/>
+
+## Variants
+
+<Canvas of={stories.Default} />

--- a/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
+++ b/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
@@ -60,3 +60,9 @@ import { Breadcrumb } from '@spark-ui/breadcrumb'
 Use the `children` property of `Breadcrumb.Separator` to use a different icon for the separator. You can also use raw text.
 
 <Canvas of={stories.CustomSeparator} />
+
+### Truncate
+
+Apply a maximum width on an element to truncate it automatically.
+
+<Canvas of={stories.Truncate} />

--- a/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
+++ b/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
@@ -49,6 +49,14 @@ import { Breadcrumb } from '@spark-ui/breadcrumb'
   }}
 />
 
-## Variants
+## Usage
+
+### Default
 
 <Canvas of={stories.Default} />
+
+### Custom Separator
+
+Use the `children` property of `Breadcrumb.Separator` to use a different icon for the separator. You can also use raw text.
+
+<Canvas of={stories.CustomSeparator} />

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -28,7 +28,7 @@ export const Default: StoryFn = _args => (
     <Breadcrumb.Separator />
 
     <Breadcrumb.Item>
-      <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
+      <Breadcrumb.CurrentPage aria-disabled>Breadcrumb</Breadcrumb.CurrentPage>
     </Breadcrumb.Item>
   </Breadcrumb>
 )
@@ -56,6 +56,28 @@ export const CustomSeparator: StoryFn = _args => (
         <ArrowRight />
       </Icon>
     </Breadcrumb.Separator>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+)
+
+export const Truncate: StoryFn = _args => (
+  <Breadcrumb aria-label="Breadcrumb">
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator />
+
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/?path=/docs/experimental-breadcrumb--docs" className="max-w-[100px]">
+        Components list - Feel free to use them
+      </Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator />
 
     <Breadcrumb.Item>
       <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@spark-ui/icon'
+import { ArrowRight } from '@spark-ui/icons/dist/icons/ArrowRight'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { Breadcrumb } from '.'
@@ -22,6 +24,34 @@ export const Default: StoryFn = _args => (
     </Breadcrumb.Item>
 
     <Breadcrumb.Separator />
+
+    <Breadcrumb.Item>
+      <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+)
+
+export const CustomSeparator: StoryFn = _args => (
+  <Breadcrumb aria-label="Breadcrumb">
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator>
+      <Icon>
+        <ArrowRight />
+      </Icon>
+    </Breadcrumb.Separator>
+
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator>
+      <Icon>
+        <ArrowRight />
+      </Icon>
+    </Breadcrumb.Separator>
 
     <Breadcrumb.Item>
       <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -20,7 +20,9 @@ export const Default: StoryFn = _args => (
     <Breadcrumb.Separator />
 
     <Breadcrumb.Item>
-      <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+      <Breadcrumb.Link href="/?path=/docs/experimental-breadcrumb--docs">
+        Components
+      </Breadcrumb.Link>
     </Breadcrumb.Item>
 
     <Breadcrumb.Separator />
@@ -44,7 +46,9 @@ export const CustomSeparator: StoryFn = _args => (
     </Breadcrumb.Separator>
 
     <Breadcrumb.Item>
-      <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+      <Breadcrumb.Link href="/?path=/docs/experimental-breadcrumb--docs">
+        Components
+      </Breadcrumb.Link>
     </Breadcrumb.Item>
 
     <Breadcrumb.Separator>

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -28,7 +28,7 @@ export const Default: StoryFn = _args => (
     <Breadcrumb.Separator />
 
     <Breadcrumb.Item>
-      <Breadcrumb.CurrentPage aria-disabled>Breadcrumb</Breadcrumb.CurrentPage>
+      <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
     </Breadcrumb.Item>
   </Breadcrumb>
 )

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { Breadcrumb } from '.'
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: 'Experimental/Breadcrumb',
+  component: Breadcrumb,
+}
+
+export default meta
+
+export const Default: StoryFn = _args => (
+  <Breadcrumb aria-label="Breadcrumb">
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator />
+
+    <Breadcrumb.Item>
+      <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+    </Breadcrumb.Item>
+
+    <Breadcrumb.Separator />
+
+    <Breadcrumb.Item>
+      <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+)

--- a/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.stories.tsx
@@ -5,7 +5,7 @@ import { Meta, StoryFn } from '@storybook/react'
 import { Breadcrumb } from '.'
 
 const meta: Meta<typeof Breadcrumb> = {
-  title: 'Experimental/Breadcrumb',
+  title: 'Components/Breadcrumb',
   component: Breadcrumb,
 }
 

--- a/packages/components/breadcrumb/src/Breadcrumb.test.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.test.tsx
@@ -21,7 +21,7 @@ describe('Breadcrumb', () => {
         <Breadcrumb.Separator />
 
         <Breadcrumb.Item>
-          <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+          <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
         </Breadcrumb.Item>
       </Breadcrumb>
     )
@@ -36,7 +36,9 @@ describe('Breadcrumb', () => {
     )
 
     // Then breadcrumb current page should be rendered
-    expect(screen.getByRole('link', { name: 'Breadcrumb' })).not.toHaveAttribute('href')
+    const currentPageLink = screen.getByRole('link', { name: 'Breadcrumb' })
+    expect(currentPageLink).toHaveAttribute('href', '')
+    expect(currentPageLink).toHaveAttribute('aria-current', 'page')
 
     // Then separators should be rendered (hidden)
     expect(screen.getAllByRole('presentation', { hidden: true })).toHaveLength(2)
@@ -59,7 +61,7 @@ describe('Breadcrumb', () => {
         <Breadcrumb.Separator>__</Breadcrumb.Separator>
 
         <Breadcrumb.Item>
-          <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+          <Breadcrumb.CurrentPage>Breadcrumb</Breadcrumb.CurrentPage>
         </Breadcrumb.Item>
       </Breadcrumb>
     )

--- a/packages/components/breadcrumb/src/Breadcrumb.test.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Breadcrumb } from '.'
+
+describe('Breadcrumb', () => {
+  it('should render all parts', () => {
+    // Given a breadcrumb with links, separator and current page item.
+    render(
+      <Breadcrumb aria-label="Breadcrumb">
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+        </Breadcrumb.Item>
+
+        <Breadcrumb.Separator />
+
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+        </Breadcrumb.Item>
+
+        <Breadcrumb.Separator />
+
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb>
+    )
+
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+
+    // Then Breadcrumb links should be rendered
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: 'Components' })).toHaveAttribute(
+      'href',
+      '/docs/components'
+    )
+
+    // Then breadcrumb current page should be rendered
+    expect(screen.getByRole('link', { name: 'Breadcrumb' })).not.toHaveAttribute('href')
+
+    // Then separators should be rendered (hidden)
+    expect(screen.getAllByRole('presentation', { hidden: true })).toHaveLength(2)
+  })
+
+  it('should render custom separators', () => {
+    // Given a breadcrumb with links, separator and current page item.
+    render(
+      <Breadcrumb aria-label="Breadcrumb">
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+        </Breadcrumb.Item>
+
+        <Breadcrumb.Separator>__</Breadcrumb.Separator>
+
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+        </Breadcrumb.Item>
+
+        <Breadcrumb.Separator>__</Breadcrumb.Separator>
+
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb>
+    )
+
+    // Then separators should be rendered with their custom content
+    expect(screen.getAllByText('__')).toHaveLength(2)
+  })
+})

--- a/packages/components/breadcrumb/src/Breadcrumb.test.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.test.tsx
@@ -37,7 +37,6 @@ describe('Breadcrumb', () => {
 
     // Then breadcrumb current page should be rendered
     const currentPageLink = screen.getByRole('link', { name: 'Breadcrumb' })
-    expect(currentPageLink).toHaveAttribute('href', '')
     expect(currentPageLink).toHaveAttribute('aria-current', 'page')
 
     // Then separators should be rendered (hidden)

--- a/packages/components/breadcrumb/src/Breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.tsx
@@ -1,0 +1,22 @@
+import { cx } from 'class-variance-authority'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+
+export interface BreadcrumbProps extends ComponentPropsWithoutRef<'nav'> {
+  className?: string
+  ['aria-label']: string
+}
+
+export const Breadcrumb = forwardRef<HTMLOListElement, BreadcrumbProps>(
+  ({ className, 'aria-label': ariaLabel, ...rest }, ref) => {
+    return (
+      <nav data-spark-component="breadcrumb" ref={ref} aria-label={ariaLabel} className={className}>
+        <ol
+          className={cx('flex flex-wrap items-center gap-sm break-words text-caption')}
+          {...rest}
+        />
+      </nav>
+    )
+  }
+)
+
+Breadcrumb.displayName = 'Breadcrumb.Breadcrumb'

--- a/packages/components/breadcrumb/src/Breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.tsx
@@ -13,7 +13,7 @@ export const Breadcrumb = forwardRef<HTMLOListElement, BreadcrumbProps>(
         data-spark-component="breadcrumb"
         ref={ref}
         aria-label={ariaLabel}
-        className={cx('text-caption', className)}
+        className={cx('text-caption text-neutral', className)}
       >
         <ol className={cx('flex flex-wrap items-center gap-sm break-words')} {...rest} />
       </nav>

--- a/packages/components/breadcrumb/src/Breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/Breadcrumb.tsx
@@ -9,11 +9,13 @@ export interface BreadcrumbProps extends ComponentPropsWithoutRef<'nav'> {
 export const Breadcrumb = forwardRef<HTMLOListElement, BreadcrumbProps>(
   ({ className, 'aria-label': ariaLabel, ...rest }, ref) => {
     return (
-      <nav data-spark-component="breadcrumb" ref={ref} aria-label={ariaLabel} className={className}>
-        <ol
-          className={cx('flex flex-wrap items-center gap-sm break-words text-caption')}
-          {...rest}
-        />
+      <nav
+        data-spark-component="breadcrumb"
+        ref={ref}
+        aria-label={ariaLabel}
+        className={cx('text-caption', className)}
+      >
+        <ol className={cx('flex flex-wrap items-center gap-sm break-words')} {...rest} />
       </nav>
     )
   }

--- a/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
@@ -1,0 +1,27 @@
+import { Slot } from '@spark-ui/slot'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+
+export interface CurrentPageProps extends ComponentPropsWithoutRef<'span'> {
+  asChild?: boolean
+  className?: string
+}
+
+export const CurrentPage = forwardRef<HTMLSpanElement, CurrentPageProps>(
+  ({ asChild = false, className, ...rest }, ref) => {
+    const Component = asChild ? Slot : 'span'
+
+    return (
+      <Component
+        data-spark-component="breadcrumb-current-page"
+        role="link"
+        aria-current="page"
+        aria-disabled
+        className={className}
+        ref={ref}
+        {...rest}
+      />
+    )
+  }
+)
+
+CurrentPage.displayName = 'Breadcrumb.CurrentPage'

--- a/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
@@ -9,25 +9,24 @@ export interface CurrentPageProps extends ComponentPropsWithoutRef<typeof TextLi
 }
 
 export const CurrentPage = forwardRef<HTMLAnchorElement, CurrentPageProps>(
-  (
-    { asChild = false, className, bold = true, intent = 'current', underline = false, ...rest },
-    ref
-  ) => {
-    const Component = asChild ? Slot : TextLink
+  ({ asChild = false, className, children, ...rest }, ref) => {
+    const Component = asChild ? Slot : 'span'
 
     return (
       <Component
         data-spark-component="breadcrumb-current-page"
         role="link"
-        href=""
+        aria-disabled
         aria-current="page"
-        className={cx('!inline overflow-hidden text-ellipsis whitespace-nowrap', className)}
-        bold={bold}
-        intent={intent}
-        underline={underline}
+        className={cx(
+          '!inline overflow-hidden text-ellipsis whitespace-nowrap font-bold text-current',
+          className
+        )}
         ref={ref}
         {...rest}
-      />
+      >
+        {children}
+      </Component>
     )
   }
 )

--- a/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbCurrentPage.tsx
@@ -1,22 +1,30 @@
 import { Slot } from '@spark-ui/slot'
+import { TextLink } from '@spark-ui/text-link'
+import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
-export interface CurrentPageProps extends ComponentPropsWithoutRef<'span'> {
+export interface CurrentPageProps extends ComponentPropsWithoutRef<typeof TextLink> {
   asChild?: boolean
   className?: string
 }
 
-export const CurrentPage = forwardRef<HTMLSpanElement, CurrentPageProps>(
-  ({ asChild = false, className, ...rest }, ref) => {
-    const Component = asChild ? Slot : 'span'
+export const CurrentPage = forwardRef<HTMLAnchorElement, CurrentPageProps>(
+  (
+    { asChild = false, className, bold = true, intent = 'current', underline = false, ...rest },
+    ref
+  ) => {
+    const Component = asChild ? Slot : TextLink
 
     return (
       <Component
         data-spark-component="breadcrumb-current-page"
         role="link"
+        href=""
         aria-current="page"
-        aria-disabled
-        className={className}
+        className={cx('!inline overflow-hidden text-ellipsis whitespace-nowrap', className)}
+        bold={bold}
+        intent={intent}
+        underline={underline}
         ref={ref}
         {...rest}
       />

--- a/packages/components/breadcrumb/src/BreadcrumbItem.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbItem.tsx
@@ -1,0 +1,19 @@
+import { cx } from 'class-variance-authority'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+
+export interface ItemProps extends ComponentPropsWithoutRef<'li'> {
+  className?: string
+}
+
+export const Item = forwardRef<HTMLLIElement, ItemProps>(({ className, ...rest }, ref) => {
+  return (
+    <li
+      data-spark-component="breadcrumb-item"
+      ref={ref}
+      className={cx('inline-flex items-center gap-sm', className)}
+      {...rest}
+    />
+  )
+})
+
+Item.displayName = 'Breadcrumb.Item'

--- a/packages/components/breadcrumb/src/BreadcrumbLink.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbLink.tsx
@@ -1,0 +1,26 @@
+import { Slot } from '@spark-ui/slot'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+
+export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
+  asChild?: boolean
+  className?: string
+  href?: string
+}
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ asChild = false, className, href, ...rest }, ref) => {
+    const Component = asChild ? Slot : 'a'
+
+    return (
+      <Component
+        data-spark-component="breadcrumb-link"
+        href={href}
+        ref={ref}
+        className={className}
+        {...rest}
+      />
+    )
+  }
+)
+
+Link.displayName = 'Breadcrumb.Link'

--- a/packages/components/breadcrumb/src/BreadcrumbLink.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbLink.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@spark-ui/slot'
 import { TextLink } from '@spark-ui/text-link'
+import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
 export interface LinkProps extends ComponentPropsWithoutRef<typeof TextLink> {
@@ -28,7 +29,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         data-spark-component="breadcrumb-link"
         href={href}
         ref={ref}
-        className={className}
+        className={cx('!inline overflow-hidden text-ellipsis whitespace-nowrap', className)}
         bold={bold}
         intent={intent}
         underline={underline}

--- a/packages/components/breadcrumb/src/BreadcrumbLink.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbLink.tsx
@@ -1,15 +1,27 @@
 import { Slot } from '@spark-ui/slot'
+import { TextLink } from '@spark-ui/text-link'
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
-export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
+export interface LinkProps extends ComponentPropsWithoutRef<typeof TextLink> {
   asChild?: boolean
   className?: string
   href?: string
 }
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ asChild = false, className, href, ...rest }, ref) => {
-    const Component = asChild ? Slot : 'a'
+  (
+    {
+      asChild = false,
+      className,
+      bold = true,
+      intent = 'current',
+      underline = true,
+      href,
+      ...rest
+    },
+    ref
+  ) => {
+    const Component = asChild ? Slot : TextLink
 
     return (
       <Component
@@ -17,6 +29,9 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         href={href}
         ref={ref}
         className={className}
+        bold={bold}
+        intent={intent}
+        underline={underline}
         {...rest}
       />
     )

--- a/packages/components/breadcrumb/src/BreadcrumbSeparator.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbSeparator.tsx
@@ -1,0 +1,29 @@
+import { Slot } from '@spark-ui/slot'
+import { cx } from 'class-variance-authority'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+
+export interface SeparatorProps extends ComponentPropsWithoutRef<'li'> {
+  asChild?: boolean
+  className?: string
+}
+
+export const Separator = forwardRef<HTMLLIElement, SeparatorProps>(
+  ({ asChild = false, className, children, ...rest }, ref) => {
+    const Component = asChild ? Slot : 'li'
+
+    return (
+      <Component
+        role="presentation"
+        aria-hidden
+        data-spark-component="breadcrumb-separator"
+        ref={ref}
+        className={cx('inline-flex items-center gap-sm', className)}
+        {...rest}
+      >
+        {children ?? '/'}
+      </Component>
+    )
+  }
+)
+
+Separator.displayName = 'Breadcrumb.Separator'

--- a/packages/components/breadcrumb/src/BreadcrumbSeparator.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbSeparator.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@spark-ui/icon'
+import { ArrowVerticalRight } from '@spark-ui/icons/dist/icons/ArrowVerticalRight'
 import { Slot } from '@spark-ui/slot'
 import { cx } from 'class-variance-authority'
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
@@ -20,7 +22,11 @@ export const Separator = forwardRef<HTMLLIElement, SeparatorProps>(
         className={cx('inline-flex items-center gap-sm', className)}
         {...rest}
       >
-        {children ?? '/'}
+        {children ?? (
+          <Icon>
+            <ArrowVerticalRight />
+          </Icon>
+        )}
       </Component>
     )
   }

--- a/packages/components/breadcrumb/src/index.ts
+++ b/packages/components/breadcrumb/src/index.ts
@@ -1,0 +1,25 @@
+import type { FC } from 'react'
+
+import { Breadcrumb as Root, type BreadcrumbProps } from './Breadcrumb'
+import { CurrentPage } from './BreadcrumbCurrentPage'
+import { Item } from './BreadcrumbItem'
+import { Link } from './BreadcrumbLink'
+import { Separator } from './BreadcrumbSeparator'
+
+export const Breadcrumb: FC<BreadcrumbProps> & {
+  Item: typeof Item
+  Link: typeof Link
+  CurrentPage: typeof CurrentPage
+  Separator: typeof Separator
+} = Object.assign(Root, {
+  Item,
+  Link,
+  CurrentPage,
+  Separator,
+})
+
+Breadcrumb.displayName = 'Breadcrumb'
+Item.displayName = 'Breadcrumb.Item'
+Link.displayName = 'Breadcrumb.Link'
+CurrentPage.displayName = 'Breadcrumb.CurrentPage'
+Separator.displayName = 'Breadcrumb.Separator'

--- a/packages/components/breadcrumb/tsconfig.json
+++ b/packages/components/breadcrumb/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src/**/*", "../../../global.d.ts"]
+}

--- a/packages/components/breadcrumb/vite.config.ts
+++ b/packages/components/breadcrumb/vite.config.ts
@@ -1,0 +1,6 @@
+import path from 'path'
+import { getComponentConfiguration } from '../../../config/index'
+
+const { name } = require(path.resolve(__dirname, 'package.json'))
+
+export default getComponentConfiguration(process.cwd(), name)


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #2366 

### Description, Motivation and Context

`Breadcrumb` component boilerplate and anatomy proposal. Inspired by https://ui.shadcn.com/docs/components/breadcrumb

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
<img width="951" alt="Capture d’écran 2024-08-12 à 15 49 43" src="https://github.com/user-attachments/assets/46a30fcb-6bb7-44f4-8034-48de13e44e6d">


