### PR TITLE
fix(snackbar): ensure toasts are properly read by screen readers

### DIFF
--- a/packages/components/snackbar/src/Snackbar.test.tsx
+++ b/packages/components/snackbar/src/Snackbar.test.tsx
@@ -132,7 +132,7 @@ describe('Snackbar', () => {
     fireEvent.pointerDown(snackBarItem, { clientX: 0, clientY: 0 })
     fireEvent.pointerMove(snackBarItem, { clientX: -100, clientY: 0 })
 
-    expect(screen.getByText('You did it!').parentNode).toHaveAttribute(
+    expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveAttribute(
       'data-swipe-direction',
       'left'
     )
@@ -147,7 +147,7 @@ describe('Snackbar', () => {
     fireEvent.pointerDown(snackBarItem, { clientX: 0, clientY: 0 })
     fireEvent.pointerMove(snackBarItem, { clientX: 100, clientY: 0 })
 
-    expect(screen.getByText('You did it!').parentNode).toHaveAttribute(
+    expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveAttribute(
       'data-swipe-direction',
       'right'
     )
@@ -175,7 +175,7 @@ describe('Snackbar', () => {
 
       await user.click(screen.getByText('Show me a snackbar'))
 
-      expect(screen.getByText('You did it!').parentNode).toHaveClass('bg-alert')
+      expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveClass('bg-alert')
       expect(screen.getByTitle('Thumb up')).toBeInTheDocument()
     })
 
@@ -194,7 +194,7 @@ describe('Snackbar', () => {
 
       await user.click(screen.getByText('Show me a snackbar'))
 
-      expect(screen.getByText('You did it!').parentNode).toHaveClass('bg-success')
+      expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveClass('bg-success')
       expect(screen.getByTitle('Thumb up').parentNode).toHaveClass('text-alert')
     })
   })
@@ -251,7 +251,7 @@ describe('Snackbar', () => {
       /**
        * If children item is provided then its props will be used in priority over function options.
        */
-      expect(screen.getByText('You did it!').parentNode).toHaveClass('bg-success')
+      expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveClass('bg-success')
       expect(screen.getByText('Undo')).toHaveClass('bg-error')
 
       await user.click(screen.getByText('Undo'))
@@ -330,7 +330,7 @@ describe('Snackbar', () => {
 
       await user.click(screen.getByText('Show me a snackbar'))
 
-      expect(screen.getByText('You did it!').parentNode).toHaveClass('bg-success')
+      expect(screen.getByText('You did it!').parentNode?.parentNode).toHaveClass('bg-success')
       expect(screen.getByLabelText('Close the snackbar')).toHaveClass('bg-error')
 
       await user.click(screen.getByLabelText('Close the snackbar'))

--- a/packages/components/snackbar/src/SnackbarItem.styles.ts
+++ b/packages/components/snackbar/src/SnackbarItem.styles.ts
@@ -4,9 +4,6 @@ import { filledVariants, tintedVariants } from './snackbarVariants'
 
 export const snackbarItemVariant = cva(
   [
-    'col-start-1 row-start-1',
-    'inline-grid items-center',
-    'px-md',
     'rounded-md shadow-sm',
     'max-w-[600px]',
     'cursor-default pointer-events-auto touch-none select-none',
@@ -77,6 +74,23 @@ export const snackbarItemVariant = cva(
         accent: '',
         inverse: '',
       },
+    },
+    compoundVariants: [...filledVariants, ...tintedVariants],
+    defaultVariants: {
+      design: 'filled',
+      intent: 'neutral',
+    },
+  }
+)
+
+export const snackbarItemVariantContent = cva(
+  [
+    'inline-grid items-center',
+    'col-start-1 row-start-1',
+    'px-md', // applying padding on the parent prevents VoiceOver on Safari from reading snackbar content 🤷
+  ],
+  {
+    variants: {
       /**
        * Force action button displaying on a new line
        * @default false
@@ -93,13 +107,11 @@ export const snackbarItemVariant = cva(
         ],
       },
     },
-    compoundVariants: [...filledVariants, ...tintedVariants],
     defaultVariants: {
-      design: 'filled',
-      intent: 'neutral',
       actionOnNewline: false,
     },
   }
 )
 
 export type SnackbarItemVariantProps = VariantProps<typeof snackbarItemVariant>
+export type SnackbarItemVariantContentProps = VariantProps<typeof snackbarItemVariantContent>

--- a/packages/components/snackbar/src/SnackbarItem.tsx
+++ b/packages/components/snackbar/src/SnackbarItem.tsx
@@ -13,7 +13,12 @@ import {
   useRef,
 } from 'react'
 
-import { snackbarItemVariant, type SnackbarItemVariantProps } from './SnackbarItem.styles'
+import {
+  snackbarItemVariant,
+  snackbarItemVariantContent,
+  type SnackbarItemVariantContentProps,
+  type SnackbarItemVariantProps,
+} from './SnackbarItem.styles'
 import { SnackbarItemAction, SnackbarItemActionProps } from './SnackbarItemAction'
 import { SnackbarItemClose, SnackbarItemCloseProps } from './SnackbarItemClose'
 import { useSnackbarItemContext } from './SnackbarItemContext'
@@ -46,7 +51,10 @@ export interface SnackbarItemValue extends SnackbarItemVariantProps {
   actionOnNewline?: boolean
 }
 
-export interface SnackbarItemProps extends ComponentPropsWithRef<'div'>, SnackbarItemVariantProps {
+export interface SnackbarItemProps
+  extends ComponentPropsWithRef<'div'>,
+    SnackbarItemVariantProps,
+    SnackbarItemVariantContentProps {
   /**
    * Defines a string value that labels the current element.
    */
@@ -104,7 +112,11 @@ export const SnackbarItem = ({
     ariaDetails,
   }
 
-  const { toastProps, titleProps, closeButtonProps } = useToast({ toast, ...ariaProps }, state, ref)
+  const { toastProps, titleProps, closeButtonProps, contentProps } = useToast(
+    { toast, ...ariaProps },
+    state,
+    ref
+  )
 
   const findElement = useCallback(
     <P extends object>(elementDisplayName: string): ReactElement<P> | undefined => {
@@ -130,9 +142,7 @@ export const SnackbarItem = ({
 
   return (
     <div
-      ref={ref}
-      {...toastProps}
-      {...rest}
+      className={snackbarItemVariant({ design, intent, className })}
       data-animation={toast.animation}
       {...(!(swipeState === 'cancel' && toast.animation === 'exiting') && {
         'data-swipe': swipeState,
@@ -142,39 +152,43 @@ export const SnackbarItem = ({
         // Remove snackbar when the exiting animation completes
         onAnimationEnd: () => state.remove(toast.key),
       })}
-      className={snackbarItemVariant({ design, intent, actionOnNewline, className })}
+      ref={ref}
+      {...toastProps}
+      {...rest}
     >
-      {/* 1. ICON */}
-      {renderSubComponent(iconFromChildren, icon ? SnackbarItemIcon : null, {
-        children: icon,
-      })}
+      <div className={snackbarItemVariantContent({ actionOnNewline })} {...contentProps}>
+        {/* 1. ICON */}
+        {renderSubComponent(iconFromChildren, icon ? SnackbarItemIcon : null, {
+          children: icon,
+        })}
 
-      {/* 2. MESSAGE */}
-      <p
-        className="row-span-3 px-md py-lg text-body-2"
-        style={{ gridArea: 'message' }}
-        {...titleProps}
-      >
-        {message}
-      </p>
+        {/* 2. MESSAGE */}
+        <p
+          className="px-md py-lg text-body-2 row-span-3"
+          style={{ gridArea: 'message' }}
+          {...titleProps}
+        >
+          {message}
+        </p>
 
-      {/* 3. ACTION BUTTON */}
-      {renderSubComponent(
-        actionBtnFromChildren,
-        actionLabel && onAction ? SnackbarItemAction : null,
-        { intent, design, onClick: onAction, children: actionLabel }
-      )}
+        {/* 3. ACTION BUTTON */}
+        {renderSubComponent(
+          actionBtnFromChildren,
+          actionLabel && onAction ? SnackbarItemAction : null,
+          { intent, design, onClick: onAction, children: actionLabel }
+        )}
 
-      {/* 4. CLOSE BUTTON */}
-      {renderSubComponent(closeBtnFromChildren, isClosable ? SnackbarItemClose : null, {
-        intent,
-        design,
-        /**
-         * React Spectrum typing of aria-label is inaccurate, and aria-label value should never be undefined.
-         * See https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/i18n/src/useLocalizedStringFormatter.ts#L40
-         */
-        'aria-label': closeButtonProps['aria-label'] as string,
-      })}
+        {/* 4. CLOSE BUTTON */}
+        {renderSubComponent(closeBtnFromChildren, isClosable ? SnackbarItemClose : null, {
+          intent,
+          design,
+          /**
+           * React Spectrum typing of aria-label is inaccurate, and aria-label value should never be undefined.
+           * See https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/i18n/src/useLocalizedStringFormatter.ts#L40
+           */
+          'aria-label': closeButtonProps['aria-label'] as string,
+        })}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
### Description, Motivation and Context
Closes #2567 

Ensure snackbar items are properly read by screen readers.

> [!WARNING]  
While snackbar items are read properly when triggered via the keyboard (using "ctrl+option+spacebar"), they are not read when triggered via a mouse click 🤷

**OS:** macOS Sequoia 15.2  
**Screen reader:** VoiceOver

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
