### PR TITLE
docs(slider): added controlled mode story for slider

### DIFF
--- a/packages/components/slider/src/Slider.doc.mdx
+++ b/packages/components/slider/src/Slider.doc.mdx
@@ -48,6 +48,16 @@ import { Slider } from '@spark-ui/slider'
 
 <Canvas of={stories.Default} />
 
+### Controlled
+
+Use `value` to control the value with your own state.
+
+Use either `onValueChange` or `onValueCommit` to update this state when internal changes happen:
+- `onValueChange` Event handler called when the value changes.
+- `onValueCommit`: Event handler called when the value changes at the end of an interaction. Useful when you only need to capture a final value e.g. to update a backend service.
+
+<Canvas of={stories.Controlled} />
+
 ### Range
 
 Add multiple thumbs and values to create a range slider.

--- a/packages/components/slider/src/Slider.stories.tsx
+++ b/packages/components/slider/src/Slider.stories.tsx
@@ -28,6 +28,34 @@ export const Default: StoryFn = _args => (
   </form>
 )
 
+export const Controlled: StoryFn = _args => {
+  const [value, setValue] = useState([0, 100])
+
+  return (
+    <form>
+      <label htmlFor="controlled-slider">
+        Volume between {value[0]} and {value[1]}
+      </label>
+
+      <Slider
+        min={0}
+        max={100}
+        value={value}
+        onValueChange={setValue}
+        onValueCommit={() => {
+          console.log(value)
+        }}
+        id="controlled-slider"
+        name="controlled-slider"
+      >
+        <Slider.Track />
+        <Slider.Thumb aria-label="Power" />
+        <Slider.Thumb aria-label="Power" />
+      </Slider>
+    </form>
+  )
+}
+
 export const Range: StoryFn = _args => (
   <div>
     <Slider defaultValue={[25, 75]}>


### PR DESCRIPTION
### Description, Motivation and Context

We forgot to add a story explaining the controlled props for `@spark-ui/slider`

### Types of changes

- [x] 🧾 Documentation
