### PR TITLE
fix(theme-utils): fixed large font size for color contrast check

### DIFF
--- a/packages/utils/theme/src/contrastCheck.ts
+++ b/packages/utils/theme/src/contrastCheck.ts
@@ -71,7 +71,7 @@ export function checkColorContrast(
 }
 
 const NORMAL_FONT_SIZE = 16
-const LARGE_FONT_SIZE = 16
+const LARGE_FONT_SIZE = 24
 
 const getSmallAndLargeCompliance = (background: string, foreground: string) => {
   return {


### PR DESCRIPTION
### Description, Motivation and Context

For WCAG color contrast check, large text font size is `24`, not `16`.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
