### PR TITLE
docs: story page to check color contrasts

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,6 +20,12 @@ module.exports = {
         'max-lines': 0,
       },
     },
+    {
+      files: ['*.stories.tsx', '*.stories.ts'], // avoid "circular dependencies" error inside stories
+      rules: {
+        '@nx/enforce-module-boundaries': 'off',
+      },
+    },
   ],
   settings: {
     react: {
@@ -48,7 +54,7 @@ module.exports = {
     // NX
     '@nx/enforce-module-boundaries': 2,
     // Prettier
-    "prettier/prettier": [1, { "endOfLine": "auto" }],
+    'prettier/prettier': [1, { endOfLine: 'auto' }],
     // Typescript
     '@typescript-eslint/consistent-type-definitions': [1, 'interface'],
     '@typescript-eslint/array-type': [2, { default: 'array', readonly: 'array' }],

--- a/packages/utils/theme/src/contrastCheck.doc.mdx
+++ b/packages/utils/theme/src/contrastCheck.doc.mdx
@@ -1,0 +1,73 @@
+import { Canvas, Meta } from '@storybook/addon-docs'
+import * as ContrastCheck from './contrastCheck.stories'
+
+<Meta of={ContrastCheck} />
+
+# Contrast check
+
+## Usage
+
+```typescript
+import { getThemeContrastReport, checkColorContrast } from '@spark-ui/theme-utils'
+```
+
+### getThemeContrastReport
+
+Use `getThemeContrastReport(theme)` to get a detailed report of the contrast ratio for each pair of colors in the theme.
+
+For exemple `main` colored background is supposed to have `onMain` colored text. The pair `main/onMain` must provide sufficient contrast ratio to pass [SC 1.4.3 - Contrast (Minimum) (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+Same goes for every other color pair in a Spark theme.
+
+Each pair is tested for normal text size and larger text size, as they both have different contrast requirements.
+
+Score can be: `Failed`, `AA` or `AAA`.
+
+```typescript
+import { checkColorContrast } from '@spark-ui/theme-utils'
+
+const report = getThemeContrastReport(theme)
+```
+
+Report looks like this:
+
+```json
+// Exemple for the main color
+{
+  "main": {
+    "previewStyles": "bg-main text-on-main",
+    "small": {
+      "contrastRatio": "3.48",
+      "score": "Failed",
+      "textSize": "Small",
+      "colors": ["#EC5A13", "#FFFFFF"]
+    },
+    "large": {
+      "contrastRatio": "3.48",
+      "score": "Failed",
+      "textSize": "Small",
+      "colors": ["#EC5A13", "#FFFFFF"]
+    }
+  }
+  // other colors...
+}
+```
+
+### checkColorContrast
+
+Use `checkColorContrast` to compare two colors given a font-size.
+
+```typescript
+import { checkColorContrast } from '@spark-ui/theme-utils'
+
+const LARGE_FONT_SIZE = 24
+
+checkColorContrast('#EC5A13', '#FFFFFF', LARGE_FONT_SIZE) // { "contrastRatio": "3.48", "score": "Failed", "textSize": "Large", "colors": ["#EC5A13", "#FFFFFF"] }
+```
+
+## Spark theme contrasts
+
+This section displays card with all color schemes offered by Spark themes (default and dark).
+
+It can be used by Axe dev tools or Playwright for an a11y color check.
+
+<Canvas of={ContrastCheck.Default} />

--- a/packages/utils/theme/src/contrastCheck.stories.tsx
+++ b/packages/utils/theme/src/contrastCheck.stories.tsx
@@ -1,0 +1,94 @@
+import { Icon } from '@spark-ui/icon'
+import { Block } from '@spark-ui/icons/dist/icons/Block'
+import { Check } from '@spark-ui/icons/dist/icons/Check'
+import { Tabs } from '@spark-ui/tabs'
+import { Tag } from '@spark-ui/tag'
+import { Meta, StoryFn } from '@storybook/react'
+import { cx } from 'class-variance-authority'
+import { ReactNode } from 'react'
+
+import { getThemeContrastReport } from './contrastCheck'
+import { defaultTheme } from './defaultTheme'
+import { defaultThemeDark } from './defaultThemeDark'
+import { type Theme } from './types'
+
+const meta: Meta = {
+  title: 'Utils/theme-utils/contrast check',
+}
+
+export default meta
+
+const ScoreTag = ({ score }: { score: string }) => {
+  const isSuccess = score.includes('AA')
+
+  return (
+    <Tag design="tinted" intent={isSuccess ? 'success' : 'danger'}>
+      {score}
+      <Icon>{isSuccess ? <Check /> : <Block />}</Icon>
+    </Tag>
+  )
+}
+
+const Cell = ({ className, children }: { className?: string; children: ReactNode }) => {
+  return <td className={cx('border-sm border-outline p-md', className)}>{children}</td>
+}
+
+const ThemeReport = ({ theme, ...rest }: { theme: Theme }) => {
+  const report = getThemeContrastReport(theme)
+
+  return (
+    <table className="table-auto bg-surface text-on-surface" {...rest}>
+      <thead className="sticky">
+        <tr>
+          <th className="p-sm text-left">Color</th>
+          <th className="p-sm text-left">Preview</th>
+          <th className="p-sm text-left">Ratio</th>
+          <th className="p-sm text-left">Score (small text)</th>
+          <th className="p-sm text-left">Score (large text)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.entries(report).map(([color, result]) => {
+          return (
+            <tr>
+              <Cell>{color}</Cell>
+              <Cell className={cx('border-current px-lg', result.previewStyles)}>
+                <span className="text-body-1">small, </span>
+                <span className="text-headline-1">large</span>
+              </Cell>
+              <Cell>{result.small.contrastRatio}</Cell>
+              <Cell>
+                <ScoreTag score={result.small.score} />
+              </Cell>
+              <Cell>
+                <ScoreTag score={result.large.score} />
+              </Cell>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+export const Default: StoryFn = _args => (
+  <div className="flex">
+    <Tabs defaultValue="tab1">
+      <Tabs.List>
+        <Tabs.Trigger value="tab1">
+          <span>Default theme</span>
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2">
+          <span>Dark theme</span>
+        </Tabs.Trigger>
+      </Tabs.List>
+
+      <Tabs.Content value="tab1" data-theme="default">
+        <ThemeReport theme={defaultTheme} />
+      </Tabs.Content>
+      <Tabs.Content value="tab2" data-theme="dark" className="bg-surface">
+        <ThemeReport theme={defaultThemeDark} />
+      </Tabs.Content>
+    </Tabs>
+  </div>
+)

--- a/packages/utils/theme/src/contrastCheck.ts
+++ b/packages/utils/theme/src/contrastCheck.ts
@@ -1,0 +1,270 @@
+import { Theme } from './types'
+
+function hexToLuminance(hex: string): number {
+  // Convert hex to RGB
+  const r = parseInt(hex.slice(1, 3), 16) / 255
+  const g = parseInt(hex.slice(3, 5), 16) / 255
+  const b = parseInt(hex.slice(5, 7), 16) / 255
+
+  // Apply the formula for relative luminance
+  const rgb = [r, g, b].map((value): number => {
+    return value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4)
+  }) as [number, number, number]
+
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+}
+
+function contrastRatio(hex1: string, hex2: string): number {
+  const luminance1 = hexToLuminance(hex1)
+  const luminance2 = hexToLuminance(hex2)
+
+  const ratio =
+    (Math.max(luminance1, luminance2) + 0.05) / (Math.min(luminance1, luminance2) + 0.05)
+
+  return ratio
+}
+
+function getWCAGScore(contrast: number, fontSizePx: number): string {
+  const isLargeText = fontSizePx >= 24 // 24px or larger is considered large text
+
+  if (contrast >= 7) {
+    return 'AAA'
+  } else if (contrast >= 4.5 && !isLargeText) {
+    return 'AA'
+  } else if (contrast >= 3 && isLargeText) {
+    return 'AA'
+  } else {
+    return 'Failed'
+  }
+}
+
+/**
+ * https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+ *
+ * - Normal text  expected ratio: 4.5:1
+ * - Large text (>= 18pt or 14pt with bold font) expected ratio: 3:1
+ *
+ * (1pt = 1.333px, therefore 14pt and 18pt are equivalent to approximately 18.5px and 24px)
+ *
+ *
+ * How to read contrast:
+ *
+ * In the ratio "4.5:1", the 4.5 represents the luminance of the lighter color compared to the darker color, which is 1.
+ * A ratio of 4.5:1 means the lighter color is 4.5 times brighter than the darker color.
+ *
+ * 1:1 – No contrast (the two colors are identical).
+ * 21:1 (maximum contrast, black vs. white).
+ */
+export function checkColorContrast(
+  hex1: string,
+  hex2: string,
+  fontSizePx: number
+): { contrastRatio: string; score: string; textSize: string; colors: [string, string] } {
+  const ratio = contrastRatio(hex1, hex2)
+
+  return {
+    contrastRatio: ratio.toFixed(2),
+    score: getWCAGScore(ratio, fontSizePx),
+    textSize: fontSizePx >= 24 ? 'Large' : 'Small',
+    colors: [hex1, hex2],
+  }
+}
+
+const NORMAL_FONT_SIZE = 16
+const LARGE_FONT_SIZE = 16
+
+const getSmallAndLargeCompliance = (background: string, foreground: string) => {
+  return {
+    small: checkColorContrast(background, foreground, NORMAL_FONT_SIZE),
+    large: checkColorContrast(background, foreground, LARGE_FONT_SIZE),
+  }
+}
+
+export const getThemeContrastReport = (theme: Theme) => {
+  const { colors } = theme
+
+  const tokenPairsReport = {
+    // MAIN
+    main: {
+      previewStyles: 'bg-main text-on-main',
+      ...getSmallAndLargeCompliance(colors.main, colors.onMain),
+    },
+    mainHovered: {
+      previewStyles: 'bg-main-hovered text-on-main',
+      ...getSmallAndLargeCompliance(colors.mainHovered, colors.onMain),
+    },
+    mainContainer: {
+      previewStyles: 'bg-main-container text-on-main-container',
+      ...getSmallAndLargeCompliance(colors.mainContainer, colors.onMainContainer),
+    },
+    mainContainerHovered: {
+      previewStyles: 'bg-main-container-hovered text-on-main-container',
+      ...getSmallAndLargeCompliance(colors.mainContainerHovered, colors.onMainContainer),
+    },
+    // SUPPORT
+    support: {
+      previewStyles: 'bg-support text-on-support',
+      ...getSmallAndLargeCompliance(colors.support, colors.onSupport),
+    },
+    supportHovered: {
+      previewStyles: 'bg-support-hovered text-on-support',
+      ...getSmallAndLargeCompliance(colors.supportHovered, colors.onSupport),
+    },
+    supportContainer: {
+      previewStyles: 'bg-support-container text-on-support-container',
+      ...getSmallAndLargeCompliance(colors.supportContainer, colors.onSupportContainer),
+    },
+    supportContainerHovered: {
+      previewStyles: 'bg-support-container-hovered text-on-support-container',
+      ...getSmallAndLargeCompliance(colors.supportContainerHovered, colors.onSupportContainer),
+    },
+    // ACCENT
+    accent: {
+      previewStyles: 'bg-accent text-on-accent',
+      ...getSmallAndLargeCompliance(colors.accent, colors.onAccent),
+    },
+    accentHovered: {
+      previewStyles: 'bg-accent-hovered text-on-accent',
+      ...getSmallAndLargeCompliance(colors.accentHovered, colors.onAccent),
+    },
+    accentContainer: {
+      previewStyles: 'bg-accent-container text-on-accent-container',
+      ...getSmallAndLargeCompliance(colors.accentContainer, colors.onAccentContainer),
+    },
+    accentContainerHovered: {
+      previewStyles: 'bg-accent-container-hovered text-on-accent-container',
+      ...getSmallAndLargeCompliance(colors.accentContainerHovered, colors.onAccentContainer),
+    },
+    // BASIC
+    basic: {
+      previewStyles: 'bg-basic text-on-basic',
+      ...getSmallAndLargeCompliance(colors.basic, colors.onBasic),
+    },
+    basicHovered: {
+      previewStyles: 'bg-basic-hovered text-on-basic',
+      ...getSmallAndLargeCompliance(colors.basicHovered, colors.onBasic),
+    },
+    basicContainer: {
+      previewStyles: 'bg-basic-container text-on-basic-container',
+      ...getSmallAndLargeCompliance(colors.basicContainer, colors.onBasicContainer),
+    },
+    basicContainerHovered: {
+      previewStyles: 'bg-basic-container-hovered text-on-basic-container',
+      ...getSmallAndLargeCompliance(colors.basicContainerHovered, colors.onBasicContainer),
+    },
+    // SUCCESS
+    success: {
+      previewStyles: 'bg-success text-on-success',
+      ...getSmallAndLargeCompliance(colors.success, colors.onSuccess),
+    },
+    successHovered: {
+      previewStyles: 'bg-success-hovered text-on-success',
+      ...getSmallAndLargeCompliance(colors.successHovered, colors.onSuccess),
+    },
+    successContainer: {
+      previewStyles: 'bg-success-container text-on-success-container',
+      ...getSmallAndLargeCompliance(colors.successContainer, colors.onSuccessContainer),
+    },
+    successContainerHovered: {
+      previewStyles: 'bg-success-container-hovered text-on-success-container',
+      ...getSmallAndLargeCompliance(colors.successContainerHovered, colors.onSuccessContainer),
+    },
+    // ERROR
+    error: {
+      previewStyles: 'bg-error text-on-error',
+      ...getSmallAndLargeCompliance(colors.error, colors.onError),
+    },
+    errorHovered: {
+      previewStyles: 'bg-error-hovered text-on-error',
+      ...getSmallAndLargeCompliance(colors.errorHovered, colors.onError),
+    },
+    errorContainer: {
+      previewStyles: 'bg-error-container text-on-error-container',
+      ...getSmallAndLargeCompliance(colors.errorContainer, colors.onErrorContainer),
+    },
+    errorContainerHovered: {
+      previewStyles: 'bg-error-container-hovered text-on-error-container',
+      ...getSmallAndLargeCompliance(colors.errorContainerHovered, colors.onErrorContainer),
+    },
+    // ALERT
+    alert: {
+      previewStyles: 'bg-alert text-on-alert',
+      ...getSmallAndLargeCompliance(colors.alert, colors.onAlert),
+    },
+    alertHovered: {
+      previewStyles: 'bg-alert-hovered text-on-alert',
+      ...getSmallAndLargeCompliance(colors.alertHovered, colors.onAlert),
+    },
+    alertContainer: {
+      previewStyles: 'bg-alert-container text-on-alert-container',
+      ...getSmallAndLargeCompliance(colors.alertContainer, colors.onAlertContainer),
+    },
+    alertContainerHovered: {
+      previewStyles: 'bg-alert-container-hovered text-on-alert-container',
+      ...getSmallAndLargeCompliance(colors.alertContainerHovered, colors.onAlertContainer),
+    },
+    // INFO
+    info: {
+      previewStyles: 'bg-info text-on-info',
+      ...getSmallAndLargeCompliance(colors.info, colors.onInfo),
+    },
+    infoHovered: {
+      previewStyles: 'bg-info-hovered text-on-info',
+      ...getSmallAndLargeCompliance(colors.infoHovered, colors.onInfo),
+    },
+    infoContainer: {
+      previewStyles: 'bg-info-container text-on-info-container',
+      ...getSmallAndLargeCompliance(colors.infoContainer, colors.onInfoContainer),
+    },
+    infoContainerHovered: {
+      previewStyles: 'bg-info-container-hovered text-on-info-container',
+      ...getSmallAndLargeCompliance(colors.infoContainerHovered, colors.onInfoContainer),
+    },
+    // NEUTRAL
+    neutral: {
+      previewStyles: 'bg-neutral text-on-neutral',
+      ...getSmallAndLargeCompliance(colors.neutral, colors.onNeutral),
+    },
+    neutralHovered: {
+      previewStyles: 'bg-neutral-hovered text-on-neutral',
+      ...getSmallAndLargeCompliance(colors.neutralHovered, colors.onNeutral),
+    },
+    neutralContainer: {
+      previewStyles: 'bg-neutral-container text-on-neutral-container',
+      ...getSmallAndLargeCompliance(colors.neutralContainer, colors.onNeutralContainer),
+    },
+    neutralContainerHovered: {
+      previewStyles: 'bg-neutral-container-hovered text-on-neutral-container',
+      ...getSmallAndLargeCompliance(colors.neutralContainerHovered, colors.onNeutralContainer),
+    },
+    // BACKGROUND
+    background: {
+      previewStyles: 'bg-background text-on-background',
+      ...getSmallAndLargeCompliance(colors.background, colors.onBackground),
+    },
+    backgroundVariant: {
+      previewStyles: 'bg-background-variant text-on-background-variant',
+      ...getSmallAndLargeCompliance(colors.backgroundVariant, colors.onBackgroundVariant),
+    },
+    // SURFACE
+    surface: {
+      previewStyles: 'bg-surface text-on-surface',
+      ...getSmallAndLargeCompliance(colors.surface, colors.onSurface),
+    },
+    surfaceHovered: {
+      previewStyles: 'bg-surface-hovered text-on-surface',
+      ...getSmallAndLargeCompliance(colors.surfaceHovered, colors.onSurface),
+    },
+    // SURFACE INVERSE
+    surfaceInverse: {
+      previewStyles: 'bg-surface-inverse text-on-surface-inverse',
+      ...getSmallAndLargeCompliance(colors.surfaceInverse, colors.onSurfaceInverse),
+    },
+    surfaceInverseHovered: {
+      previewStyles: 'bg-surface-inverse-hovered text-on-surface-inverse',
+      ...getSmallAndLargeCompliance(colors.surfaceInverseHovered, colors.onSurfaceInverse),
+    },
+  }
+
+  return tokenPairsReport
+}

--- a/packages/utils/theme/src/index.doc.mdx
+++ b/packages/utils/theme/src/index.doc.mdx
@@ -1,25 +1,16 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="utils/Theme" />
+<Meta title="utils/theme-utils/theming" />
 
 # Theme utils
 
 The **`@spark-ui/theme-utils`** exposes the following:
 
 ```tsx
-import { Theme, defaultTheme, defaultThemeDark, createTheme } from '@spark-ui/theme-utils'
+import { defaultTheme, defaultThemeDark, createTheme, type Theme } from '@spark-ui/theme-utils'
 ```
 
-- [Theme](#theme)
-- [defaultTheme](#defaulttheme)
-- [defaultThemeDark](#defaultthemedark)
-- [createTheme](#createtheme)
-
 ## @spark-ui/theme-utils
-
-### Theme
-
-- `Theme`, the TypeScript interface for our theme
 
 ### defaultTheme
 
@@ -28,6 +19,10 @@ import { Theme, defaultTheme, defaultThemeDark, createTheme } from '@spark-ui/th
 ### defaultThemeDark
 
 - `defaultTheme`, our dark default theme, represented as an `Object`
+
+### Theme
+
+- `Theme`, the TypeScript interface for our theme
 
 ### createTheme
 

--- a/packages/utils/theme/src/index.ts
+++ b/packages/utils/theme/src/index.ts
@@ -1,5 +1,6 @@
 export { createTheme } from './createTheme'
 export { defaultTheme } from './defaultTheme'
 export { defaultThemeDark } from './defaultThemeDark'
+export { getThemeContrastReport, checkColorContrast } from './contrastCheck'
 
 export type { Theme, ThemeConfig } from './types'


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: #2440 

### Description, Motivation and Context

Added utility to `@spark-ui/theme-utils` to check the accessibility of color contrasts in Spark's themes (or custom themes)


### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
![Capture d’écran 2024-10-08 à 18 07 20](https://github.com/user-attachments/assets/27358b90-a9f4-4a27-9077-40e1ab09d0a8)

