### PR TITLE
style(form-field): inline required indicator placement

### DIFF
--- a/packages/components/form-field/src/FormFieldLabel.tsx
+++ b/packages/components/form-field/src/FormFieldLabel.tsx
@@ -38,7 +38,6 @@ export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>(
         htmlFor={htmlFor}
         className={cx(
           className,
-          'flex items-center gap-sm',
           disabled ? 'pointer-events-none text-on-surface/dim-3' : undefined
         )}
         asChild={asChild}

--- a/packages/components/form-field/src/FormFieldRequiredIndicator.tsx
+++ b/packages/components/form-field/src/FormFieldRequiredIndicator.tsx
@@ -1,4 +1,5 @@
 import { Label, LabelRequiredIndicatorProps } from '@spark-ui/label'
+import { cx } from 'class-variance-authority'
 import { forwardRef } from 'react'
 
 export type FormFieldRequiredIndicatorProps = LabelRequiredIndicatorProps
@@ -6,8 +7,8 @@ export type FormFieldRequiredIndicatorProps = LabelRequiredIndicatorProps
 export const FormFieldRequiredIndicator = forwardRef<
   HTMLSpanElement,
   FormFieldRequiredIndicatorProps
->((props, ref) => {
-  return <Label.RequiredIndicator ref={ref} {...props} />
+>(({ className, ...props }, ref) => {
+  return <Label.RequiredIndicator ref={ref} className={cx('ml-sm', className)} {...props} />
 })
 
 FormFieldRequiredIndicator.displayName = 'FormField.RequiredIndicator'


### PR DESCRIPTION
**TASK**: [SPA-6](https://jira.ets.mpi-internal.com/browse/SPA-6)

### Description, Motivation and Context

- Update `FormField.Label` to not be a `flex` container, in order to inline the `RequiredIndicator` with the label text. 

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles


### Screenshots - Animations
![Capture d’écran 2024-09-18 à 14 37 32](https://github.com/user-attachments/assets/c64d1f21-db98-4d79-add1-139d54c5c9e9)

