### PR TITLE
chore: upgrade zag.js to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12154,79 +12154,79 @@
       "dev": true
     },
     "node_modules/@zag-js/accordion": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-0.81.0.tgz",
-      "integrity": "sha512-0q1EQkaVUblqWWdO8rkMXIOFg8GtvTTtccW1AJfwznVAsSbKSAmKycpLafR1wYBX4kOo/wR3WGKoNVNU+ALWKA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.3.0.tgz",
+      "integrity": "sha512-MTMWiyiSjVrVk+INR8FcTKX/R4DUZxfHVL+wIgnzopVw/nfQSXFY+bP54JzgJ+5ggj700OMBYCXCXFVKfqYTyw==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "0.81.0",
-        "@zag-js/core": "0.81.0",
-        "@zag-js/dom-query": "0.81.0",
-        "@zag-js/types": "0.81.0",
-        "@zag-js/utils": "0.81.0"
+        "@zag-js/anatomy": "1.3.0",
+        "@zag-js/core": "1.3.0",
+        "@zag-js/dom-query": "1.3.0",
+        "@zag-js/types": "1.3.0",
+        "@zag-js/utils": "1.3.0"
       }
     },
     "node_modules/@zag-js/anatomy": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-0.81.0.tgz",
-      "integrity": "sha512-5BtIkyeObwuCH0nppdcksX+nUo2HCcSGV8PnskyOYL35ToQ076kiT/Ko1qHkh05io+40dGjfLvJ5LG6SStjEzw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.3.0.tgz",
+      "integrity": "sha512-OMz3qujunxuOGjIlVs9w29QrFCbKANog8kkRebvsT4Bt7ITMi39ZE0WLiOZup6kgT36xbqEqsCdH/L3VojA3/w==",
       "license": "MIT"
     },
     "node_modules/@zag-js/collapsible": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-0.81.0.tgz",
-      "integrity": "sha512-GYBQgAj7iG+38GcX7lkO/bHvcD2UMGzPTbkpcTrKqQGt2V5TvJgJbz8JcPFxnv0UaV7HZUD6vU4VPNDG749m/Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.3.0.tgz",
+      "integrity": "sha512-RVCx6jEvYyNSHOvslx2K/H5Ap5u21Y5kFrtES6/ewTavOTo9fGKf1Cek7A4fLySZOFp3e6HWAxcUtL5kXPW35A==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "0.81.0",
-        "@zag-js/core": "0.81.0",
-        "@zag-js/dom-query": "0.81.0",
-        "@zag-js/types": "0.81.0",
-        "@zag-js/utils": "0.81.0"
+        "@zag-js/anatomy": "1.3.0",
+        "@zag-js/core": "1.3.0",
+        "@zag-js/dom-query": "1.3.0",
+        "@zag-js/types": "1.3.0",
+        "@zag-js/utils": "1.3.0"
       }
     },
     "node_modules/@zag-js/core": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-0.81.0.tgz",
-      "integrity": "sha512-babGUqnyPN4iWGHXQMlrNsB9rzb/6V+R4x3IYFDZINXlo40RW9rSsaDkr4AV/4d1jUR46jQNxz/9mF1+sHMjsw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-IARCMRFcjSpbRPOs5NrKSzjGxWg1HXZmrX+c1JnicYXNFKCMWP/ijU6B4Bm8OPaFwufJ6EvFcDJ8i6Mfotv5cQ==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/store": "0.81.0",
-        "@zag-js/utils": "0.81.0"
+        "@zag-js/dom-query": "1.3.0",
+        "@zag-js/utils": "1.3.0"
       }
     },
     "node_modules/@zag-js/dom-query": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.81.0.tgz",
-      "integrity": "sha512-G3ES4D8/uiX/nwROxmsC4xA2Z5ZKzQJdWNRT7AFhQG74oV5PHJPPeDPOZoohzWXNrZtPS/HmvPl87MYLz5xtwA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.3.0.tgz",
+      "integrity": "sha512-WSIOCOI8uearfR2ibIcM6PcfD8Eidbnys00h5fiJaoTxwV9KuduSHweVfy6WOgfNDM0Xz+193Fwd3G8S5RS1fg==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/types": "0.81.0"
+        "@zag-js/types": "1.3.0"
       }
     },
     "node_modules/@zag-js/pagination": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-0.81.0.tgz",
-      "integrity": "sha512-Obv+xsJT+FFXJB+j351oEonusvWaDD94FqaWMXLIlVu6+U/LpLLOo6fYN3RXBx4n9d8iDWaXkSxEls1JqGcG4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.3.0.tgz",
+      "integrity": "sha512-l57Cp/SVH7ebJINhq2l8HX4/21DAIRkX7MCUmv95PccD1CQUFk2RezTktK+7qT0eErKT6wsP2dQi4Ke2hUQvqQ==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "0.81.0",
-        "@zag-js/core": "0.81.0",
-        "@zag-js/dom-query": "0.81.0",
-        "@zag-js/types": "0.81.0",
-        "@zag-js/utils": "0.81.0"
+        "@zag-js/anatomy": "1.3.0",
+        "@zag-js/core": "1.3.0",
+        "@zag-js/dom-query": "1.3.0",
+        "@zag-js/types": "1.3.0",
+        "@zag-js/utils": "1.3.0"
       }
     },
     "node_modules/@zag-js/react": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-0.81.0.tgz",
-      "integrity": "sha512-GQi80lBK7UtiERsdAryOiF0HIHkpXVMIxYpgI2dlTzwr10mVUPiPRaTWhysz8X73eFq76O1TKg7930zjyv3nng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-Y6n4dDDB+n7RSg/FaPOiB+JGqa5aiP+9X9WgUH1CGlUsyj4+oHjiBtKY6M+uyC9MT2+yDctjT+sZCIHeCindPg==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/core": "0.81.0",
-        "@zag-js/store": "0.81.0",
-        "@zag-js/types": "0.81.0",
-        "proxy-compare": "3.0.1"
+        "@zag-js/core": "1.3.0",
+        "@zag-js/store": "1.3.0",
+        "@zag-js/types": "1.3.0",
+        "@zag-js/utils": "1.3.0"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -12234,27 +12234,27 @@
       }
     },
     "node_modules/@zag-js/store": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-0.81.0.tgz",
-      "integrity": "sha512-TKigOBEl1RPXqzA5mKVnUZVXBaqxp8mJl+bPGf23+at5GgZAjKsMzNQReQYHkl0FhcakHew7dlZBvcApsMeYag==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.3.0.tgz",
+      "integrity": "sha512-Q5yS23GzVKl/rGsnqIN9tKkmP+SXzDzXuhQ2MDeiH9IhcwEzj20ZWwQ5wRZfMe8vwfthyShg/lE3T/inIAs9YA==",
       "license": "MIT",
       "dependencies": {
         "proxy-compare": "3.0.1"
       }
     },
     "node_modules/@zag-js/types": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-0.81.0.tgz",
-      "integrity": "sha512-Lhunl8BkuntdxPBJS0pZOULYfcHOlLZKEJgHz37nA8hSD9+o8jk3cta91yEijPdd963hME7IAuGUNqbJW+VC/A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.3.0.tgz",
+      "integrity": "sha512-9ac9E9QVLwZfn7+SjCGfg6Hnh1KrmHGMFZ+4KjbFyy5JYBI/OXp3gbeL2kmIoVvjrhWOFk6iW1M2l/b2HtAh8w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"
       }
     },
     "node_modules/@zag-js/utils": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-0.81.0.tgz",
-      "integrity": "sha512-Lc24Y1lDCUJH4vb8ft1wUwy9x1fK5HcSI0ltnrnQFL7rSL8gIc+U13tK2eg5GMOL6oetQFkWI9xP2kyJTHonAA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.3.0.tgz",
+      "integrity": "sha512-KXlZjLYX+LMDEjCjDxwbl+Y+zSMHW14RUwcw4crzE29sU3emsQdFyE76KkufMgYNwf/l5RTVH87MTD/lbBRBHg==",
       "license": "MIT"
     },
     "node_modules/@zkochan/js-yaml": {
@@ -31271,8 +31271,8 @@
         "@spark-ui/icons": "^9.2.2",
         "@spark-ui/internal-utils": "^9.2.2",
         "@spark-ui/slot": "^9.2.2",
-        "@zag-js/accordion": "0.81.0",
-        "@zag-js/react": "0.81.0"
+        "@zag-js/accordion": "1.3.0",
+        "@zag-js/react": "1.3.0"
       },
       "peerDependencies": {
         "@spark-ui/theme-utils": "latest",
@@ -31411,8 +31411,8 @@
       "dependencies": {
         "@spark-ui/internal-utils": "^9.2.2",
         "@spark-ui/slot": "^9.2.2",
-        "@zag-js/collapsible": "0.81.0",
-        "@zag-js/react": "0.81.0"
+        "@zag-js/collapsible": "1.3.0",
+        "@zag-js/react": "1.3.0"
       },
       "peerDependencies": {
         "@spark-ui/theme-utils": "latest",
@@ -31675,8 +31675,8 @@
         "@spark-ui/icon-button": "^9.2.2",
         "@spark-ui/icons": "^9.2.2",
         "@spark-ui/internal-utils": "^9.2.2",
-        "@zag-js/pagination": "0.81.0",
-        "@zag-js/react": "0.81.0"
+        "@zag-js/pagination": "1.3.0",
+        "@zag-js/react": "1.3.0"
       },
       "peerDependencies": {
         "@spark-ui/theme-utils": "latest",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -49,7 +49,7 @@
     "@spark-ui/icons": "^9.2.2",
     "@spark-ui/internal-utils": "^9.2.2",
     "@spark-ui/slot": "^9.2.2",
-    "@zag-js/accordion": "0.81.0",
-    "@zag-js/react": "0.81.0"
+    "@zag-js/accordion": "1.3.0",
+    "@zag-js/react": "1.3.0"
   }
 }

--- a/packages/components/accordion/src/Accordion.tsx
+++ b/packages/components/accordion/src/Accordion.tsx
@@ -1,4 +1,3 @@
-import { useEvent } from '@spark-ui/internal-utils'
 import { Slot } from '@spark-ui/slot'
 import * as accordion from '@zag-js/accordion'
 import { mergeProps, normalizeProps, type PropTypes, useMachine } from '@zag-js/react'
@@ -6,7 +5,7 @@ import { cx } from 'class-variance-authority'
 import { type ComponentPropsWithoutRef, createContext, Ref, useContext, useId } from 'react'
 
 type ExtentedZagInterface = Omit<
-  accordion.Context,
+  accordion.Props,
   'id' | 'ids' | 'orientation' | 'getRootNode' | 'onValueChange'
 > &
   Omit<ComponentPropsWithoutRef<'div'>, 'defaultChecked'>
@@ -20,7 +19,7 @@ export interface AccordionProps extends ExtentedZagInterface {
    * Whether an accordion item can be closed after it has been expanded.
    */
   collapsible?: boolean
-  defaultValue?: accordion.Context['value']
+  defaultValue?: accordion.Props['value']
   /**
    * Whether the accordion items are disabled
    */
@@ -68,34 +67,23 @@ export const Accordion = ({
     collapsible,
     value,
     disabled,
-    // onValueChange,
     className: cx('bg-surface rounded-lg h-fit', className),
     ...props,
   })
 
-  const [state, send] = useMachine(
-    // Initial state
-    accordion.machine({
-      ...machineProps,
-      value: defaultValue,
-      id: useId(),
-      onValueChange(details) {
-        onValueChange?.(details.value)
-      },
-    }),
-    // Dynamic state
-    {
-      context: {
-        ...machineProps,
-        onValueChange: useEvent((details: accordion.ValueChangeDetails) => {
-          onValueChange?.(details.value)
-        }),
-      },
-    }
-  )
+  const service = useMachine(accordion.machine, {
+    ...machineProps,
+    defaultValue,
+    value,
+    id: useId(),
+    onValueChange(details) {
+      onValueChange?.(details.value)
+    },
+  })
 
   const Component = asChild ? Slot : 'div'
-  const api = accordion.connect(state, send, normalizeProps)
+  const api = accordion.connect(service, normalizeProps)
+
   const mergedProps = mergeProps(api.getRootProps(), localProps)
 
   return (

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@spark-ui/internal-utils": "^9.2.2",
     "@spark-ui/slot": "^9.2.2",
-    "@zag-js/collapsible": "0.81.0",
-    "@zag-js/react": "0.81.0"
+    "@zag-js/collapsible": "1.3.0",
+    "@zag-js/react": "1.3.0"
   }
 }

--- a/packages/components/collapsible/src/Collapsible.tsx
+++ b/packages/components/collapsible/src/Collapsible.tsx
@@ -1,4 +1,3 @@
-import { useEvent } from '@spark-ui/internal-utils'
 import { Slot } from '@spark-ui/slot'
 import * as collapsible from '@zag-js/collapsible'
 import { mergeProps, normalizeProps, type PropTypes, useMachine } from '@zag-js/react'
@@ -28,7 +27,7 @@ export interface CollapsibleProps extends ComponentProps<'div'> {
   /**
    * The ids of the elements in the collapsible. Useful for composition
    */
-  ids?: collapsible.Context['ids']
+  ids?: collapsible.Props['ids']
   ref?: Ref<HTMLDivElement>
 }
 
@@ -45,28 +44,17 @@ export const Collapsible = ({
   ref,
   ...props
 }: CollapsibleProps) => {
-  const initialContext: collapsible.Context = {
-    'open.controlled': open !== undefined,
-    open: defaultOpen || open,
+  const service = useMachine(collapsible.machine, {
+    open,
+    defaultOpen,
     disabled,
     id: useId(),
     ids,
-  }
-
-  const context: collapsible.Context = {
-    ...initialContext,
-    onOpenChange: useEvent(
-      (details: collapsible.OpenChangeDetails) => {
-        onOpenChange?.(details.open)
-      },
-      { sync: true }
-    ),
-    open,
-    disabled,
-  }
-
-  const [state, send] = useMachine(collapsible.machine(initialContext), { context })
-  const api = collapsible.connect(state, send, normalizeProps)
+    onOpenChange(details) {
+      onOpenChange?.(details.open)
+    },
+  })
+  const api = collapsible.connect(service, normalizeProps)
   const Component = asChild ? Slot : 'div'
 
   const mergedProps = mergeProps(api.getRootProps(), props)

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -48,7 +48,7 @@
     "@spark-ui/icon-button": "^9.2.2",
     "@spark-ui/icons": "^9.2.2",
     "@spark-ui/internal-utils": "^9.2.2",
-    "@zag-js/pagination": "0.81.0",
-    "@zag-js/react": "0.81.0"
+    "@zag-js/pagination": "1.3.0",
+    "@zag-js/react": "1.3.0"
   }
 }

--- a/packages/components/pagination/src/PaginationContext.tsx
+++ b/packages/components/pagination/src/PaginationContext.tsx
@@ -1,4 +1,3 @@
-import { useEvent } from '@spark-ui/internal-utils'
 import * as pagination from '@zag-js/pagination'
 import { normalizeProps, type PropTypes, useMachine } from '@zag-js/react'
 import { createContext, type ReactNode, useContext, useId } from 'react'
@@ -6,7 +5,7 @@ import { createContext, type ReactNode, useContext, useId } from 'react'
 import { sliceArrayWithIndex } from './utils'
 
 export interface PaginationContextState<T extends PropTypes = PropTypes> {
-  type: pagination.Context['type']
+  type: pagination.Props['type']
   pagination: pagination.Api<T> & {
     getFirstPageTriggerProps: () => ReturnType<pagination.Api<T>['getPrevTriggerProps']> & {
       'data-part': string
@@ -38,12 +37,12 @@ export interface PaginationProviderProps {
   /**
    * The current page (active page)
    */
-  page?: pagination.Context['page']
+  page?: pagination.Props['page']
   /**
    * If your pagination contains buttons instead of links, set `type` to `button`, extra attributes will be applied on page items for a11y.
    */
-  type?: pagination.Context['type']
-  onPageChange?: pagination.Context['onPageChange']
+  type?: pagination.Props['type']
+  onPageChange?: pagination.Props['onPageChange']
   noEllipsis?: boolean
 }
 
@@ -65,29 +64,17 @@ export const PaginationProvider = ({
 
   const id = useId()
 
-  const [state, send] = useMachine(
-    pagination.machine({
-      id,
-      count,
-      siblingCount,
-      pageSize,
-      page,
-      onPageChange,
-      type,
-    }),
-    // Dynamic state
-    {
-      context: {
-        page,
-        count,
-        siblingCount,
-        pageSize,
-        onPageChange: useEvent(onPageChange, { sync: true }),
-      },
-    }
-  )
+  const service = useMachine(pagination.machine, {
+    id,
+    count,
+    siblingCount,
+    pageSize,
+    page,
+    onPageChange,
+    type,
+  })
 
-  const api = pagination.connect(state, send, normalizeProps)
+  const api = pagination.connect(service, normalizeProps)
   const pages = noEllipsis
     ? sliceArrayWithIndex(api.pages, api.page - 1, visiblePageItems)
     : api.pages


### PR DESCRIPTION


### Description, Motivation and Context
Update Spark components to use the latest stable version (v1) of zag.js following its official release
