### PR TITLE
fix: prevent removal of anchors from URLs upon page load

### DIFF
--- a/.storybook/addons/SkinlessThemeSwitcherHandler.jsx
+++ b/.storybook/addons/SkinlessThemeSwitcherHandler.jsx
@@ -1,19 +1,61 @@
-import { memo, useEffect } from "react"
+import { memo, useEffect, useSyncExternalStore, useRef } from "react"
+
+/*
+  1. Refer to this issue for the context behind this:
+     https://github.com/adevinta/spark/pull/2497
+*/
 
 import { useGlobals } from "@storybook/manager-api"
 
+
+function useUrlChange() {
+  /* 1 */
+  return useSyncExternalStore(
+    (callback) => {
+      window.addEventListener("popstate", callback)
+
+      return () => {
+        window.removeEventListener("popstate", callback)
+      }
+    },
+    () => window.location.href,
+  )
+}
+
 export const SkinlessThemeSwitcherHandler = memo(function SkinlessThemeSwitcherHandler() {
   const [globals] = useGlobals()
+
   const theme = globals?.theme
+  const url = useUrlChange()
+  const initialUrlHashRef = useRef("")
+  const initialUrlSearchRef = useRef("")
+
+  useEffect(() => {
+    /* 1 */
+    initialUrlHashRef.current = window.location.hash
+    initialUrlSearchRef.current = window.location.search
+  }, [])
+
+  useEffect(() => {
+    /* 1 */
+    const isNotInitialPage = initialUrlSearchRef.current !== window.location.search
+    const isNotInitialHash =
+      window.location.hash.length && window.location.hash !== initialUrlHashRef.current
+
+    if (isNotInitialPage || isNotInitialHash) return
+
+    const newUrl = new URL(window.location)
+    newUrl.hash = initialUrlHashRef.current
+    window.history.replaceState(null, "", newUrl)
+  }, [url])
 
   useEffect(() => {
     if (!theme) return
 
     const htmlElement = document.querySelector("html")
-    if (htmlElement)  {
+    if (htmlElement) {
       htmlElement.setAttribute("data-theme", theme)
     }
-
     const iframe = document.querySelector("#storybook-preview-iframe")
     if (iframe) {
       const iframeHtmlElement = iframe.contentDocument?.documentElement


### PR DESCRIPTION
### Description, Motivation and Context

Our Storybook URLs with anchors are currently not functioning as expected. When a URL contains an anchor (href) to a specific heading on the page, the anchor is being removed upon page load. As a result, the page is not automatically scrolling to the corresponding section.

### Types of changes
- [x] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
