### PR TITLE
fix(dialog): do not close dialog when foreground elements are clicked

### DIFF
--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -13,7 +13,14 @@ export interface ContentProps extends RadixDialog.DialogContentProps, DialogCont
 
 export const Content = forwardRef(
   (
-    { children, className, isNarrow = false, size = 'md', ...rest }: ContentProps,
+    {
+      children,
+      className,
+      isNarrow = false,
+      size = 'md',
+      onInteractOutside,
+      ...rest
+    }: ContentProps,
     ref: Ref<HTMLDivElement>
   ): ReactElement => {
     const { setIsFullScreen } = useDialog()
@@ -33,6 +40,21 @@ export const Content = forwardRef(
           isNarrow,
           size,
         })}
+        onInteractOutside={e => {
+          const isForegroundElement = (e.target as HTMLElement).closest('.z-toast, .z-popover')
+
+          /**
+           * The focus trap of the dialog applies `pointer-events-none` on the body of the page in the background, but
+           * some components with an higher z-index have `pointer-events-auto` applied on them to remain interactive and ignore the focust trap (ex: a Snackbar with actions).
+           *
+           * Clicking on the snackbar will be considered as an "outside click" and close the dialog. We want to prevent this.
+           */
+          if (isForegroundElement) {
+            e.preventDefault()
+          }
+
+          onInteractOutside?.(e)
+        }}
         {...rest}
       >
         {children}

--- a/packages/components/drawer/src/DrawerContent.tsx
+++ b/packages/components/drawer/src/DrawerContent.tsx
@@ -7,7 +7,7 @@ export type DrawerContentProps = RadixDrawer.DialogContentProps & DrawerContentS
 
 export const DrawerContent = forwardRef(
   (
-    { className, size = 'md', side = 'right', ...rest }: DrawerContentProps,
+    { className, size = 'md', side = 'right', onInteractOutside, ...rest }: DrawerContentProps,
     ref: Ref<HTMLDivElement>
   ) => (
     <RadixDrawer.Content
@@ -18,6 +18,21 @@ export const DrawerContent = forwardRef(
         side,
         className,
       })}
+      onInteractOutside={e => {
+        const isForegroundElement = (e.target as HTMLElement).closest('.z-toast, .z-popover')
+
+        /**
+         * The focus trap of the drawer applies `pointer-events-none` on the body of the page in the background, but
+         * some components with an higher z-index have `pointer-events-auto` applied on them to remain interactive and ignore the focust trap (ex: a Snackbar with actions).
+         *
+         * Clicking on the snackbar will be considered as an "outside click" and close the drawer. We want to prevent this.
+         */
+        if (isForegroundElement) {
+          e.preventDefault()
+        }
+
+        onInteractOutside?.(e)
+      }}
       {...rest}
     />
   )


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: [SPA-193](https://jira.ets.mpi-internal.com/browse/SPA-193)

### Description, Motivation and Context

Dialog/Drawer have a focus trap by default. It applies `pointer-events-none` on the whole page in the background to disabled clicks.

But some components might be displayed on top of dialogs and have a stronger `z-index` (ex: `Snackbar`, `Popover`). Such components must remain interactive, so they have `pointer-events-auto` on them.

Let's say I am inside a dialog:

1. I click somewhere inside the dialog that triggers a snackbar.
2. I click the close button of the snackbar displayed.
3. It closes the snackbar, **but ALSO the dialog.** (we don't want that).

Here are the z-index system of Spark: 
```
zIndex: {
    hide: '-1',
    base: '0',
    raised: '1',
    dropdown: '1000',
    sticky: '1100',
    overlay: '1300',
    modal: '1400', // dialog/drawer are using this one
    popover: '1500', 
    skipLink: '1600',
    toast: '1700',
    tooltip: '1800',
  },
```

As you can see `popover` and `toast` (snackbar) elements are on top. Such elements should not close the dialog when interacted with.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧠 Refactor
- [x] 💄 Styles
