### PR TITLE
fix(spinner): set spinner as span

### DIFF
--- a/packages/components/spinner/src/Spinner.tsx
+++ b/packages/components/spinner/src/Spinner.tsx
@@ -20,7 +20,7 @@ export const Spinner = ({
   ...others
 }: PropsWithChildren<SpinnerProps>) => {
   return (
-    <div
+    <span
       role="status"
       data-spark-component="spinner"
       ref={ref}
@@ -28,6 +28,6 @@ export const Spinner = ({
       {...others}
     >
       {label && <VisuallyHidden>{label}</VisuallyHidden>}
-    </div>
+    </span>
   )
 }


### PR DESCRIPTION
**TASK**: [SPA-486](https://jira.ets.mpi-internal.com/browse/SPA-486)

### Description, Motivation and Context

`span` is more appropriate than `div` for the Spinner, as it can be used inside a `Button` (`div` inside a `button` is invalid HTML)

### Types of changes
- [X] 🪲 Bug fix (non-breaking change which fixes an issue)
