### PR TITLE
feat(dialog): handle missing Dialog description warning

### DIFF
--- a/packages/components/dialog/src/DialogContent.tsx
+++ b/packages/components/dialog/src/DialogContent.tsx
@@ -54,6 +54,8 @@ export const Content = ({
         onInteractOutside?.(e)
       }}
       {...rest}
+      // silence Radix Dialog warning when no Description is provided, see https://www.radix-ui.com/primitives/docs/components/dialog#description
+      aria-describedby={rest['aria-describedby'] || undefined}
     >
       {children}
     </RadixDialog.Content>


### PR DESCRIPTION
### Description, Motivation and Context
Addresses the Radix UI Dialog warning that appears when no Description component is provided, see https://www.radix-ui.com/primitives/docs/components/dialog#description