### PR TITLE
fix(popover): fixed invalid ss var in popover className

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1801,6 +1801,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/input/src/InputClearButton.tsx
+++ b/packages/components/input/src/InputClearButton.tsx
@@ -31,7 +31,7 @@ const Root = ({ className, tabIndex = -1, onClick, ref, ...others }: InputClearB
         'pointer-events-auto absolute top-1/2 -translate-y-1/2',
         'inline-flex h-full items-center justify-center outline-hidden',
         'text-neutral hover:text-neutral-hovered',
-        hasTrailingIcon ? 'right-3xl px-[var(--sz-12)]' : 'pl-md pr-lg right-0'
+        hasTrailingIcon ? 'right-3xl px-sz-12' : 'pl-md pr-lg right-0'
       )}
       tabIndex={tabIndex}
       onClick={handleClick}

--- a/packages/components/popover/src/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent.styles.ts
@@ -48,7 +48,7 @@ export const styles = cva(
       {
         enforceBoundaries: false,
         matchTriggerWidth: false,
-        class: 'max-w-[min(var(--sz-384),100vw)]',
+        class: 'max-w-[min(var(--spacing-sz-384),100vw)]',
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
### Description, Motivation and Context

Following Tailwindcss v4 update, some arbitrary classNames are using invalid css variables.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles

