### PR TITLE
feat(visually-hidden): added asChild prop to VisuallyHidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30460,6 +30460,9 @@
       "name": "@spark-ui/visually-hidden",
       "version": "8.0.3",
       "license": "MIT",
+      "dependencies": {
+        "@spark-ui/slot": "^8.0.2"
+      },
       "peerDependencies": {
         "react": "^19.0",
         "react-dom": "^19.0",

--- a/packages/components/visually-hidden/package.json
+++ b/packages/components/visually-hidden/package.json
@@ -23,6 +23,9 @@
   "scripts": {
     "build": "vite build"
   },
+  "dependencies": {
+    "@spark-ui/slot": "^8.0.2"
+  },
   "peerDependencies": {
     "react": "^19.0",
     "react-dom": "^19.0",

--- a/packages/components/visually-hidden/src/VisuallyHidden.test.tsx
+++ b/packages/components/visually-hidden/src/VisuallyHidden.test.tsx
@@ -20,4 +20,17 @@ describe('VisuallyHidden', () => {
     // Then
     expect(screen.getByRole('button', { name: 'Checkmark', hidden: true })).toBeInTheDocument()
   })
+
+  it('should render as alternative html tag using asChild prop', () => {
+    render(
+      <VisuallyHidden asChild>
+        <h3>Hidden heading</h3>
+      </VisuallyHidden>
+    )
+
+    // Then
+    expect(
+      screen.getByRole('heading', { name: 'Hidden heading', hidden: true })
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/components/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/components/visually-hidden/src/VisuallyHidden.tsx
@@ -1,12 +1,19 @@
+import { Slot } from '@spark-ui/slot'
 import { HTMLAttributes, PropsWithChildren, Ref } from 'react'
 
 export type VisuallyHiddenProps = PropsWithChildren<HTMLAttributes<HTMLElement>> & {
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   */
+  asChild?: boolean
   ref?: Ref<HTMLElement>
 }
 
-export const VisuallyHidden = ({ ref, ...props }: VisuallyHiddenProps) => {
+export const VisuallyHidden = ({ asChild = false, ref, ...props }: VisuallyHiddenProps) => {
+  const Component = asChild ? Slot : 'span'
+
   return (
-    <span
+    <Component
       {...props}
       ref={ref}
       style={{


### PR DESCRIPTION
<!-- https://github.com/adevinta/spark/issues -->
**TASK**: [SPA-485](https://jira.ets.mpi-internal.com/browse/SPA-485)

### Description, Motivation and Context

Missing `asChild` prop on `VisuallyHidden` to make it polymorphic. Until now it was a `span` and could not be any other html tag.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
