### PR TITLE
feat(breadcrumb): update BreadcrumbItem styles

### DIFF
--- a/packages/components/breadcrumb/src/BreadcrumbItem.tsx
+++ b/packages/components/breadcrumb/src/BreadcrumbItem.tsx
@@ -10,7 +10,7 @@ export const Item = forwardRef<HTMLLIElement, ItemProps>(({ className, ...rest }
     <li
       data-spark-component="breadcrumb-item"
       ref={ref}
-      className={cx('inline-flex items-center gap-sm', className)}
+      className={cx('inline-flex min-w-none items-center gap-sm', className)}
       {...rest}
     />
   )


### PR DESCRIPTION
Add the `min-w-none` class to `BreadcrumbItem` to ensure text truncation occurs when it's too long relative to the container