### PR TITLE
chore: bump @zag-js packages to fixed version 0.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14820,74 +14820,74 @@
       "dev": true
     },
     "node_modules/@zag-js/accordion": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-0.65.0.tgz",
-      "integrity": "sha512-cCXxsqEuLPOpgORR8Mb2xtADBhJZBPbxQGirI6Q6wdqtDSvwsGfhVfSKy4QMyeYxUhu3U5auILIeTqCCz80mzA==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-0.67.0.tgz",
+      "integrity": "sha512-qWaXccvTj9h2OelCzUjqMhaMw8THBAoziyiyfeF4nce/5fGZ3lreyGcLIGGwYn06rnFe3aLi6UYA6a/3OKtsvQ==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "0.65.0",
-        "@zag-js/core": "0.65.0",
-        "@zag-js/dom-event": "0.65.0",
-        "@zag-js/dom-query": "0.65.0",
-        "@zag-js/types": "0.65.0",
-        "@zag-js/utils": "0.65.0"
+        "@zag-js/anatomy": "0.67.0",
+        "@zag-js/core": "0.67.0",
+        "@zag-js/dom-event": "0.67.0",
+        "@zag-js/dom-query": "0.67.0",
+        "@zag-js/types": "0.67.0",
+        "@zag-js/utils": "0.67.0"
       }
     },
     "node_modules/@zag-js/anatomy": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-0.65.0.tgz",
-      "integrity": "sha512-P9SVWgx5ngwYGKODNBMLH6chk9AKq4CrLRawH1KXK0gISsolQG+8yWyok5E9sdPc6UkV6eI+5k8T/teIrOfuOw==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-0.67.0.tgz",
+      "integrity": "sha512-IeL8O1cm7DGaej6FHgb01NKqt3gE075IM5g/yIqYXxCgunVn80j8QZ4LFytoH3Q/q6nXsIwbAPIbAbnu2T4d1w==",
       "license": "MIT"
     },
     "node_modules/@zag-js/collapsible": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-0.65.0.tgz",
-      "integrity": "sha512-X/TrNvmiQQq4CoFIc/ibHEDGJ8cgqttrZAT9izC84ZlVB8MLe42iwAPTui56S8Wo1QGWaqPRtSr7KQuuwcyQyQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-0.67.0.tgz",
+      "integrity": "sha512-hfks9Bzk2pj8kOCndj3Fr2EkoEuBujsPDEZ9jDA6Gjo5AT8XwkKM1F3EenZdyYaoDGbjCVfYfEAUyvnJMEK19A==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "0.65.0",
-        "@zag-js/core": "0.65.0",
-        "@zag-js/dom-query": "0.65.0",
-        "@zag-js/types": "0.65.0",
-        "@zag-js/utils": "0.65.0"
+        "@zag-js/anatomy": "0.67.0",
+        "@zag-js/core": "0.67.0",
+        "@zag-js/dom-query": "0.67.0",
+        "@zag-js/types": "0.67.0",
+        "@zag-js/utils": "0.67.0"
       }
     },
     "node_modules/@zag-js/core": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-0.65.0.tgz",
-      "integrity": "sha512-LuzfnFbmAyDW7buJn46/j2hO0Qy59NWbgUNFrrvBFrzLiiVKVugwXpdc1J/nPOp+op7oDGP63sxgZuFmMeAEZg==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-0.67.0.tgz",
+      "integrity": "sha512-zas+Ci4MKRf/C1jVAL0yzkkqEotvT+39HNuykWUjSqTBsvJQqhRgyKl+7wEkYTpaYIX7WCs4rXYjvDKTsTYfgA==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/store": "0.65.0",
+        "@zag-js/store": "0.67.0",
         "klona": "2.0.6"
       }
     },
     "node_modules/@zag-js/dom-event": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-event/-/dom-event-0.65.0.tgz",
-      "integrity": "sha512-ansSv07lb6OwN2gknGdYBAaBd4I4kPJth1VnJe8a6Tw5dqiTlhrbNKjXX+bKw7G8bvQ4uViYCys+kzLvX+lnQw==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-event/-/dom-event-0.67.0.tgz",
+      "integrity": "sha512-DGuJX6kReoe13/rxLuAfBD8BggvRf462RVIx0fKTkJDv81JYgcGdQYeyBSXm04vIKlh8hf8XZXWCKE8KozQcWQ==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "0.65.0",
-        "@zag-js/text-selection": "0.65.0",
-        "@zag-js/types": "0.65.0"
+        "@zag-js/dom-query": "0.67.0",
+        "@zag-js/text-selection": "0.67.0",
+        "@zag-js/types": "0.67.0"
       }
     },
     "node_modules/@zag-js/dom-query": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.65.0.tgz",
-      "integrity": "sha512-ERYyqdvf/+7dS8XxhMA2gKrrdVoyv0LpxwYRSc9PnPE9zo3zUagSsYgVdyG84BU+WpOJyXW3lm/2vYM+LYg82A==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.67.0.tgz",
+      "integrity": "sha512-yltNJaMSL1LjRI3PprglOU44Fd9fX3b70KCboJSdiiBgTNL4+V6DvwsQbvUdNRSMhbvNiORW7R4KdjABtK3Vqg==",
       "license": "MIT"
     },
     "node_modules/@zag-js/react": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-0.65.0.tgz",
-      "integrity": "sha512-6NG4yClh4maczF46ShLVA/Fj5Or1FVguXTl/fPROSPOrPEZODthNIdJrHSiP5XJBh+2TJCS9tzLkKINHJY5aUQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-0.67.0.tgz",
+      "integrity": "sha512-pRykEQwu0ugvrw6tvvccQhopPb4q+cxPG5HDAA3RGEZLMdxfMBq8RMM8as8K0hOwQ1O0QBjl4bqQfTxotLMYcA==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/core": "0.65.0",
-        "@zag-js/store": "0.65.0",
-        "@zag-js/types": "0.65.0",
+        "@zag-js/core": "0.67.0",
+        "@zag-js/store": "0.67.0",
+        "@zag-js/types": "0.67.0",
         "proxy-compare": "3.0.0"
       },
       "peerDependencies": {
@@ -14896,36 +14896,36 @@
       }
     },
     "node_modules/@zag-js/store": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-0.65.0.tgz",
-      "integrity": "sha512-yeF9HrTczp/8cMiJewk+QfLqLg3/1+YQmkJzFwvLb3tU2/WrrUPMMgw112963RQRSzfRDg3HeWkmfw6L5+EBQg==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-0.67.0.tgz",
+      "integrity": "sha512-p6FeFH32zHeiVcBun70UTx5G+5XMcqc//aPxec2BJ8SBp8IB9NsDX3sIQtSv6q9tCtrDO4sxvWKGjOyUmFAuAQ==",
       "license": "MIT",
       "dependencies": {
         "proxy-compare": "3.0.0"
       }
     },
     "node_modules/@zag-js/text-selection": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/text-selection/-/text-selection-0.65.0.tgz",
-      "integrity": "sha512-aC2A4DSP0oVhAm6VYRMUF6uBrpxdlJGn+itKe/ggszidAkil/zyhkcPQkx3LI/5gSkoWdL3uMyypj+FkuoEz9w==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/text-selection/-/text-selection-0.67.0.tgz",
+      "integrity": "sha512-f/3ZdBtXPXM6OIqluN++kTtDwmRKmNAjpQ00xsNpG0e2+9nSRIXg2ONg4z0iBhAZpDnLNXsC8g0vzReWKEo1iw==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "0.65.0"
+        "@zag-js/dom-query": "0.67.0"
       }
     },
     "node_modules/@zag-js/types": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-0.65.0.tgz",
-      "integrity": "sha512-4GqO0rytOvpR2OamyndPeOcpVcZ6dMmOJgoAuIH2b7K6GtQLgU7lix9eAwlvhZhC2BZm0zOB8QCABNKJ1bRDUg==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-0.67.0.tgz",
+      "integrity": "sha512-9o2ZxGY3Pg5EW8b4TjFr45oKOq7E6mF8Kg7RlrInks0OOAevnwr9uXcaEWVkqMdTmUMD1fSXwUjGw+8bKkDFig==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"
       }
     },
     "node_modules/@zag-js/utils": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-0.65.0.tgz",
-      "integrity": "sha512-u7pBhfiUizyiBiOWy8ALeIJT9kPZ5c1gtKSQ1Vjr6Z3WrMYEtCrLPTXhpjgksghcRvYNSKv14M+fKmOO1R9Pgg==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-0.67.0.tgz",
+      "integrity": "sha512-uQh0girQN4NPARBVamxzpu8wnln9zRaC7W7ScDh5y/EBpxUPtwMwxMuQ64Vo9KwSV3LzieAXR4xrQIbELJlJtw==",
       "license": "MIT"
     },
     "node_modules/@zkochan/js-yaml": {
@@ -23869,6 +23869,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -36207,8 +36208,8 @@
         "@spark-ui/icons": "^5.3.5",
         "@spark-ui/internal-utils": "^5.3.5",
         "@spark-ui/slot": "^5.3.5",
-        "@zag-js/accordion": "^0.65.0",
-        "@zag-js/react": "^0.65.0"
+        "@zag-js/accordion": "0.67.0",
+        "@zag-js/react": "0.67.0"
       },
       "peerDependencies": {
         "@spark-ui/tailwind-plugins": "latest",
@@ -36334,8 +36335,8 @@
       "license": "MIT",
       "dependencies": {
         "@spark-ui/slot": "^5.3.5",
-        "@zag-js/collapsible": "^0.65.0",
-        "@zag-js/react": "^0.65.0"
+        "@zag-js/collapsible": "0.67.0",
+        "@zag-js/react": "0.67.0"
       },
       "peerDependencies": {
         "@spark-ui/tailwind-plugins": "latest",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -50,7 +50,7 @@
     "@spark-ui/icons": "^5.3.5",
     "@spark-ui/internal-utils": "^5.3.5",
     "@spark-ui/slot": "^5.3.5",
-    "@zag-js/accordion": "^0.65.0",
-    "@zag-js/react": "^0.65.0"
+    "@zag-js/accordion": "0.67.0",
+    "@zag-js/react": "0.67.0"
   }
 }

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "@spark-ui/slot": "^5.3.5",
-    "@zag-js/collapsible": "^0.65.0",
-    "@zag-js/react": "^0.65.0"
+    "@zag-js/collapsible": "0.67.0",
+    "@zag-js/react": "0.67.0"
   }
 }


### PR DESCRIPTION
### Description, Motivation and Context
Bump `@zagjs` packages to latest 0.67.0 version, but use a fixed version instead of a caret one, according to our [agreement](https://github.com/adevinta/spark/wiki/Agreements#managing-dependencies-within-spark-components)