### PR TITLE
docs: remove deprecated docs links in badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@ coverage
 .nx
 
 # Testing reports
-/public/a11y/*
-!/public/a11y/a11y-report.json
+!/public/a11y/*.json
 /test-results/
 /playwright-report/
 /e2e/report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,6 +2330,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/accordion/README.md
+++ b/packages/components/accordion/README.md
@@ -1,11 +1,10 @@
 # Accordion
+
 > @spark-ui/accordion
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-accordion--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/accordion)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=component,accordion)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/accordion?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/accordion)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/alert-dialog/README.md
+++ b/packages/components/alert-dialog/README.md
@@ -1,11 +1,10 @@
 # Alert Dialog
+
 > @spark-ui/alert-dialog
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-alertdialog--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/alert-dialog)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20alert-dialog)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/alert-dialog?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/alert-dialog)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/badge/README.md
+++ b/packages/components/badge/README.md
@@ -1,8 +1,8 @@
 # Badge
+
 > @spark-ui/badge
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-badge--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/badge)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20badge)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/badge?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/badge)
 

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -1,11 +1,10 @@
 # Breadcrumb
+
 > @spark-ui/breadcrumb
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-breadcrumb--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/breadcrumb)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20breadcrumb)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/breadcrumb?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/breadcrumb)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -2,6 +2,7 @@
 
 > @spark-ui/button
 
+![accessibility](https://img.shields.io/badge/WCAG_2.1_AA-passed-green)
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-button--docs)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20button)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/button?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/button)

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -1,11 +1,10 @@
 # Button
+
 > @spark-ui/button
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-button--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/button)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20button)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/button?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/button)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/checkbox/README.md
+++ b/packages/components/checkbox/README.md
@@ -1,11 +1,10 @@
 # Checkbox
+
 > @spark-ui/checkbox
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-checkbox--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/checkbox)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20checkbox)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/checkbox?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/checkbox)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/chip/README.md
+++ b/packages/components/chip/README.md
@@ -1,12 +1,10 @@
 # Chip
+
 > @spark-ui/chip
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-chip--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/chip)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20chip)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/chip?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/chip)
-
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/collapsible/README.md
+++ b/packages/components/collapsible/README.md
@@ -1,11 +1,10 @@
 # Collapsible
+
 > @spark-ui/collapsible
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-collapsible--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/collapsible)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=component,collapsible)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/collapsible?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/collapsible)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/combobox/README.md
+++ b/packages/components/combobox/README.md
@@ -1,11 +1,10 @@
 # Combobox
+
 > @spark-ui/combobox
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-combobox--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/combobox)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20combobox)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/combobox?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/combobox)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/dialog/README.md
+++ b/packages/components/dialog/README.md
@@ -1,12 +1,10 @@
 # Dialog
+
 > @spark-ui/dialog
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-dialog--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/dialog)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20dialog)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/dialog?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/dialog)
-
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/divider/README.md
+++ b/packages/components/divider/README.md
@@ -1,11 +1,10 @@
 # Divider
+
 > @spark-ui/divider
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-divider--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/divider)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20divider)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/divider?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/divider)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/drawer/README.md
+++ b/packages/components/drawer/README.md
@@ -1,12 +1,10 @@
 # Drawer
+
 > @spark-ui/drawer
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-drawer--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/drawer)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20drawer)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/drawer?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/drawer)
-
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/dropdown/README.md
+++ b/packages/components/dropdown/README.md
@@ -1,11 +1,10 @@
 # Dropdown
+
 > @spark-ui/dropdown
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-dropdown--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/dropdown)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20dropdown)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/dropdown?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/dropdown)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/form-field/README.md
+++ b/packages/components/form-field/README.md
@@ -1,11 +1,10 @@
 # Form Field
+
 > @spark-ui/form-field
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-formfield--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/form-field)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%form-field)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/form-field?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/form-field)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/icon-button/README.md
+++ b/packages/components/icon-button/README.md
@@ -1,11 +1,10 @@
 # Icon Button
+
 > @spark-ui/icon-button
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-iconbutton--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/icon-button)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20icon-button)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/icon-button?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/icon-button)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/icon/README.md
+++ b/packages/components/icon/README.md
@@ -1,11 +1,10 @@
 # Icon
+
 > @spark-ui/icon
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-icon--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/icon)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20icon)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/icon?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/icon)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/icons/README.md
+++ b/packages/components/icons/README.md
@@ -1,11 +1,10 @@
 # Icons
+
 > @spark-ui/icons
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-icons--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/icons)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20icons)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/icons?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/icons)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -1,11 +1,10 @@
 # Input
+
 > @spark-ui/input
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-input--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/input)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20input)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/input?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/input)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/kbd/README.md
+++ b/packages/components/kbd/README.md
@@ -1,11 +1,10 @@
 # Kbd
+
 > @spark-ui/kbd
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-kbd--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/kbd)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20kbd)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/kbd?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/kbd)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/label/README.md
+++ b/packages/components/label/README.md
@@ -1,11 +1,10 @@
 # Label
+
 > @spark-ui/label
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-label--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/label)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20label)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/label?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/label)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/link-box/README.md
+++ b/packages/components/link-box/README.md
@@ -1,11 +1,10 @@
 # Link Box
+
 > @spark-ui/link-box
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-linkbox--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/link-box)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20link-box)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/link-box?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/link-box)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -1,11 +1,10 @@
 # Pagination
+
 > @spark-ui/pagination
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-pagination--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/pagination)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20pagination)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/pagination?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/pagination)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/popover/README.md
+++ b/packages/components/popover/README.md
@@ -1,11 +1,10 @@
 # Popover
+
 > @spark-ui/popover
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-popover--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/popover)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20popover)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/popover?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/popover)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/portal/README.md
+++ b/packages/components/portal/README.md
@@ -1,11 +1,10 @@
 # Portal
+
 > @spark-ui/portal
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-portal--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/portal)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20portal)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/portal?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/portal)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/progress-tracker/README.md
+++ b/packages/components/progress-tracker/README.md
@@ -1,11 +1,10 @@
 # Progress Tracker
+
 > @spark-ui/progress-tracker
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-progresstracker--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/progress-tracker)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20progress-tracker)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/progress-tracker?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/progress-tracker)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/progress/README.md
+++ b/packages/components/progress/README.md
@@ -1,11 +1,10 @@
 # Progress
+
 > @spark-ui/progress
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-progress--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/progress)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20progress)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/progress?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/progress)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/radio-group/README.md
+++ b/packages/components/radio-group/README.md
@@ -1,11 +1,10 @@
 # Radio Group
+
 > @spark-ui/radio-group
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-radiogroup--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/radio-group)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20ratio-group)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/radio-group?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/radio-group)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/rating/README.md
+++ b/packages/components/rating/README.md
@@ -1,11 +1,10 @@
 # Rating
+
 > @spark-ui/rating
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-rating--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/rating)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20rating)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/rating?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/rating)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -1,11 +1,10 @@
 # Select
+
 > @spark-ui/select
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-select--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/select)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20select)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/select?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/select)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/slot/README.md
+++ b/packages/components/slot/README.md
@@ -1,11 +1,10 @@
 # Slot
+
 > @spark-ui/slot
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-slot--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/slot)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20slot)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/slot?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/slot)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/snackbar/README.md
+++ b/packages/components/snackbar/README.md
@@ -1,11 +1,10 @@
 # Snackbar
+
 > @spark-ui/snackbar
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-snackbar--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/snackbar)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20snackbar)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/snackbar?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/snackbar)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/spinner/README.md
+++ b/packages/components/spinner/README.md
@@ -1,11 +1,10 @@
 # Spinner
+
 > @spark-ui/spinner
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-spinner--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/spinner)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20spinner)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/spinner?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/spinner)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/stepper/README.md
+++ b/packages/components/stepper/README.md
@@ -1,11 +1,10 @@
 # Stepper
+
 > @spark-ui/stepper
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-stepper--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/stepper)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20stepper)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/stepper?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/stepper)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/switch/README.md
+++ b/packages/components/switch/README.md
@@ -3,7 +3,6 @@
 > @spark-ui/switch
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-switch--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/switch)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20switch)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/switch?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/switch)
 

--- a/packages/components/tabs/README.md
+++ b/packages/components/tabs/README.md
@@ -1,11 +1,10 @@
 # Tabs
+
 > @spark-ui/tabs
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-tabs--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/tabs)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20tabs)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/tabs?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/tabs)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/tag/README.md
+++ b/packages/components/tag/README.md
@@ -1,11 +1,10 @@
 # Tag
+
 > @spark-ui/tag
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-tag--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/tag)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20tag)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/tag?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/tag)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/text-link/README.md
+++ b/packages/components/text-link/README.md
@@ -1,11 +1,10 @@
 # Text Link
+
 > @spark-ui/text-link
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-textlink--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/text-link)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20text-link)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/text-link?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/text-link)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -1,11 +1,10 @@
 # Textarea
+
 > @spark-ui/textarea
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-textarea--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/textarea)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%text-area)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/textarea?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/textarea)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/components/visually-hidden/README.md
+++ b/packages/components/visually-hidden/README.md
@@ -1,11 +1,10 @@
 # Visually Hidden
+
 > @spark-ui/visually-hidden
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-visuallyhidden--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/visually-hidden)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%visually-hidden)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/visually-hidden?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/visually-hidden)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/hooks/use-combined-state/README.md
+++ b/packages/hooks/use-combined-state/README.md
@@ -1,11 +1,10 @@
 # useCombinedState
+
 > @spark-ui/use-combined-state
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/hooks-usecombinedstate--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/hooks/useCombinedState)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=hook,use-combined-state)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/use-combined-state?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/use-combined-state)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/hooks/use-merge-refs/README.md
+++ b/packages/hooks/use-merge-refs/README.md
@@ -1,11 +1,10 @@
 # useMergeRefs
+
 > @spark-ui/use-merge-refs
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/hooks-usemergerefs--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/hooks/useMergeRefs)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=hook,use-merge-refs)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/use-merge-refs?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/use-merge-refs)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/hooks/use-mounted-state/README.md
+++ b/packages/hooks/use-mounted-state/README.md
@@ -1,11 +1,10 @@
 # useMountedState
+
 > @spark-ui/use-mounted-state
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/hooks-usemountedstate--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/hooks/useMountedState)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=hook,use-mounted-state)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/use-mounted-state?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/use-mounted-state)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/utils/cli/README.md
+++ b/packages/utils/cli/README.md
@@ -1,11 +1,10 @@
 # CLI
+
 > @spark-ui/cli-utils
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/utils-cli--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/utils/cli)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=util,Type:%20Cli)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/cli-utils?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/cli-utils)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/utils/cli/src/generate/templates/component/[README.md].js
+++ b/packages/utils/cli/src/generate/templates/component/[README.md].js
@@ -7,7 +7,6 @@ export default ({ name }) => `# ${name
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/components-${name
   .split('-')
   .join('')}--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/components/${name})
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=Component,Component%3A%20${name})
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/${name}?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/${name})
 

--- a/packages/utils/cli/src/generate/templates/hook/[README.md].js
+++ b/packages/utils/cli/src/generate/templates/hook/[README.md].js
@@ -6,7 +6,6 @@ export default ({ name }) => `# ${pascalCase(name)}
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/hooks-${name
   .split('-')
   .join('')}--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/hooks/${name})
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=hook,${name})
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/${name}?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/${name})
 

--- a/packages/utils/cli/src/generate/templates/util/[README.md].js
+++ b/packages/utils/cli/src/generate/templates/util/[README.md].js
@@ -7,7 +7,6 @@ export default ({ name }) => `# ${name
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/utils-${name
   .split('-')
   .join('')}--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/utils/${name})
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=util,${name})
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/${name}?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/${name})
 

--- a/packages/utils/internal-utils/README.md
+++ b/packages/utils/internal-utils/README.md
@@ -1,11 +1,11 @@
 # Internal utils
+
 > @spark-ui/internal-utils
 
-[//]: # ([![storybook]&#40;https://img.shields.io/badge/storybook-black?logo=storybook&#41;]&#40;https://sparkui.vercel.app/?path=/docs/utils-internalutils--docs&#41;)
-[//]: # ([![documentation]&#40;https://img.shields.io/badge/documentation-black?logo=googledocs&#41;]&#40;https://sparkui-adv.vercel.app/docs/utils/internal-utils&#41;)
+[//]: # '[![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/utils-internalutils--docs)'
+
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=util,internal-utils)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/internal-utils?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/internal-utils)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/utils/tailwind-plugins/README.md
+++ b/packages/utils/tailwind-plugins/README.md
@@ -1,11 +1,10 @@
 # Tailwind Plugins
+
 > @spark-ui/tailwind-plugins
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/utils-tailwind-plugins-index--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/utils/tailwind-plugins)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=util,tailwind-plugins)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/tailwind-plugins?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/tailwind-plugins)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/packages/utils/theme/README.md
+++ b/packages/utils/theme/README.md
@@ -3,10 +3,8 @@
 > @spark-ui/theme-utils
 
 [![storybook](https://img.shields.io/badge/storybook-black?logo=storybook)](https://sparkui.vercel.app/?path=/docs/utils-theme--docs)
-[![documentation](https://img.shields.io/badge/documentation-black?logo=googledocs)](https://sparkui-adv.vercel.app/docs/utils/theme)
 [![issue](https://img.shields.io/badge/report%20a%20bug-black?logo=openbugbounty&logoColor=red)](https://github.com/adevinta/spark/issues/new?&projects=4&template=bug-report.yml&assignees=&labels=util,theme)
 [![npm](https://img.shields.io/npm/dt/%40spark-ui/theme-utils?logo=npm&labelColor=black)](https://www.npmjs.com/package/@spark-ui/theme-utils)
-
 
 This package is part of the [`@spark-ui`](https://github.com/adevinta/spark) react-js user interface component library project.
 

--- a/public/a11y/a11y-report-accordion.json
+++ b/public/a11y/a11y-report-accordion.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/accordion": {
+    "timestamp": "2024-10-07T11:59:12.707Z",
+    "url": "http://localhost:3002/a11y/accordion",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-alert-dialog.json
+++ b/public/a11y/a11y-report-alert-dialog.json
@@ -1,0 +1,114 @@
+{
+  "@spark-ui/alert-dialog": {
+    "timestamp": "2024-10-07T11:59:14.737Z",
+    "url": "http://localhost:3002/a11y/alert-dialog",
+    "incomplete": [
+      {
+        "id": "aria-hidden-focus",
+        "impact": "serious",
+        "tags": [
+          "cat.name-role-value",
+          "wcag2a",
+          "wcag412",
+          "TTv5",
+          "TT6.a",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure aria-hidden elements are not focusable nor contain focusable elements",
+        "help": "ARIA hidden element must not be focusable or contain focusable elements",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span:nth-child(1)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span:nth-child(1)"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span:nth-child(6)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span:nth-child(6)"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\"radix-:r3:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\"radix-:r3:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button data-spark-component=\"alert-dialog-title\" type=\"button\" class=\"u-shadow-border-transition box-border inline-flex items-center justify-center gap-md whitespace-nowrap px-lg text-body-1 font-bold focus-visible:outline-none focus-visible:u-ring [&amp;:not(:focus-visible)]:ring-inset min-w-sz-44 h-sz-44 rounded-lg text-on-error bg-error hover:bg-error-hovered enabled:active:bg-error-hovered focus-visible:bg-error-hovered\" aria-busy=\"false\" aria-live=\"off\" aria-haspopup=\"dialog\" aria-expanded=\"true\" aria-controls=\"radix-:r3:\" data-state=\"open\">",
+            "target": [
+              "button[aria-haspopup=\"dialog\"]"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-badge.json
+++ b/public/a11y/a11y-report-badge.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/badge": {
+    "timestamp": "2024-10-07T11:59:16.197Z",
+    "url": "http://localhost:3002/a11y/badge",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-breadcrumb.json
+++ b/public/a11y/a11y-report-breadcrumb.json
@@ -1,0 +1,61 @@
+{
+  "@spark-ui/breadcrumb": {
+    "timestamp": "2024-10-07T11:59:17.914Z",
+    "url": "http://localhost:3002/a11y/breadcrumb",
+    "incomplete": [
+      {
+        "id": "bypass",
+        "impact": "serious",
+        "tags": [
+          "cat.keyboard",
+          "wcag2a",
+          "wcag241",
+          "section508",
+          "section508.22.o",
+          "TTv5",
+          "TT9.a",
+          "EN-301-549",
+          "EN-9.2.4.1"
+        ],
+        "description": "Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content",
+        "help": "Page must have means to bypass repeated blocks",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/bypass?application=playwright",
+        "nodes": [
+          {
+            "any": [
+              {
+                "id": "internal-link-present",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "No valid skip link found"
+              },
+              {
+                "id": "header-present",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "Page does not have a heading"
+              },
+              {
+                "id": "landmark",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "Page does not have a landmark region"
+              }
+            ],
+            "all": [],
+            "none": [],
+            "impact": "serious",
+            "html": "<html lang=\"en\">",
+            "target": [
+              "html"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-button.json
+++ b/public/a11y/a11y-report-button.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/button": {
+    "timestamp": "2024-10-07T11:59:19.512Z",
+    "url": "http://localhost:3002/a11y/button",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-checkbox.json
+++ b/public/a11y/a11y-report-checkbox.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/checkbox": {
+    "timestamp": "2024-10-07T11:59:21.098Z",
+    "url": "http://localhost:3002/a11y/checkbox",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-chip.json
+++ b/public/a11y/a11y-report-chip.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/chip": {
+    "timestamp": "2024-10-07T11:59:22.605Z",
+    "url": "http://localhost:3002/a11y/chip",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-collapsible.json
+++ b/public/a11y/a11y-report-collapsible.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/collapsible": {
+    "timestamp": "2024-10-07T11:59:24.179Z",
+    "url": "http://localhost:3002/a11y/collapsible",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-combobox.json
+++ b/public/a11y/a11y-report-combobox.json
@@ -1,0 +1,67 @@
+{
+  "@spark-ui/combobox": {
+    "timestamp": "2024-10-07T11:59:25.951Z",
+    "url": "http://localhost:3002/a11y/combobox",
+    "incomplete": [
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\":combobox-field-:r4:-menu\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\":combobox-field-:r4:-menu\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<input data-spark-component=\"combobox-input\" type=\"text\" placeholder=\"Pick a book\" class=\"max-w-full shrink-0 grow basis-[80px] h-sz-28 text-ellipsis bg-surface px-sm text-body-1 outline-none disabled:cursor-not-allowed disabled:bg-transparent disabled:text-on-surface/dim-3 read-only:cursor-default read-only:bg-transparent read-only:text-on-surface\" aria-activedescendant=\"\" aria-autocomplete=\"list\" aria-controls=\":combobox-field-:r4:-menu\" aria-expanded=\"false\" aria-labelledby=\":combobox-label-:r3:\" autocomplete=\"off\" id=\":combobox-field-:r4:\" role=\"combobox\" aria-label=\"Book\" aria-haspopup=\"dialog\" data-state=\"open\" value=\"\">",
+            "target": [
+              "#\\:combobox-field-\\:r4\\:"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\":combobox-field-:rc:-menu\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\":combobox-field-:rc:-menu\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<input data-spark-component=\"combobox-input\" type=\"text\" class=\"max-w-full shrink-0 grow basis-[80px] h-sz-28 text-ellipsis bg-surface px-sm text-body-1 outline-none disabled:cursor-not-allowed disabled:bg-transparent disabled:text-on-surface/dim-3 read-only:cursor-default read-only:bg-transparent read-only:text-on-surface\" aria-activedescendant=\"\" aria-autocomplete=\"list\" aria-controls=\":combobox-field-:rc:-menu\" aria-expanded=\"true\" aria-labelledby=\":combobox-label-:rb:\" autocomplete=\"off\" id=\":combobox-field-:rc:\" role=\"combobox\" aria-label=\"Book\" aria-haspopup=\"dialog\" data-state=\"open\" value=\"\">",
+            "target": [
+              "#\\:combobox-field-\\:rc\\:"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-dialog.json
+++ b/public/a11y/a11y-report-dialog.json
@@ -1,0 +1,135 @@
+{
+  "@spark-ui/dialog": {
+    "timestamp": "2024-10-07T11:59:27.560Z",
+    "url": "http://localhost:3002/a11y/dialog",
+    "incomplete": [
+      {
+        "id": "aria-hidden-focus",
+        "impact": "serious",
+        "tags": [
+          "cat.name-role-value",
+          "wcag2a",
+          "wcag412",
+          "TTv5",
+          "TT6.a",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure aria-hidden elements are not focusable nor contain focusable elements",
+        "help": "ARIA hidden element must not be focusable or contain focusable elements",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span[data-radix-focus-guard=\"\"]:nth-child(1)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span[data-radix-focus-guard=\"\"]:nth-child(1)"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span[data-radix-focus-guard=\"\"]:nth-child(6)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span[data-radix-focus-guard=\"\"]:nth-child(6)"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\"radix-:r3:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\"radix-:r3:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button data-spark-component=\"button\" type=\"button\" class=\"u-shadow-border-transition box-border inline-flex items-center justify-center gap-md whitespace-nowrap px-lg text-body-1 font-bold focus-visible:outline-none focus-visible:u-ring [&amp;:not(:focus-visible)]:ring-inset min-w-sz-44 h-sz-44 rounded-lg bg-main text-on-main hover:bg-main-hovered enabled:active:bg-main-hovered focus-visible:bg-main-hovered\" aria-busy=\"false\" aria-live=\"off\" aria-haspopup=\"dialog\" aria-expanded=\"true\" aria-controls=\"radix-:r3:\" data-state=\"open\">",
+            "target": [
+              "button[aria-haspopup=\"dialog\"]"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "noId",
+                  "needsReview": "aria-describedby=\"radix-:r5:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "ARIA attribute element ID does not exist on the page: aria-describedby=\"radix-:r5:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<div role=\"dialog\" id=\"radix-:r3:\" aria-describedby=\"radix-:r5:\" aria-labelledby=\"radix-:r4:\" data-state=\"open\" data-spark-component=\"dialog-content\" class=\"z-modal flex flex-col bg-surface group focus-visible:outline-none focus-visible:u-ring [&amp;:not(:has(footer))]:pb-lg [&amp;:not(:has(header))]:pt-lg max-w-sz-672 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-h-[80%] shadow-md rounded-lg data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out w-full\" tabindex=\"-1\" style=\"pointer-events: auto;\">",
+            "target": [
+              "#radix-\\:r3\\:"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-divider.json
+++ b/public/a11y/a11y-report-divider.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/divider": {
+    "timestamp": "2024-10-07T11:59:14.025Z",
+    "url": "http://localhost:3002/a11y/divider",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-drawer.json
+++ b/public/a11y/a11y-report-drawer.json
@@ -1,0 +1,114 @@
+{
+  "@spark-ui/drawer": {
+    "timestamp": "2024-10-07T11:59:15.632Z",
+    "url": "http://localhost:3002/a11y/drawer",
+    "incomplete": [
+      {
+        "id": "aria-hidden-focus",
+        "impact": "serious",
+        "tags": [
+          "cat.name-role-value",
+          "wcag2a",
+          "wcag412",
+          "TTv5",
+          "TT6.a",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure aria-hidden elements are not focusable nor contain focusable elements",
+        "help": "ARIA hidden element must not be focusable or contain focusable elements",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span:nth-child(1)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span:nth-child(1)"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "focusable-modal-open",
+                "data": null,
+                "relatedNodes": [
+                  {
+                    "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+                    "target": [
+                      "span:nth-child(6)"
+                    ]
+                  }
+                ],
+                "impact": "serious",
+                "message": "Check that focusable elements are not tabbable in the current state"
+              }
+            ],
+            "none": [],
+            "impact": "serious",
+            "html": "<span data-radix-focus-guard=\"\" tabindex=\"0\" style=\"outline: currentcolor; opacity: 0; position: fixed; pointer-events: none;\" data-aria-hidden=\"true\" aria-hidden=\"true\"></span>",
+            "target": [
+              "span:nth-child(6)"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\"radix-:r3:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\"radix-:r3:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button data-spark-component=\"button\" type=\"button\" class=\"u-shadow-border-transition box-border inline-flex items-center justify-center gap-md whitespace-nowrap px-lg text-body-1 font-bold focus-visible:outline-none focus-visible:u-ring [&amp;:not(:focus-visible)]:ring-inset min-w-sz-44 h-sz-44 rounded-lg bg-main text-on-main hover:bg-main-hovered enabled:active:bg-main-hovered focus-visible:bg-main-hovered\" aria-busy=\"false\" aria-live=\"off\" aria-haspopup=\"dialog\" aria-expanded=\"true\" aria-controls=\"radix-:r3:\" data-state=\"open\">",
+            "target": [
+              "button[aria-haspopup=\"dialog\"]"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-dropdown.json
+++ b/public/a11y/a11y-report-dropdown.json
@@ -1,0 +1,67 @@
+{
+  "@spark-ui/dropdown": {
+    "timestamp": "2024-10-07T11:59:17.417Z",
+    "url": "http://localhost:3002/a11y/dropdown",
+    "incomplete": [
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\":dropdown-input-:r4:-menu\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\":dropdown-input-:r4:-menu\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button type=\"button\" class=\"flex w-full items-center justify-between min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg text-body-1 ring-1 outline-none ring-inset focus:ring-2 ring-outline focus:ring-outline-high hover:ring-outline-high\" aria-activedescendant=\"\" aria-controls=\":dropdown-input-:r4:-menu\" aria-expanded=\"false\" aria-haspopup=\"listbox\" aria-labelledby=\":dropdown-label-:r3:\" id=\":dropdown-input-:r4:-toggle-button\" role=\"combobox\" tabindex=\"0\" data-spark-component=\"dropdown-trigger\" data-state=\"open\">",
+            "target": [
+              "#\\:dropdown-input-\\:r4\\:-toggle-button"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\":dropdown-input-:rc:-menu\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\":dropdown-input-:rc:-menu\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button type=\"button\" class=\"flex w-full items-center justify-between min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg text-body-1 ring-1 outline-none ring-inset focus:ring-2 ring-outline focus:ring-outline-high hover:ring-outline-high\" aria-activedescendant=\"\" aria-controls=\":dropdown-input-:rc:-menu\" aria-expanded=\"false\" aria-haspopup=\"listbox\" aria-labelledby=\":dropdown-label-:rb:\" id=\":dropdown-input-:rc:-toggle-button\" role=\"combobox\" tabindex=\"0\" data-spark-component=\"dropdown-trigger\" data-state=\"open\">",
+            "target": [
+              "#\\:dropdown-input-\\:rc\\:-toggle-button"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-form-field.json
+++ b/public/a11y/a11y-report-form-field.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/form-field": {
+    "timestamp": "2024-10-07T11:59:19.036Z",
+    "url": "http://localhost:3002/a11y/form-field",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-icon-button.json
+++ b/public/a11y/a11y-report-icon-button.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/icon-button": {
+    "timestamp": "2024-10-07T11:59:21.935Z",
+    "url": "http://localhost:3002/a11y/icon-button",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-icon.json
+++ b/public/a11y/a11y-report-icon.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/icon": {
+    "timestamp": "2024-10-07T11:59:20.538Z",
+    "url": "http://localhost:3002/a11y/icon",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-input.json
+++ b/public/a11y/a11y-report-input.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/input": {
+    "timestamp": "2024-10-07T11:59:23.447Z",
+    "url": "http://localhost:3002/a11y/input",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-kbd.json
+++ b/public/a11y/a11y-report-kbd.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/kbd": {
+    "timestamp": "2024-10-07T11:59:24.916Z",
+    "url": "http://localhost:3002/a11y/kbd",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-label.json
+++ b/public/a11y/a11y-report-label.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/label": {
+    "timestamp": "2024-10-07T11:59:26.385Z",
+    "url": "http://localhost:3002/a11y/label",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-link-box.json
+++ b/public/a11y/a11y-report-link-box.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/link-box": {
+    "timestamp": "2024-10-07T11:59:27.839Z",
+    "url": "http://localhost:3002/a11y/link-box",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-pagination.json
+++ b/public/a11y/a11y-report-pagination.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/pagination": {
+    "timestamp": "2024-10-07T11:59:17.854Z",
+    "url": "http://localhost:3002/a11y/pagination",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-popover.json
+++ b/public/a11y/a11y-report-popover.json
@@ -1,0 +1,67 @@
+{
+  "@spark-ui/popover": {
+    "timestamp": "2024-10-07T11:59:19.689Z",
+    "url": "http://localhost:3002/a11y/popover",
+    "incomplete": [
+      {
+        "id": "aria-valid-attr-value",
+        "impact": "critical",
+        "tags": [
+          "cat.aria",
+          "wcag2a",
+          "wcag412",
+          "EN-301-549",
+          "EN-9.4.1.2"
+        ],
+        "description": "Ensure all ARIA attributes have valid values",
+        "help": "ARIA attributes must conform to valid values",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=playwright",
+        "nodes": [
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\"radix-:r1:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\"radix-:r1:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button data-spark-component=\"popover-trigger\" type=\"button\" class=\"u-shadow-border-transition box-border inline-flex items-center justify-center gap-md whitespace-nowrap px-lg text-body-1 font-bold focus-visible:outline-none focus-visible:u-ring [&amp;:not(:focus-visible)]:ring-inset min-w-sz-44 h-sz-44 rounded-lg bg-main text-on-main hover:bg-main-hovered enabled:active:bg-main-hovered focus-visible:bg-main-hovered\" aria-busy=\"false\" aria-live=\"off\" aria-haspopup=\"dialog\" aria-expanded=\"false\" aria-controls=\"radix-:r1:\" data-state=\"closed\">",
+            "target": [
+              "button[aria-controls=\"radix-:r1:\"]"
+            ]
+          },
+          {
+            "any": [],
+            "all": [
+              {
+                "id": "aria-valid-attr-value",
+                "data": {
+                  "messageKey": "controlsWithinPopup",
+                  "needsReview": "aria-controls=\"radix-:r3:\""
+                },
+                "relatedNodes": [],
+                "impact": "critical",
+                "message": "Unable to determine if aria-controls referenced ID exists on the page while using aria-haspopup: aria-controls=\"radix-:r3:\""
+              }
+            ],
+            "none": [],
+            "impact": "critical",
+            "html": "<button data-spark-component=\"popover-trigger\" type=\"button\" class=\"u-shadow-border-transition box-border inline-flex items-center justify-center gap-md whitespace-nowrap px-lg text-body-1 font-bold focus-visible:outline-none focus-visible:u-ring [&amp;:not(:focus-visible)]:ring-inset min-w-sz-44 h-sz-44 rounded-lg bg-main text-on-main hover:bg-main-hovered enabled:active:bg-main-hovered focus-visible:bg-main-hovered\" aria-busy=\"false\" aria-live=\"off\" aria-haspopup=\"dialog\" aria-expanded=\"false\" aria-controls=\"radix-:r3:\" data-state=\"closed\">",
+            "target": [
+              "button[aria-controls=\"radix-:r3:\"]"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-progress-tracker.json
+++ b/public/a11y/a11y-report-progress-tracker.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/progress-tracker": {
+    "timestamp": "2024-10-07T11:59:22.754Z",
+    "url": "http://localhost:3002/a11y/progress-tracker",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-progress.json
+++ b/public/a11y/a11y-report-progress.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/progress": {
+    "timestamp": "2024-10-07T11:59:21.179Z",
+    "url": "http://localhost:3002/a11y/progress",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-radio-group.json
+++ b/public/a11y/a11y-report-radio-group.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/radio-group": {
+    "timestamp": "2024-10-07T11:59:24.371Z",
+    "url": "http://localhost:3002/a11y/radio-group",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-rating.json
+++ b/public/a11y/a11y-report-rating.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/rating": {
+    "timestamp": "2024-10-07T11:59:25.922Z",
+    "url": "http://localhost:3002/a11y/rating",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-select.json
+++ b/public/a11y/a11y-report-select.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/select": {
+    "timestamp": "2024-10-07T11:59:27.437Z",
+    "url": "http://localhost:3002/a11y/select",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-slider.json
+++ b/public/a11y/a11y-report-slider.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/slider": {
+    "timestamp": "2024-10-07T11:59:28.697Z",
+    "url": "http://localhost:3002/a11y/slider",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-snackbar.json
+++ b/public/a11y/a11y-report-snackbar.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/snackbar": {
+    "timestamp": "2024-10-07T11:59:29.675Z",
+    "url": "http://localhost:3002/a11y/snackbar",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-spinner.json
+++ b/public/a11y/a11y-report-spinner.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/spinner": {
+    "timestamp": "2024-10-07T11:59:30.600Z",
+    "url": "http://localhost:3002/a11y/spinner",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-stepper.json
+++ b/public/a11y/a11y-report-stepper.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/stepper": {
+    "timestamp": "2024-10-07T11:59:18.236Z",
+    "url": "http://localhost:3002/a11y/stepper",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-switch.json
+++ b/public/a11y/a11y-report-switch.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/switch": {
+    "timestamp": "2024-10-07T11:59:19.889Z",
+    "url": "http://localhost:3002/a11y/switch",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-tabs.json
+++ b/public/a11y/a11y-report-tabs.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/tabs": {
+    "timestamp": "2024-10-07T11:59:21.439Z",
+    "url": "http://localhost:3002/a11y/tabs",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-tag.json
+++ b/public/a11y/a11y-report-tag.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/tag": {
+    "timestamp": "2024-10-07T11:59:22.959Z",
+    "url": "http://localhost:3002/a11y/tag",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-text-link.json
+++ b/public/a11y/a11y-report-text-link.json
@@ -1,0 +1,61 @@
+{
+  "@spark-ui/text-link": {
+    "timestamp": "2024-10-07T11:59:26.068Z",
+    "url": "http://localhost:3002/a11y/text-link",
+    "incomplete": [
+      {
+        "id": "bypass",
+        "impact": "serious",
+        "tags": [
+          "cat.keyboard",
+          "wcag2a",
+          "wcag241",
+          "section508",
+          "section508.22.o",
+          "TTv5",
+          "TT9.a",
+          "EN-301-549",
+          "EN-9.2.4.1"
+        ],
+        "description": "Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content",
+        "help": "Page must have means to bypass repeated blocks",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/bypass?application=playwright",
+        "nodes": [
+          {
+            "any": [
+              {
+                "id": "internal-link-present",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "No valid skip link found"
+              },
+              {
+                "id": "header-present",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "Page does not have a heading"
+              },
+              {
+                "id": "landmark",
+                "data": null,
+                "relatedNodes": [],
+                "impact": "serious",
+                "message": "Page does not have a landmark region"
+              }
+            ],
+            "all": [],
+            "none": [],
+            "impact": "serious",
+            "html": "<html lang=\"en\">",
+            "target": [
+              "html"
+            ]
+          }
+        ]
+      }
+    ],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-textarea.json
+++ b/public/a11y/a11y-report-textarea.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/textarea": {
+    "timestamp": "2024-10-07T11:59:24.496Z",
+    "url": "http://localhost:3002/a11y/textarea",
+    "incomplete": [],
+    "violations": []
+  }
+}

--- a/public/a11y/a11y-report-visually-hidden.json
+++ b/public/a11y/a11y-report-visually-hidden.json
@@ -1,0 +1,8 @@
+{
+  "@spark-ui/visually-hidden": {
+    "timestamp": "2024-10-07T11:59:27.520Z",
+    "url": "http://localhost:3002/a11y/visually-hidden",
+    "incomplete": [],
+    "violations": []
+  }
+}


### PR DESCRIPTION
We noticed the documentation badge was deprecated and sending to outdated url.