### PR TITLE
fix(pagination): update vite config to exclude JSX runtime bundling

### DIFF
--- a/packages/components/pagination/vite.config.ts
+++ b/packages/components/pagination/vite.config.ts
@@ -3,4 +3,4 @@ import { getComponentConfiguration } from '../../../config/index'
 
 const { name } = require(path.resolve(__dirname, 'package.json'))
 
-export default getComponentConfiguration(process.cwd(), name)
+export default getComponentConfiguration(process.cwd(), name, { external: ['react/jsx-runtime'] })


### PR DESCRIPTION
For a reason I still don't completely understand, the **JSX runtime** was bundled in our `.js` files from our `dist` folder for the Pagination component. This PR addresses that.

See also ➡️ #2315 