### PR TITLE
docs: updated order of sections in stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,6 +18,8 @@ const config: StorybookConfig = {
     '../documentation/**/*.mdx',
     '../packages/**/*.doc.mdx',
     '../packages/**/*.stories.tsx',
+    '!..packages/components/icons/**/*.doc.mdx',
+    '!..packages/components/icons/**/*.stories.tsx',
   ],
   addons: [
     'storybook-addon-tag-badges',

--- a/documentation/helpers/ArgTypes/index.tsx
+++ b/documentation/helpers/ArgTypes/index.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@spark-ui/button'
+import { Drawer } from '@spark-ui/drawer'
 import { Tabs, type TabsProps } from '@spark-ui/tabs'
 import { ArgTypes as StorybookArgTypes } from '@storybook/blocks'
 import { type FC, type ReactNode, useEffect, useState } from 'react'
@@ -40,6 +42,44 @@ function useTabsOrientation() {
   return tabsOrientation
 }
 
+const ArgTypesDialog = ({
+  componentName,
+  description,
+  children,
+}: {
+  componentName: string
+  description?: string
+  children: ReactNode
+}) => {
+  return (
+    <Drawer>
+      <Drawer.Trigger asChild>
+        <Button className="top-md right-md z-raised" design="filled" intent="support">
+          {componentName} API
+        </Button>
+      </Drawer.Trigger>
+
+      <Drawer.Portal>
+        <Drawer.Overlay />
+
+        <Drawer.Content size="lg" className="z-popover!">
+          <Drawer.Header>
+            <Drawer.Title>{componentName} props</Drawer.Title>
+          </Drawer.Header>
+
+          <Drawer.Body>
+            {description && <Drawer.Description>{description}</Drawer.Description>}
+
+            {children}
+          </Drawer.Body>
+
+          <Drawer.CloseButton aria-label="Close" />
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer>
+  )
+}
+
 export const ArgTypes = <T extends FC>({
   of,
   description,
@@ -48,43 +88,54 @@ export const ArgTypes = <T extends FC>({
 }: Props<T>) => {
   const tabsOrientation = useTabsOrientation()
 
-  if (!subcomponents) return <StorybookArgTypes of={of} />
-
   const { displayName: name = 'Root' } = of // "Root" in case the root component is missing a displayName
+
+  if (!subcomponents) {
+    return (
+      <ArgTypesDialog componentName={name} description={description}>
+        <StorybookArgTypes of={of} />
+      </ArgTypesDialog>
+    )
+  }
+
   const subComponentsList = Object.entries(subcomponents)
 
   return (
-    <Tabs
-      defaultValue={name}
-      orientation={tabsOrientation}
-      className="sb-unstyled mt-xl overflow-hidden rounded-md"
-    >
-      <Tabs.List className={tabsOrientation === 'horizontal' ? 'mb-md' : ''}>
-        <Tabs.Trigger key={name} value={name} className="text-support bg-transparent">
-          {name}
-        </Tabs.Trigger>
-        <>
-          {subComponentsList.map(([name]) => (
-            <Tabs.Trigger key={name} value={name} className="text-on-surface bg-transparent">
-              {name}
-            </Tabs.Trigger>
-          ))}
-        </>
-      </Tabs.List>
+    <ArgTypesDialog componentName={name} description={description}>
+      <Tabs
+        defaultValue={name}
+        orientation={tabsOrientation}
+        className="sb-unstyled mt-xl overflow-hidden rounded-md"
+      >
+        <Tabs.List className={tabsOrientation === 'horizontal' ? 'mb-md' : ''}>
+          <Tabs.Trigger key={name} value={name} className="text-support bg-transparent">
+            {name}
+          </Tabs.Trigger>
+          <>
+            {subComponentsList.map(([name]) => (
+              <Tabs.Trigger key={name} value={name} className="text-on-surface bg-transparent">
+                {name}
+              </Tabs.Trigger>
+            ))}
+          </>
+        </Tabs.List>
 
-      <Tabs.Content key={name} value={name} className="py-lg">
-        {description && <ComponentDescription name={name}>{description}</ComponentDescription>}
-        <StorybookArgTypes of={of} {...rest} />
-      </Tabs.Content>
+        <Tabs.Content key={name} value={name} className="py-lg">
+          {description && <ComponentDescription name={name}>{description}</ComponentDescription>}
+          <StorybookArgTypes of={of} {...rest} />
+        </Tabs.Content>
 
-      {subComponentsList.map(([name, { of, description }]) => {
-        return (
-          <Tabs.Content key={name} value={name} className="py-lg">
-            {description && <ComponentDescription name={name}>{description}</ComponentDescription>}
-            <StorybookArgTypes of={of} {...rest} />
-          </Tabs.Content>
-        )
-      })}
-    </Tabs>
+        {subComponentsList.map(([name, { of, description }]) => {
+          return (
+            <Tabs.Content key={name} value={name} className="py-lg">
+              {description && (
+                <ComponentDescription name={name}>{description}</ComponentDescription>
+              )}
+              <StorybookArgTypes of={of} {...rest} />
+            </Tabs.Content>
+          )
+        })}
+      </Tabs>
+    </ArgTypesDialog>
   )
 }

--- a/packages/components/accordion/src/Accordion.doc.mdx
+++ b/packages/components/accordion/src/Accordion.doc.mdx
@@ -12,48 +12,6 @@ import * as stories from './Accordion.stories'
 
 An accordion is a vertically stacked set of interactive headings containing a title, content snippet, or thumbnail representing a section of content.
 
-## Install
-
-```sh
-npm install @spark-ui/accordion
-```
-
-## Import
-
-```tsx
-import { Accordion } from '@spark-ui/accordion'
-```
-
-## Props
-
-<ArgTypes
-  of={Accordion}
-  description="Contains all the parts of an accordion."
-  subcomponents={{
-    'Accordion.Item': {
-      of: Accordion.Item,
-      description: 'Contains all the parts of a collapsible section..',
-    },
-    'Accordion.ItemHeader': {
-      of: Accordion.ItemHeader,
-      description:
-        'Set the heading level for your accordion trigger elements. By default, renders an `h3`.',
-    },
-    'Accordion.ItemTrigger': {
-      of: Accordion.ItemTrigger,
-      description: 'Toggles the collapsed state of its associated item.',
-    },
-    'Accordion.ItemContent': {
-      of: Accordion.ItemContent,
-      description: 'Contains the collapsible content for an item.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
 An `Accordion` is closed by default. Interacting with its trigger will open the associated content.
 
 Important, as per ARIA specifications:
@@ -64,6 +22,34 @@ For this, you must wrap each `Accordion.ItemTrigger` with an `Accordion.ItemHead
 For example, in the context of this storybook page, we use `h4` because the accordion is preceded by an `h3` already.
 
 <Canvas of={stories.Default} />
+
+## Install
+
+```sh
+npm install @spark-ui/accordion
+```
+
+## Anatomy
+
+```tsx
+import { Accordion } from "@spark-ui/accordion"
+
+export default () => (
+  <Accordion>
+    <Accordion.Item> 
+      <Accordion.ItemHeader>
+        <Accordion.ItemTrigger />
+      </Accordion.ItemHeader>
+      <Accordion.ItemContent />
+    </Accordion.Item>
+  </Accordion>
+);
+```
+
+
+
+## Examples
+
 
 ### Controlled
 
@@ -96,6 +82,32 @@ Use `multiple` to allow multiple panels to be opened at the same time.
 Use `defaultValue` to pass an array of panels values to open by default.
 
 <Canvas of={stories.Multiple} />
+
+## API Reference
+
+<ArgTypes
+  of={Accordion}
+  description="Contains all the parts of an accordion."
+  subcomponents={{
+    'Accordion.Item': {
+      of: Accordion.Item,
+      description: 'Contains all the parts of a collapsible section..',
+    },
+    'Accordion.ItemHeader': {
+      of: Accordion.ItemHeader,
+      description:
+        'Set the heading level for your accordion trigger elements. By default, renders an `h3`.',
+    },
+    'Accordion.ItemTrigger': {
+      of: Accordion.ItemTrigger,
+      description: 'Toggles the collapsed state of its associated item.',
+    },
+    'Accordion.ItemContent': {
+      of: Accordion.ItemContent,
+      description: 'Contains the collapsible content for an item.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/alert-dialog/src/AlertDialog.doc.mdx
+++ b/packages/components/alert-dialog/src/AlertDialog.doc.mdx
@@ -18,19 +18,50 @@ A modal dialog that interrupts the user with important content and expects a res
 - Manages screen reader announcements with Title and Description components.
 - Esc closes the component automatically.
 
+<Canvas of={stories.Usage} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/alert-dialog
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { AlertDialog } from '@spark-ui/alert-dialog'
+
+export default () => (
+  <AlertDialog>
+      <AlertDialog.Trigger />
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay />
+        <AlertDialog.Content>
+          <AlertDialog.Header>
+            <AlertDialog.Title />
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <AlertDialog.Description />
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <AlertDialog.Cancel />
+            <AlertDialog.Action />
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog>
+);
 ```
 
-## Props
+## Examples
+
+### Controlled
+
+Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
+
+<Canvas of={stories.Controlled} />
+
+## API Reference
 
 <ArgTypes
   of={AlertDialog}
@@ -86,18 +117,6 @@ import { AlertDialog } from '@spark-ui/alert-dialog'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Usage} />
-
-### Controlled
-
-Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
-
-<Canvas of={stories.Controlled} />
 
 ## Accessibility
 

--- a/packages/components/badge/src/Badge.doc.mdx
+++ b/packages/components/badge/src/Badge.doc.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas } from '@storybook/blocks'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { A11yReport } from '@docs/helpers/A11yReport'
 import { Badge } from '.'
 import * as stories from './Badge.stories'
@@ -10,29 +10,27 @@ import * as stories from './Badge.stories'
 
 Badge component is a visual indicator for numeric values such as tallies and scores.
 
+When using `Badge` as a wrapper, it will position itself to the top-right corner of its child element.
+
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/badge
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Badge } from '@spark-ui/badge'
+
+export default () => (
+  <Badge />
+);
 ```
 
-## Props
-
-<ArgTypes of={Badge} />
-
-## Usage
-
-### Default
-
-When using `Badge` as a wrapper, it will position itself to the top-right corner of its child element.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Intents
 
@@ -61,6 +59,10 @@ Use `count` prop to display a number inside the `Badge`. There is a default thre
 Use `size` prop to set the size of the badge.
 
 <Canvas of={stories.Sizes} />
+
+## API Reference
+
+<ArgTypes of={Badge} />
 
 ## Accessibility
 

--- a/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
+++ b/packages/components/breadcrumb/src/Breadcrumb.doc.mdx
@@ -13,19 +13,44 @@ import * as stories from './Breadcrumb.stories'
 
 Navigation pattern that helps users understand the hierarchy of a website
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/breadcrumb
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Breadcrumb } from '@spark-ui/breadcrumb'
+
+export default () => (
+  <Breadcrumb>
+    <Breadcrumb.Item>
+      <Breadcrumb.Link /> // or <Breadcrumb.CurrentPage />
+    </Breadcrumb.Item>
+    <Breadcrumb.Separator />
+  </Breadcrumb>
+);
 ```
 
-## Props
+## Examples
+
+### Custom Separator
+
+Use the `children` property of `Breadcrumb.Separator` to use a different icon for the separator. You can also use raw text.
+
+<Canvas of={stories.CustomSeparator} />
+
+### Truncate
+
+Apply a maximum width on an element to truncate it automatically.
+
+<Canvas of={stories.Truncate} />
+
+## API Reference
 
 <ArgTypes
   of={Breadcrumb}
@@ -50,24 +75,6 @@ import { Breadcrumb } from '@spark-ui/breadcrumb'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
-
-### Custom Separator
-
-Use the `children` property of `Breadcrumb.Separator` to use a different icon for the separator. You can also use raw text.
-
-<Canvas of={stories.CustomSeparator} />
-
-### Truncate
-
-Apply a maximum width on an element to truncate it automatically.
-
-<Canvas of={stories.Truncate} />
 
 ## Accessibility
 

--- a/packages/components/button/src/Button.doc.mdx
+++ b/packages/components/button/src/Button.doc.mdx
@@ -1,7 +1,8 @@
 import { Kbd } from '@spark-ui/kbd'
 import { Canvas, Meta } from '@storybook/blocks'
-import { ArgTypes, Source } from '@storybook/blocks'
+import { Source } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Callout } from '@docs/helpers/Callout'
 import { Button } from '.'
 import * as ButtonStories from './Button.stories'
@@ -12,27 +13,25 @@ import * as ButtonStories from './Button.stories'
 
 Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, canceling an action, or performing a delete operation.
 
+<Canvas of={ButtonStories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/button
 ```
 
-## Import
+## Anatomy
 
 ```js
 import { Button } from '@spark-ui/button'
+
+export default () => (
+  <Button />
+);
 ```
 
-## Props
-
-<ArgTypes of={Button} />
-
-## Usage
-
-### Default
-
-<Canvas of={ButtonStories.Default} />
+## Examples
 
 ### Design
 
@@ -87,7 +86,7 @@ Use `size` prop to set the size of a button.
 
 <Canvas of={ButtonStories.Sizes} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Link
 
@@ -110,6 +109,10 @@ This polymorphic behaviour can be used with any type of HTML element.
 Use `aria-pressed` to transform the button into a toggle button.
 
 <Canvas of={ButtonStories.Toggle} />
+
+## API Reference
+
+<ArgTypes of={Button} />
 
 ## Accessibility
 

--- a/packages/components/carousel/src/Carousel.doc.mdx
+++ b/packages/components/carousel/src/Carousel.doc.mdx
@@ -12,9 +12,13 @@ import * as stories from './Carousel.stories'
 
 A carousel is a user interface component that displays a collection of items, such as images or content cards, one (or a few) at a time within a single frame.
 
-Users navigate through these items using controls like "Previous" and "Next" buttons or pagination indicators ("dots").
+Users navigate through these items using controls like "Previous" and "Next" buttons or a page picker below the carousel.
 
 Carousels are ideal for presenting content sequentially, guiding users to focus on one item or group of items at a time.
+
+**a11y**: items outside of the carousel viewport will be considered inert/unreachable with keyboard navigation and screen readers.
+
+<Canvas of={stories.Default} />
 
 ## Install
 
@@ -22,62 +26,30 @@ Carousels are ideal for presenting content sequentially, guiding users to focus 
 npm install @spark-ui/carousel
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Carousel } from '@spark-ui/carousel'
+
+export default () => (
+  <Carousel>
+    <CarouselViewport>
+      <CarouselSlides>
+        <CarouselSlide />
+      </CarouselSlides>
+      <CarouselControls>
+        <CarouselPrevButton />
+        <CarouselNextButton />
+      </CarouselControls>
+    </CarouselViewport>
+    <CarouselPagePicker />
+  </Carousel>
+)
 ```
 
-## Props
 
-<ArgTypes
-  of={Carousel}
-  description="Presents a set of slides, by sequentially displaying a subset of one or more items."
-  subcomponents={{
-    'Carousel.Viewport': {
-      of: Carousel.Viewport,
-      description:
-        'Container for both the carousel items and the carousel controls. The carousel slide picker should remain outside of it.',
-    },
-    'Carousel.Slides': {
-      of: Carousel.Slides,
-      description: 'The scroll area of the carousel, contains all items to display in slides.',
-    },
-    'Carousel.Slide': {
-      of: Carousel.Slide,
-      description:
-        'A single content container within a set of content containers that hold the content to be presented by the carousel.',
-    },
-    'Carousel.Controls': {
-      of: Carousel.Controls,
-      description:
-        'Two interactive elements, styled as arrow buttons, that displays the next or previous slide in the rotation sequence.',
-    },
-    'Carousel.PagePicker': {
-      of: Carousel.PagePicker,
-      description:
-        'A group of elements, styled as small dots, that enable the user to pick a specific page in the rotation sequence to display. Behave like a radiogroup',
-    },
-    'Carousel.PageIndicator': {
-      of: Carousel.PageIndicator,
-      description:
-        'A button with "radio" role that takes you to a specific page in the carousel. You can customize it.',
-    },
-  }}
-/>
 
-## Usage
-
-### Default
-
-By default, the carousel will preserve the natural width of every item, and calculate its pagination from it.
-The first cropped item on the right side will be the next snap point (start on the next slide).
-
-It optimizes how many click are necessary to traverse the full list of items.
-
-**a11y**: items outside of the carousel viewport will be considered inert/unreachable with keyboard navigation and screen readers.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -139,13 +111,51 @@ To customize number of slides to move at a time, set the `slidesPerMove` propert
 
 <Canvas of={stories.SlidesPerMove} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Custom page indicators
 
 The `unstyled` prop of `Carousel.PageIndicator` allows you to use your own styles for the page indicators.
 
 <Canvas of={stories.CustomPageIndicators} />
+
+## API Reference
+
+<ArgTypes
+  of={Carousel}
+  description="Presents a set of slides, by sequentially displaying a subset of one or more items."
+  subcomponents={{
+    'Carousel.Viewport': {
+      of: Carousel.Viewport,
+      description:
+        'Container for both the carousel items and the carousel controls. The carousel slide picker should remain outside of it.',
+    },
+    'Carousel.Slides': {
+      of: Carousel.Slides,
+      description: 'The scroll area of the carousel, contains all items to display in slides.',
+    },
+    'Carousel.Slide': {
+      of: Carousel.Slide,
+      description:
+        'A single content container within a set of content containers that hold the content to be presented by the carousel.',
+    },
+    'Carousel.Controls': {
+      of: Carousel.Controls,
+      description:
+        'Two interactive elements, styled as arrow buttons, that displays the next or previous slide in the rotation sequence.',
+    },
+    'Carousel.PagePicker': {
+      of: Carousel.PagePicker,
+      description:
+        'A group of elements, styled as small dots, that enable the user to pick a specific page in the rotation sequence to display. Behave like a radiogroup',
+    },
+    'Carousel.PageIndicator': {
+      of: Carousel.PageIndicator,
+      description:
+        'A button with "radio" role that takes you to a specific page in the carousel. You can customize it.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/checkbox/src/Checkbox.doc.mdx
+++ b/packages/components/checkbox/src/Checkbox.doc.mdx
@@ -13,36 +13,6 @@ import * as stories from './Checkbox.stories'
 A control that allows the user to toggle between checked and not checked.
 It is used in forms when a user needs to select multiple values from several options.
 
-## Install
-
-```sh
-npm install @spark-ui/checkbox
-```
-
-## Import
-
-```tsx
-import { Checkbox, CheckboxGroup } from '@spark-ui/checkbox'
-```
-
-## Props
-
-<ArgTypes
-  of={Checkbox}
-  description="A control that allows the user to toggle between checked and not checked."
-  subcomponents={{
-    CheckboxGroup: {
-      of: CheckboxGroup,
-      description:
-        'A checkbox group allows users to select one or more items from a list of choices.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
 Checkbox label can be multiline. Still you should care of not using elements (for the label) with greater line height than the checkbox input height, to preserve vertical alignment.
 
 <StoryLabel>Standalone</StoryLabel>
@@ -50,6 +20,30 @@ Checkbox label can be multiline. Still you should care of not using elements (fo
 
 <StoryLabel>Group</StoryLabel>
 <Canvas of={stories.DefaultGroup} />
+
+## Install
+
+```sh
+npm install @spark-ui/checkbox
+```
+
+## Anatomy
+
+```tsx
+import { Checkbox, CheckboxGroup } from '@spark-ui/checkbox'
+
+// Standalone
+export default () => <Checkbox />;
+
+// Group
+export default () => (
+  <CheckboxGroup>
+    <Checkbox />
+  </CheckboxGroup>
+);
+```
+
+## Examples
 
 ### Uncontrolled
 
@@ -122,7 +116,7 @@ Use `orientation` prop to set the orientation of the checkbox group which could 
 
 <Canvas of={stories.GroupOrientation} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Indeterminate
 
@@ -179,6 +173,20 @@ Use the `isRequired` prop of the `FormField` to indicate that the input is requi
 set the `state` prop of the `FormField` to `error` to indicate that the input is invalid. Optionally use the `FormField.ErrorMessage` to describe why the input is invalid.
 
 <Canvas of={stories.FieldInvalid} />
+
+## API Reference
+
+<ArgTypes
+  of={Checkbox}
+  description="A control that allows the user to toggle between checked and not checked."
+  subcomponents={{
+    CheckboxGroup: {
+      of: CheckboxGroup,
+      description:
+        'A checkbox group allows users to select one or more items from a list of choices.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/chip/src/Chip.doc.mdx
+++ b/packages/components/chip/src/Chip.doc.mdx
@@ -13,6 +13,8 @@ import * as stories from './Chip.stories'
 
 Help people enter information, make selections, filter content, or trigger actions.
 
+<Canvas of={stories.Default} />
+
 #### Chips aren’t buttons
 
 <Callout kind="warning">
@@ -61,42 +63,21 @@ Combining those features chips give 4 different usages:
 npm install @spark-ui/chip
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Chip } from '@spark-ui/chip'
+
+export default () => (
+  <Chip>
+    <Chip.LeadingIcon />
+    <Chip.Content />
+    <Chip.ClearButton />
+  </Chip>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Chip}
-  description="Component for offering information"
-  subcomponents={{
-    'Chip.Content': {
-      of: Chip.Content,
-      description: 'The main chip container',
-    },
-    'Chip.LeadingIcon': {
-      of: Chip.LeadingIcon,
-      description: 'Prepend a decorative icon inside the chip (to the left).',
-    },
-    'Chip.TrailingIcon': {
-      of: Chip.TrailingIcon,
-      description: 'Append a decorative icon inside the chip (to the right).',
-    },
-    'Chip.ClearButton': {
-      of: Chip.ClearButton,
-      description: 'For removing the chip.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Kind
 
@@ -122,7 +103,7 @@ When a chip is `disabled`, no action is fired when clicking on it.
 
 <Canvas of={stories.Disabled} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Assist
 
@@ -188,6 +169,31 @@ Suggestion chips help narrow a user’s intent by presenting dynamically generat
 <Canvas of={stories.Suggestion} />
 
 Suggestion chips can offer quick-reply options in a chat or email app, or It can help the user start a search.
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Chip}
+  description="Component for offering information"
+  subcomponents={{
+    'Chip.Content': {
+      of: Chip.Content,
+      description: 'The main chip container',
+    },
+    'Chip.LeadingIcon': {
+      of: Chip.LeadingIcon,
+      description: 'Prepend a decorative icon inside the chip (to the left).',
+    },
+    'Chip.TrailingIcon': {
+      of: Chip.TrailingIcon,
+      description: 'Append a decorative icon inside the chip (to the right).',
+    },
+    'Chip.ClearButton': {
+      of: Chip.ClearButton,
+      description: 'For removing the chip.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/collapsible/src/Collapsible.doc.mdx
+++ b/packages/components/collapsible/src/Collapsible.doc.mdx
@@ -15,19 +15,30 @@ An interactive component which expands/collapses a panel.
 
 This component has no styles and serves as a behaviourial component.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/collapsible
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Collapsible } from '@spark-ui/collapsible'
+
+export default () => (
+  <Collapsible>
+    <Collapsible.Trigger />
+    <Collapsible.Content />
+  </Collapsible>
+);
 ```
 
-## Props
+## Examples
+
+## API Reference
 
 <ArgTypes
   of={Collapsible}
@@ -43,14 +54,6 @@ import { Collapsible } from '@spark-ui/collapsible'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-A `Collapsible` is closed by default. Interacting with its trigger will open the associated content.
-
-<Canvas of={stories.Default} />
 
 ## Accessibility
 

--- a/packages/components/combobox/src/Combobox.doc.mdx
+++ b/packages/components/combobox/src/Combobox.doc.mdx
@@ -15,6 +15,10 @@ A combobox is an input widget that has an associated popup.
 
 The popup enables users to choose one or multiple values for the input from a collection. The popup itself contains a listbox of items.
 
+AutoComplete is used as the default behaviour. The user can only type a value that exists in the list of suggestions.
+
+<Canvas of={stories.Default} />
+
 #### ComboBox is not a Dropdown
 
 <Callout kind="warning">
@@ -54,82 +58,38 @@ However, they have different behaviors and purposes:
 npm install @spark-ui/combobox
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Combobox } from '@spark-ui/combobox'
+
+export default () => (
+  <Combobox>
+    <Combobox.Trigger>
+      <Combobox.LeadingIcon />
+      <ComboBox.SelectedItems /> // only when multiple selection is used
+      <Combobox.Input />
+      <Combobox.TrailingIcon />
+      <Combobox.ClearButton />
+      <Combobox.Disclosure />
+    </Combobox.Trigger>
+    <ComboBox.Popover>
+      <Combobox.Items>
+        <Combobox.Empty />
+        <Combobox.Group>
+          <Combobox.Label />
+          <Combobox.Item>
+            <ComboBox.ItemIndicator />
+            <ComboBox.ItemText />
+          </Combobox.Item>
+        </Combobox.Group>
+      </Combobox.Items>
+    </ComboBox.Popover>
+  </Combobox>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Combobox}
-  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
-  subcomponents={{
-    'Combobox.Trigger': {
-      of: Combobox.Trigger,
-      description:
-        'The area that toggles the combobox popover. The Select.Popover will position itself by aligning with its trigger.',
-    },
-    'Combobox.SelectedItems': {
-      of: Combobox.SelectedItems,
-      description: 'Multiple selection only. Displays selected items as chips inside the trigger.',
-    },
-    'Combobox.Input': {
-      of: Combobox.Input,
-      description:
-        'The typing area in which the user can type. The input behaviour will differ if `autoComplete` is used or not.',
-    },
-    'Combobox.LeadingIcon': {
-      of: Combobox.LeadingIcon,
-      description: 'Prepend a decorative icon inside the input (to the left).',
-    },
-    'Combobox.Disclosure': {
-      of: Combobox.Disclosure,
-      description: 'Optional visual button to open and close the combobox items list.',
-    },
-    'Combobox.Portal': {
-      of: Combobox.Portal,
-      description: 'When used, portals the content part into the body.',
-    },
-    'Combobox.Popover': {
-      of: Combobox.Popover,
-      description: 'The part that is toggled and portaled when the trigger element is clicked.',
-    },
-    'Combobox.Items': {
-      of: Combobox.Items,
-      description: 'The wrapper which contains all the options.',
-    },
-    'Combobox.Item': { of: Combobox.Item, description: 'Each option of the element field' },
-    'Combobox.ItemText': {
-      of: Combobox.ItemText,
-      description:
-        'The textual part of the item. It should only contain the text you want to see in the trigger when that item is selected. It should not be styled to ensure correct positioning.',
-    },
-    'Combobox.ItemIndicator': {
-      of: Combobox.ItemIndicator,
-      description:
-        'Renders when the item is selected. You can style this element directly, or you can use it as a wrapper to put an icon into, or both.',
-    },
-    'Combobox.Group': {
-      of: Combobox.Group,
-      description:
-        'A wrapper for grouping a subset of options (Combobox.Item) when needed. Use in conjunction with Combobox.Label to ensure good accessibility via automatic labelling.',
-    },
-    'Combobox.Label': {
-      of: Combobox.Label,
-      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-AutoSuggest is used as the default behaviour. The user can type anything in the input, the list is showing optional suggestions.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -252,7 +212,7 @@ This can be useful when the component is used inside a sticky navbar.
 
 <Canvas of={stories.MultipleSelectionNoWrap} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Custom item
 
@@ -303,6 +263,69 @@ Apply `readOnly` to the wrapping `FormField` to indicate the combobox is only re
 Set the `state` prop of the `FormField` to `error` to indicate that the combobox is invalid. Optionally use the `FormField.ErrorMessage` to describe why the combobox is invalid.
 
 <Canvas of={stories.FormFieldValidation} />
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Combobox}
+  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
+  subcomponents={{
+    'Combobox.Trigger': {
+      of: Combobox.Trigger,
+      description:
+        'The area that toggles the combobox popover. The Select.Popover will position itself by aligning with its trigger.',
+    },
+    'Combobox.SelectedItems': {
+      of: Combobox.SelectedItems,
+      description: 'Multiple selection only. Displays selected items as chips inside the trigger.',
+    },
+    'Combobox.Input': {
+      of: Combobox.Input,
+      description:
+        'The typing area in which the user can type. The input behaviour will differ if `autoComplete` is used or not.',
+    },
+    'Combobox.LeadingIcon': {
+      of: Combobox.LeadingIcon,
+      description: 'Prepend a decorative icon inside the input (to the left).',
+    },
+    'Combobox.Disclosure': {
+      of: Combobox.Disclosure,
+      description: 'Optional visual button to open and close the combobox items list.',
+    },
+    'Combobox.Portal': {
+      of: Combobox.Portal,
+      description: 'When used, portals the content part into the body.',
+    },
+    'Combobox.Popover': {
+      of: Combobox.Popover,
+      description: 'The part that is toggled and portaled when the trigger element is clicked.',
+    },
+    'Combobox.Items': {
+      of: Combobox.Items,
+      description: 'The wrapper which contains all the options.',
+    },
+    'Combobox.Item': { of: Combobox.Item, description: 'Each option of the element field' },
+    'Combobox.ItemText': {
+      of: Combobox.ItemText,
+      description:
+        'The textual part of the item. It should only contain the text you want to see in the trigger when that item is selected. It should not be styled to ensure correct positioning.',
+    },
+    'Combobox.ItemIndicator': {
+      of: Combobox.ItemIndicator,
+      description:
+        'Renders when the item is selected. You can style this element directly, or you can use it as a wrapper to put an icon into, or both.',
+    },
+    'Combobox.Group': {
+      of: Combobox.Group,
+      description:
+        'A wrapper for grouping a subset of options (Combobox.Item) when needed. Use in conjunction with Combobox.Label to ensure good accessibility via automatic labelling.',
+    },
+    'Combobox.Label': {
+      of: Combobox.Label,
+      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/dialog/src/Dialog.doc.mdx
+++ b/packages/components/dialog/src/Dialog.doc.mdx
@@ -19,6 +19,8 @@ A window overlaid on either the primary window or another dialog window, renderi
 - Manages screen reader announcements with `Title` and `Description` components.
 - Esc closes the component automatically.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 Install the component from your command line.
@@ -27,15 +29,68 @@ Install the component from your command line.
 npm install @spark-ui/dialog
 ```
 
-## Import
-
-Import all parts and piece them together.
+## Anatomy
 
 ```tsx
 import { Dialog } from '@spark-ui/dialog'
+
+export default () => (
+  <Dialog>
+    <Dialog.Trigger />
+    <Dialog.Portal>
+      <Dialog.Overlay />
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title />
+        </Dialog.Header>
+        <Dialog.Body>
+          <Dialog.Description />
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Dialog.Close />
+        </Dialog.Footer>
+        <Dialog.CloseButton>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog>
+);
 ```
 
-## Props
+## Examples
+
+### Controlled
+
+Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
+
+<Canvas of={stories.Controlled} />
+
+### Sizes
+
+Pick a size among `sm`, `md`, `lg` and `fullscreen`.
+
+<Canvas of={stories.Sizes} />
+
+### Inset
+
+When set to `true`, this option will remove the internal padding of the `Dialog.Body` component. This allows you to have an image or any content that occupies the full width, for example.
+
+<Canvas of={stories.Inset} />
+
+## Advanced Examples
+
+### Form inside a dialog
+
+The `Dialog` component can be effortlessly combined with a form element.
+
+<Canvas of={stories.Form} />
+
+### Forward focus
+
+Use `onOpenAutoFocus` and a `ref` to direct focus to a specific element when the dialog opens.
+
+<Canvas of={stories.ForwardFocus} />
+
+## API Reference
 
 <ArgTypes
   of={Dialog}
@@ -85,44 +140,6 @@ import { Dialog } from '@spark-ui/dialog'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
-
-### Controlled
-
-Use `open` and `onOpenChange` props to control the state of the dialog. This is specially useful to close the dialog after an async operation has completed.
-
-<Canvas of={stories.Controlled} />
-
-### Sizes
-
-Pick a size among `sm`, `md`, `lg` and `fullscreen`.
-
-<Canvas of={stories.Sizes} />
-
-### Inset
-
-When set to `true`, this option will remove the internal padding of the `Dialog.Body` component. This allows you to have an image or any content that occupies the full width, for example.
-
-<Canvas of={stories.Inset} />
-
-## Advanced usage
-
-### Form inside a dialog
-
-The `Dialog` component can be effortlessly combined with a form element.
-
-<Canvas of={stories.Form} />
-
-### Forward focus
-
-Use `onOpenAutoFocus` and a `ref` to direct focus to a specific element when the dialog opens.
-
-<Canvas of={stories.ForwardFocus} />
 
 ## Accessibility
 

--- a/packages/components/divider/src/Divider.doc.mdx
+++ b/packages/components/divider/src/Divider.doc.mdx
@@ -18,36 +18,27 @@ A few common uses are:
 - Separating items in a list
 - Creating a visual contrast between 2 sides of a page
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/divider
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Divider } from '@spark-ui/divider'
+
+export default () => (
+  <Divider>
+    <Divider.Content />
+  </Divider>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Divider}
-  description="Visually or semantically separates content."
-  subcomponents={{
-    'Divider.Content': {
-      of: Divider.Content,
-      description: 'A label appearing on top of the divider if necessary.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Content
 
@@ -87,7 +78,7 @@ The divider can set its intent setting it as a prop.
 
 <Canvas of={stories.Intent} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Wrapped Content
 
@@ -98,6 +89,20 @@ Users can also rotate the text to achieve the proper design.
 ### Card Content
 
 <Canvas of={stories.Card} />
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Divider}
+  description="Visually or semantically separates content."
+  subcomponents={{
+    'Divider.Content': {
+      of: Divider.Content,
+      description: 'A label appearing on top of the divider if necessary.',
+    },
+  }}
+/>
+
 
 ## Accessibility
 

--- a/packages/components/drawer/src/Drawer.doc.mdx
+++ b/packages/components/drawer/src/Drawer.doc.mdx
@@ -13,6 +13,8 @@ import * as stories from './Drawer.stories'
 
 A panel that slides out from the edge of the screen. It can be useful when you need users to complete a task or view some details without leaving the current page.
 
+<Canvas of={stories.Usage} />
+
 - ✅ Supports modal and non-modal modes.
 - ✅ Focus is automatically trapped when modal.
 - ✅ Can be controlled or uncontrolled.
@@ -27,15 +29,54 @@ Install the component from your command line.
 npm install @spark-ui/drawer
 ```
 
-## Import
-
-Import all parts and piece them together.
+## Anatomy
 
 ```tsx
 import { Drawer } from '@spark-ui/drawer'
+
+export default () => (
+  <Drawer>
+    <Drawer.Trigger />
+    <Drawer.Portal>
+      <Drawer.Overlay />
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title />
+        </Drawer.Header>
+        <Drawer.Body>
+          <Drawer.Description />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close />
+        </Drawer.Footer>
+        <Drawer.CloseButton>
+      </Drawer.Content>
+    </Drawer.Portal>
+  </Drawer>
+);
 ```
 
-## Props
+## Examples
+
+### Side
+
+Pick a side among `right`, `left`, `top` and `bottom`.
+
+<Canvas of={stories.Side} />
+
+### Size
+
+Pick a size among `sm`, `md`, `lg`, `fluid` and `fullscreen`.
+
+<Canvas of={stories.Sizes} />
+
+### Inset
+
+When set to `true`, this option will remove the internal padding of the `Drawer.Body` component. This allows you to have an image or any content that occupies the full width, for example.
+
+<Canvas of={stories.Inset} />
+
+## API Reference
 
 <ArgTypes
   of={Drawer}
@@ -85,30 +126,6 @@ import { Drawer } from '@spark-ui/drawer'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Usage} />
-
-### Side
-
-Pick a side among `right`, `left`, `top` and `bottom`.
-
-<Canvas of={stories.Side} />
-
-### Size
-
-Pick a size among `sm`, `md`, `lg`, `fluid` and `fullscreen`.
-
-<Canvas of={stories.Sizes} />
-
-### Inset
-
-When set to `true`, this option will remove the internal padding of the `Drawer.Body` component. This allows you to have an image or any content that occupies the full width, for example.
-
-<Canvas of={stories.Inset} />
 
 ## Accessibility
 

--- a/packages/components/dropdown/src/Dropdown.doc.mdx
+++ b/packages/components/dropdown/src/Dropdown.doc.mdx
@@ -17,6 +17,8 @@ It saves space on the interface by concealing the options until the user interac
 
 Displays a **closed** list of options for the user to pick triggered by a button.
 
+<Canvas of={stories.Default} />
+
 #### Dropdown is not a ComboBox
 
 <Callout kind="warning">
@@ -56,76 +58,34 @@ However, they have different behaviors and purposes:
 npm install @spark-ui/dropdown
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Dropdown } from '@spark-ui/dropdown'
+
+export default () => (
+  <Dropdown>
+    <Dropdown.Trigger>
+      <Dropdown.LeadingIcon />
+      <Dropdown.Value />
+    </Dropdown.Trigger>
+    <Dropdown.Popover>
+      <Dropdown.Items>
+        <Dropdown.Group>
+          <Dropdown.Label />
+          <Dropdown.Item>
+            <Dropdown.ItemIndicator />
+            <Dropdown.ItemText />
+          </Dropdown.Item>
+        </Dropdown.Group>
+        <Dropdown.Divider />
+      </Dropdown.Items>
+    </Dropdown.Popover>
+  </Dropdown>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Dropdown}
-  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
-  subcomponents={{
-    'Dropdown.Trigger': {
-      of: Dropdown.Trigger,
-      description:
-        'The button that toggles the select. The Select.Popover will position itself by aligning over the trigger.',
-    },
-    'Dropdown.Value': {
-      of: Dropdown.Value,
-      description:
-        "The part that reflects the selected value. By default the selected item's text will be rendered. if you require more control, you can instead control the select and pass your own children. It should not be styled to ensure correct positioning. An optional placeholder prop is also available for when the select has no value.",
-    },
-    'Dropdown.LeadingIcon': {
-      of: Dropdown.LeadingIcon,
-      description: 'Prepend a decorative icon inside the input (to the left).',
-    },
-    'Dropdown.Portal': {
-      of: Dropdown.Portal,
-      description: 'When used, portals the content part into the body.',
-    },
-    'Dropdown.Popover': {
-      of: Dropdown.Popover,
-      description: 'The part that is toggled and portaled when the trigger element is clicked.',
-    },
-    'Dropdown.Items': {
-      of: Dropdown.Items,
-      description: 'The wrapper which contains all the options.',
-    },
-    'Dropdown.Item': { of: Dropdown.Item, description: 'Each option of the element field' },
-    'Dropdown.ItemText': {
-      of: Dropdown.ItemText,
-      description:
-        'The textual part of the item. It should only contain the text you want to see in the trigger when that item is selected. It should not be styled to ensure correct positioning.',
-    },
-    'Dropdown.ItemIndicator': {
-      of: Dropdown.ItemIndicator,
-      description:
-        'Renders when the item is selected. You can style this element directly, or you can use it as a wrapper to put an icon into, or both.',
-    },
-    'Dropdown.Group': {
-      of: Dropdown.Group,
-      description:
-        'A wrapper for grouping a subset of options (Dropdown.Item) when needed. Use in conjunction with Dropdown.Label to ensure good accessibility via automatic labelling.',
-    },
-    'Dropdown.Label': {
-      of: Dropdown.Label,
-      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
-    },
-    'Dropdown.Divider': {
-      of: Dropdown.Divider,
-      description: 'Used to visually separate items in the select.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -205,7 +165,7 @@ Use `value` and `onValueChange` props to control the value of the dropdown.
 
 <Canvas of={stories.MultipleSelectionControlled} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Custom item
 
@@ -252,6 +212,67 @@ Apply `readOnly` to the wrapping `FormField` to indicate the dropdown is only re
 Set the `state` prop of the `FormField` to `error` to indicate that the dropdown is invalid. Optionally use the `FormField.ErrorMessage` to describe why the dropdown is invalid.
 
 <Canvas of={stories.FormFieldValidation} />
+
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Dropdown}
+  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
+  subcomponents={{
+    'Dropdown.Trigger': {
+      of: Dropdown.Trigger,
+      description:
+        'The button that toggles the select. The Select.Popover will position itself by aligning over the trigger.',
+    },
+    'Dropdown.Value': {
+      of: Dropdown.Value,
+      description:
+        "The part that reflects the selected value. By default the selected item's text will be rendered. if you require more control, you can instead control the select and pass your own children. It should not be styled to ensure correct positioning. An optional placeholder prop is also available for when the select has no value.",
+    },
+    'Dropdown.LeadingIcon': {
+      of: Dropdown.LeadingIcon,
+      description: 'Prepend a decorative icon inside the input (to the left).',
+    },
+    'Dropdown.Portal': {
+      of: Dropdown.Portal,
+      description: 'When used, portals the content part into the body.',
+    },
+    'Dropdown.Popover': {
+      of: Dropdown.Popover,
+      description: 'The part that is toggled and portaled when the trigger element is clicked.',
+    },
+    'Dropdown.Items': {
+      of: Dropdown.Items,
+      description: 'The wrapper which contains all the options.',
+    },
+    'Dropdown.Item': { of: Dropdown.Item, description: 'Each option of the element field' },
+    'Dropdown.ItemText': {
+      of: Dropdown.ItemText,
+      description:
+        'The textual part of the item. It should only contain the text you want to see in the trigger when that item is selected. It should not be styled to ensure correct positioning.',
+    },
+    'Dropdown.ItemIndicator': {
+      of: Dropdown.ItemIndicator,
+      description:
+        'Renders when the item is selected. You can style this element directly, or you can use it as a wrapper to put an icon into, or both.',
+    },
+    'Dropdown.Group': {
+      of: Dropdown.Group,
+      description:
+        'A wrapper for grouping a subset of options (Dropdown.Item) when needed. Use in conjunction with Dropdown.Label to ensure good accessibility via automatic labelling.',
+    },
+    'Dropdown.Label': {
+      of: Dropdown.Label,
+      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
+    },
+    'Dropdown.Divider': {
+      of: Dropdown.Divider,
+      description: 'Used to visually separate items in the select.',
+    },
+  }}
+/>
+
 
 ## Accessibility
 

--- a/packages/components/form-field/src/FormField.doc.mdx
+++ b/packages/components/form-field/src/FormField.doc.mdx
@@ -12,19 +12,63 @@ import * as stories from './FormField.stories'
 
 Provide context to your form elements easily.
 
+By default, all Spark input components use `FormField.Control` behind the scenes. However, if you want to use a custom input component, or if you need more fine-grained control over the state of a form control, it can be used.
+
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/form-field
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { FormField } from '@spark-ui/form-field'
+
+export default () => (
+  <FormField>
+    <FormField.Label />
+    /**
+     * FormField.Control can be replaced by any Spark component that is an input:
+     * - Checkbox, Combobox, Dropdown, TextInput, RadioGroup, Select, Stepper, Switch, etc
+     */
+    <FormField.Control /> 
+
+    <FormField.HelperMessage>We will never share your email</FormField.HelperMessage>
+  </FormField>
+)
 ```
 
-## Props
+
+## Examples
+
+### Characters count
+
+Use `FormField.CharactersCount` to show users how many characters they have left. Can be used in combination with all types of text inputs.
+
+<Canvas of={stories.CharactersCount} />
+
+### Required
+
+Set `isRequired` prop to `true` to mark the input as required and display a required indicator. The default indicator is an asterisk `*`.
+
+<Canvas of={stories.Required} />
+
+#### Custom required indicator
+
+Configure the required indicator using the `requiredIndicator` prop and the `FormRequiredIndicator` component.
+
+<Canvas of={stories.CustomRequired} />
+
+### State
+
+Use the `state` prop to set the visual validation state. Choose between `error`, `success` and `alert`.
+
+<Canvas of={stories.State} />
+
+## API Reference
 
 <ArgTypes
   of={FormField}
@@ -71,37 +115,6 @@ import { FormField } from '@spark-ui/form-field'
   }}
 />
 
-## Usage
-
-### Default
-
-By default, all Spark input components use `FormField.Control` behind the scenes, so **you do not need to use it explicitly**. However, if you want to use a custom input component, or if you need more fine-grained control over the state of a form control, it can be used.
-
-<Canvas of={stories.Default} />
-
-### Characters count
-
-Use `FormField.CharactersCount` to show users how many characters they have left. Can be used in combination with all types of text inputs.
-
-<Canvas of={stories.CharactersCount} />
-
-### Required
-
-Set `isRequired` prop to `true` to mark the input as required and display a required indicator. The default indicator is an asterisk `*`.
-
-<Canvas of={stories.Required} />
-
-#### Custom required indicator
-
-Configure the required indicator using the `requiredIndicator` prop and the `FormRequiredIndicator` component.
-
-<Canvas of={stories.CustomRequired} />
-
-### State
-
-Use the `state` prop to set the visual validation state. Choose between `error`, `success` and `alert`.
-
-<Canvas of={stories.State} />
 
 ## Accessibility
 

--- a/packages/components/icon-button/src/IconButton.doc.mdx
+++ b/packages/components/icon-button/src/IconButton.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Kbd } from '@spark-ui/kbd'
 import { Callout } from '@docs/helpers/Callout'
 import { IconButton } from '.'
@@ -12,27 +12,23 @@ import * as stories from './IconButton.stories'
 
 Icon button renders an icon within in a button
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/icon-button
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { IconButton } from '@spark-ui/icon-button'
+
+export default () => <IconButton />;
 ```
 
-## Props
-
-<ArgTypes of={IconButton} />
-
-## usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Design
 
@@ -72,7 +68,7 @@ Use `size` prop to set the size of a button.
 
 <Canvas of={stories.Sizes} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Link
 
@@ -95,6 +91,10 @@ This polymorphic behaviour can be used with any type of HTML element.
 Use `aria-pressed` to transform the button into a toggle button.
 
 <Canvas of={stories.Toggle} />
+
+## API Reference
+
+<ArgTypes of={IconButton} />
 
 ## Accessibility
 

--- a/packages/components/icon/src/Icon.doc.mdx
+++ b/packages/components/icon/src/Icon.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Icon } from '.'
 import * as IconStories from './Icon.stories'
 
@@ -10,27 +10,27 @@ import * as IconStories from './Icon.stories'
 
 Accessible icon wrapper
 
+<Canvas of={IconStories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/icon
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Icon } from '@spark-ui/icon'
+
+export default () => (
+  <Icon />
+);
 ```
 
-## Props
 
-<ArgTypes of={Icon} />
 
-## Usage
-
-### Default
-
-<Canvas of={IconStories.Default} />
+## Examples
 
 ### Intent
 
@@ -49,6 +49,10 @@ Use `label` prop so it could be announced correctly by screen readers. There is 
 Use `size` prop to change the size of the icon. If `current` is set the current font size will be used.
 
 <Canvas of={IconStories.Sizes} />
+
+## API Reference
+
+<ArgTypes of={Icon} />
 
 ## Accessibility
 

--- a/packages/components/icons/src/index.stories.tsx
+++ b/packages/components/icons/src/index.stories.tsx
@@ -9,7 +9,7 @@ import { Check as IconCheck } from './icons/Check'
 const meta: Meta = {
   title: 'Components/Icons',
   component: IconCheck,
-  tags: ['others'],
+  tags: ['others', 'hidden'],
 }
 
 export default meta

--- a/packages/components/input/src/Input.doc.mdx
+++ b/packages/components/input/src/Input.doc.mdx
@@ -14,61 +14,35 @@ Component used to get user input in a text field.
 
 Use `InputGroup` component to group your input with addons and elements like icons.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/input
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Input, InputGroup } from '@spark-ui/input'
+
+export default () => <Input />
+
+// Or with InputGroup
+export default () => (
+  <InputGroup>
+    <InputGroup.LeadingAddon />
+    <InputGroup.LeadingIcon />
+    <Input />
+    <InputGroup.ClearButton />
+    <InputGroup.TrailingIcon />
+    <InputGroup.TrailingAddon />
+  </InputGroup.LeadingIcon>
+)
 ```
 
-## Props
-
-<ArgTypes
-  of={Input}
-  description="Input component is a component that is used to get user input in a text field."
-  subcomponents={{
-    InputGroup: {
-      of: InputGroup,
-      description:
-        'Use this wrapper whenever you need a more complex text input. For example if you need to have leading/trailing icons or addons.',
-    },
-    'InputGroup.LeadingAddon': {
-      of: InputGroup.LeadingAddon,
-      description:
-        'Add any type of component that will be displayed before the input field.\n This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
-    },
-    'InputGroup.LeadingIcon': {
-      of: InputGroup.LeadingIcon,
-      description: 'Prepend a decorative icon inside the input (to the left).',
-    },
-    'InputGroup.TrailingAddon': {
-      of: InputGroup.TrailingAddon,
-      description:
-        'Add any type of component that will be displayed after the input field. This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
-    },
-    'InputGroup.TrailingIcon': {
-      of: InputGroup.TrailingIcon,
-      description:
-        'Append a decorative icon inside the input (to the right). This element will be replaced by a status indicator whenever the input is in error/alert/success state.',
-    },
-    'InputGroup.ClearButton': {
-      of: InputGroup.ClearButton,
-      description:
-        'Clears the input value. Only for search inputs. This button will be shown when the user has typed something in the input.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Uncontrolled
 
@@ -114,7 +88,7 @@ Use `state` prop to assign a specific state to the group, choosing from: `error`
 
 <Canvas of={stories.State} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Search
 
@@ -167,6 +141,44 @@ Use the `isRequired` prop of the `FormField` to indicate that the input is requi
 set the `state` prop of the `FormField` to `error` to indicate that the input is invalid. Optionally use the `FormField.ErrorMessage` to describe why the input is invalid.
 
 <Canvas of={stories.FieldInvalid} />
+
+## API Reference
+
+<ArgTypes
+  of={Input}
+  description="Input component is a component that is used to get user input in a text field."
+  subcomponents={{
+    InputGroup: {
+      of: InputGroup,
+      description:
+        'Use this wrapper whenever you need a more complex text input. For example if you need to have leading/trailing icons or addons.',
+    },
+    'InputGroup.LeadingAddon': {
+      of: InputGroup.LeadingAddon,
+      description:
+        'Add any type of component that will be displayed before the input field.\n This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
+    },
+    'InputGroup.LeadingIcon': {
+      of: InputGroup.LeadingIcon,
+      description: 'Prepend a decorative icon inside the input (to the left).',
+    },
+    'InputGroup.TrailingAddon': {
+      of: InputGroup.TrailingAddon,
+      description:
+        'Add any type of component that will be displayed after the input field. This provides flexibility to include additional elements, such as buttons or dropdowns, to enhance the user interface and provide clear context or guidance to the user.',
+    },
+    'InputGroup.TrailingIcon': {
+      of: InputGroup.TrailingIcon,
+      description:
+        'Append a decorative icon inside the input (to the right). This element will be replaced by a status indicator whenever the input is in error/alert/success state.',
+    },
+    'InputGroup.ClearButton': {
+      of: InputGroup.ClearButton,
+      description:
+        'Clears the input value. Only for search inputs. This button will be shown when the user has typed something in the input.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/kbd/src/Kbd.doc.mdx
+++ b/packages/components/kbd/src/Kbd.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 
 import { Kbd } from '.'
 
@@ -12,28 +12,6 @@ import * as stories from './Kbd.stories'
 
 The keyboard key component exists to show which key or combination of keys performs a given action.
 
-## Install
-
-```sh
-npm install @spark-ui/kbd
-```
-
-## Import
-
-```tsx
-import { Kbd } from '@spark-ui/kbd'
-```
-
-## Props
-
-<ArgTypes of={Kbd} />
-
-## Default
-
-<Canvas of={stories.Default} />
-
-# Guideline
-
 All shortcuts should do their best to match what appears on the user’s keyboard.
 
 - All single letters A-Z are uppercase.
@@ -43,7 +21,26 @@ All shortcuts should do their best to match what appears on the user’s keyboar
 - For function keys, stick to uppercase.
 - For combination between keys and mouse events type the mouse event name upper-cased preceded by the 🖱️unicode glyph.
 
-# Combinations
+
+<Canvas of={stories.Default} />
+
+## Install
+
+```sh
+npm install @spark-ui/kbd
+```
+
+## Anatomy
+
+```tsx
+import { Kbd } from '@spark-ui/kbd'
+
+export default () => <Kbd />;
+```
+
+## Examples
+
+### Combinations
 
 The only punctuation you should need is the + to indicate that a combination of keys will activate the shortcut.
 
@@ -60,6 +57,10 @@ If two different keys can execute the same action or the shortcut itself may loo
 When combining a keyboard key and a mouse action combine it using the previous rules and the action name bold and uppercase preceded by the 🖱symbol glyph.
 
 <Canvas of={stories.OptionPlusScroll} />
+
+## API Reference
+
+<ArgTypes of={Kbd} />
 
 ## Accessibility
 

--- a/packages/components/label/src/Label.doc.mdx
+++ b/packages/components/label/src/Label.doc.mdx
@@ -10,37 +10,27 @@ import * as stories from './Label.stories'
 
 Renders an accessible label associated with controls.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/label
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Label } from '@spark-ui/label'
+
+export default () => (
+  <Label>
+    <Label.RequiredIndicator />
+  </Label>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Label}
-  description="A label that can be used to describe a field"
-  subcomponents={{
-    'Label.RequiredIndicator': {
-      of: Label.RequiredIndicator,
-      description:
-        'An optional indicator to display a field as required. Must be rendered inside Label.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Required
 
@@ -53,6 +43,20 @@ Use `Label.RequiredIndicator` component to display a required indicator inside t
 Optionally use the `children` prop to change the indicator.
 
 <Canvas of={stories.RequiredIndicator} />
+
+## API Reference
+
+<ArgTypes
+  of={Label}
+  description="A label that can be used to describe a field"
+  subcomponents={{
+    'Label.RequiredIndicator': {
+      of: Label.RequiredIndicator,
+      description:
+        'An optional indicator to display a field as required. Must be rendered inside Label.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/link-box/src/LinkBox.doc.mdx
+++ b/packages/components/link-box/src/LinkBox.doc.mdx
@@ -12,19 +12,40 @@ import * as stories from './LinkBox.stories'
 
 Semantic component used to wrap elements (cards, blog posts, articles, etc.) in a link.
 
+Simply wrapping an entire component in an `a` tag may seem convenient for linking, but it's considered unsemantic and incorrect. This is because the component might include other clickable elements like tags, timestamps, or buttons.
+
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/link-box
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { LinkBox } from '@spark-ui/link-box'
+
+export default () => (
+  <LinkBox>
+    <LinkBox.Link /> 
+    <LinkBox.Raised />
+  </LinkBox>
+);
 ```
 
-## Props
+## Examples
+
+### Nesting
+
+If your linkbox contains interactive elements inside of it, wrap them with `LinkBox.Raised`.
+
+It will raise their `z-index` to stay above the main link of your `LinkBox`.
+
+<Canvas of={stories.Nesting} />
+
+## API Reference
 
 <ArgTypes
   of={LinkBox}
@@ -42,22 +63,6 @@ import { LinkBox } from '@spark-ui/link-box'
     },
   }}
 />
-
-## Usage
-
-### Default
-
-Simply wrapping an entire component in an `a` tag may seem convenient for linking, but it's considered unsemantic and incorrect. This is because the component might include other clickable elements like tags, timestamps, or buttons.
-
-<Canvas of={stories.Default} />
-
-### Nesting
-
-If your linkbox contains interactive elements inside of it, wrap them with `LinkBox.Raised`.
-
-It will raise their `z-index` to stay above the main link of your `LinkBox`.
-
-<Canvas of={stories.Nesting} />
 
 ## Accessibility
 

--- a/packages/components/pagination/src/Pagination.doc.mdx
+++ b/packages/components/pagination/src/Pagination.doc.mdx
@@ -11,7 +11,9 @@ import * as stories from './Pagination.stories'
 
 # Pagination
 
-interface that allows navigating between pages that contain split information, instead of being shown on a single page.
+Interface that allows navigating between pages that contain split information, instead of being shown on a single page.
+
+<Canvas of={stories.Default} />
 
 ## Install
 
@@ -19,58 +21,26 @@ interface that allows navigating between pages that contain split information, i
 npm install @spark-ui/pagination
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Pagination } from '@spark-ui/pagination'
+
+export default () => (
+  <Pagination>
+    <Pagination.FirstPageTrigger /> 
+    <Pagination.PrevTrigger /> 
+    <Pagination.Pages>
+      <Pagination.Item />
+      <Pagination.Ellipsis />
+    </Pagination.Pages>
+    <Pagination.NextTrigger />
+    <Pagination.LastPageTrigger />  
+  </Pagination.Pages>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Pagination}
-  description="Contains all the parts of a pagination."
-  subcomponents={{
-    'Pagination.FirstPageTrigger': {
-      of: Pagination.FirstPageTrigger,
-      description: 'A button to go to the first page, no matter which page is currently selected.',
-    },
-    'Pagination.PrevTrigger': {
-      of: Pagination.PrevTrigger,
-      description:
-        'A button to go to the previous page, no matter which page is currently selected.',
-    },
-    'Pagination.NextTrigger': {
-      of: Pagination.NextTrigger,
-      description: 'A button to go to the next page, no matter which page is currently selected.',
-    },
-    'Pagination.LastPageTrigger': {
-      of: Pagination.LastPageTrigger,
-      description: 'A button to go to the last page, no matter which page is currently selected.',
-    },
-    'Pagination.Pages': {
-      of: Pagination.Pages,
-      description:
-        'This component exposes the internal api of the pagination to render individual page elements by yourself.',
-    },
-    'Pagination.Item': {
-      of: Pagination.Item,
-      description: 'A numbered page item. Can be a link or a button.',
-    },
-    'Pagination.Ellipsis': {
-      of: Pagination.Ellipsis,
-      description: 'Indicates a jump between visible page elements.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-A basic example combining all parts of the component: a "previous page" button, "last page" button, and a list of pages items/ellipsis.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -176,6 +146,45 @@ The `type` of the trigger element can be either a **button** (`<Pagination type=
   <Pagination.NextTrigger aria-label="Next page" href="#next" />
 </Pagination>
 ```
+
+## API Reference
+
+<ArgTypes
+  of={Pagination}
+  description="Contains all the parts of a pagination."
+  subcomponents={{
+    'Pagination.FirstPageTrigger': {
+      of: Pagination.FirstPageTrigger,
+      description: 'A button to go to the first page, no matter which page is currently selected.',
+    },
+    'Pagination.PrevTrigger': {
+      of: Pagination.PrevTrigger,
+      description:
+        'A button to go to the previous page, no matter which page is currently selected.',
+    },
+    'Pagination.NextTrigger': {
+      of: Pagination.NextTrigger,
+      description: 'A button to go to the next page, no matter which page is currently selected.',
+    },
+    'Pagination.LastPageTrigger': {
+      of: Pagination.LastPageTrigger,
+      description: 'A button to go to the last page, no matter which page is currently selected.',
+    },
+    'Pagination.Pages': {
+      of: Pagination.Pages,
+      description:
+        'This component exposes the internal api of the pagination to render individual page elements by yourself.',
+    },
+    'Pagination.Item': {
+      of: Pagination.Item,
+      description: 'A numbered page item. Can be a link or a button.',
+    },
+    'Pagination.Ellipsis': {
+      of: Pagination.Ellipsis,
+      description: 'Indicates a jump between visible page elements.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/popover/src/Popover.doc.mdx
+++ b/packages/components/popover/src/Popover.doc.mdx
@@ -13,62 +13,6 @@ import * as stories from './Popover.stories'
 
 Displays rich content in a portal, triggered by a button.
 
-## Install
-
-```sh
-npm install @spark-ui/popover
-```
-
-## Import
-
-```tsx
-import { Popover } from '@spark-ui/popover'
-```
-
-## Props
-
-<ArgTypes
-  of={Popover}
-  description="Contains all the parts of a popover."
-  subcomponents={{
-    'Popover.Trigger': {
-      of: Popover.Trigger,
-      description:
-        'The button that toggles the popover. By default, the Popover.Content will position itself against the trigger.',
-    },
-    'Popover.Anchor': {
-      of: Popover.Anchor,
-      description:
-        'An optional element to position the Popover.Content against. If this part is not used, the content will position alongside the Popover.Trigger.',
-    },
-    'Popover.Portal': {
-      of: Popover.Portal,
-      description: 'When used, portals the content part into the body.',
-    },
-    'Popover.Content': {
-      of: Popover.Content,
-      description: 'The component that pops out when the popover is open.',
-    },
-    'Popover.Header': {
-      of: Popover.Header,
-      description:
-        'Header for the popover content. Also serve as an accessible name for the Popover. Must be rendered inside Popover.Content.',
-    },
-    'Popover.CloseButton': {
-      of: Popover.CloseButton,
-      description: 'The button that closes an open popover.',
-    },
-    'Popover.Arrow': {
-      of: Popover.Arrow,
-      description:
-        'An optional arrow element to render alongside the popover. This can be used to help visually link the anchor with the Popover.Content. Must be rendered inside Popover.Content.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
 
 A basic popover should have a trigger element and a content element.
 
@@ -76,6 +20,34 @@ The trigger is the element that should toggle the popover.
 The content is the popover itself.
 
 <Canvas of={stories.Default} />
+
+## Install
+
+```sh
+npm install @spark-ui/popover
+```
+
+## Anatomy
+
+```tsx
+import { Popover } from '@spark-ui/popover'
+
+export default () => (
+  <Popover>
+    <Popover.Trigger />
+    <Popover.Portal>
+      <Popover.Content>
+        <Popover.Header />
+        <Popover.Arrow />
+        <Popover.CloseButton />
+      </Popover.Content>
+    </Popover.Portal>
+    <Popover.Anchor />
+  </Popover.Portal>
+);
+```
+
+## Examples
 
 ### Inset
 
@@ -136,6 +108,47 @@ By combining `side` and `align` you can achieve many positions for the popover.
 - `align`: The preferred alignment against the anchor. May change when collisions occur.
 
 <Canvas of={stories.Positionning} />
+
+## API Reference
+
+<ArgTypes
+  of={Popover}
+  description="Contains all the parts of a popover."
+  subcomponents={{
+    'Popover.Trigger': {
+      of: Popover.Trigger,
+      description:
+        'The button that toggles the popover. By default, the Popover.Content will position itself against the trigger.',
+    },
+    'Popover.Anchor': {
+      of: Popover.Anchor,
+      description:
+        'An optional element to position the Popover.Content against. If this part is not used, the content will position alongside the Popover.Trigger.',
+    },
+    'Popover.Portal': {
+      of: Popover.Portal,
+      description: 'When used, portals the content part into the body.',
+    },
+    'Popover.Content': {
+      of: Popover.Content,
+      description: 'The component that pops out when the popover is open.',
+    },
+    'Popover.Header': {
+      of: Popover.Header,
+      description:
+        'Header for the popover content. Also serve as an accessible name for the Popover. Must be rendered inside Popover.Content.',
+    },
+    'Popover.CloseButton': {
+      of: Popover.CloseButton,
+      description: 'The button that closes an open popover.',
+    },
+    'Popover.Arrow': {
+      of: Popover.Arrow,
+      description:
+        'An optional arrow element to render alongside the popover. This can be used to help visually link the anchor with the Popover.Content. Must be rendered inside Popover.Content.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/portal/src/Portal.doc.mdx
+++ b/packages/components/portal/src/Portal.doc.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas } from '@storybook/blocks'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Portal } from '.'
 import * as PortalStories from './Portal.stories'
 
@@ -12,26 +12,27 @@ Renders a React subtree in a different part of the DOM.
 - Render any React subtree outside of your App.
 - Appends to `document.body` by default but can be customized to use a different container.
 
+In the following example, the JSX element is located in the left block, but rendered inside the right block.
+
+This is because we wrapped it with a `Portal` whose `container` is the block to the right.
+
+<Canvas of={PortalStories.Usage} />
+
 ## Install
 
 ```
 npm install @spark-ui/portal
 ```
 
-## Import
+## Anatomy
 
-```
+```tsx
 import { Portal } from "@spark-ui/portal"
+
+export default () => <Portal />;
 ```
 
-## Props
+## API Reference
 
 <ArgTypes of={Portal} />
 
-## Usage
-
-In the following example, the JSX element is located in the left block, but rendered inside the right block.
-
-This is because we wrapped it with a `Portal` whose `container` is the block to the right.
-
-<Canvas of={PortalStories.Usage} />

--- a/packages/components/progress-tracker/src/ProgressTracker.doc.mdx
+++ b/packages/components/progress-tracker/src/ProgressTracker.doc.mdx
@@ -13,46 +13,32 @@ import * as stories from './ProgressTracker.stories'
 
 A progress tracker component is a visual navigation element typically used to display progress or guide user through a multi-step process.
 
+Step indicator content defaults to step index, or checkmark icon when completed. Use `StepIndicator` to customize this content, through `complete` and `incomplete` props.
+
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/progress-tracker
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { ProgressTracker } from '@spark-ui/progress-tracker'
+
+export default () => (
+  <ProgressTracker>
+    <ProgressTracker.Step>
+      <ProgressTracker.StepIndicator />
+      <ProgressTracker.StepLabel />
+    </ProgressTracker.Step>
+  </ProgressTracker.Step>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={ProgressTracker}
-  description="Contains all the progress tracker component parts."
-  subcomponents={{
-    'ProgressTracker.Step': {
-      of: ProgressTracker.Step,
-      description: 'Contains the button associated to a step.',
-    },
-    'ProgressTracker.StepLabel': {
-      of: ProgressTracker.StepLabel,
-      description: 'The label describing the step.',
-    },
-    'ProgressTracker.StepIndicator': {
-      of: ProgressTracker.StepIndicator,
-      description: 'Contains the custom content of a step, for complete and incomplete states.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-Step indicator content defaults to step index, or checkmark icon when completed. Use `StepIndicator` to customize this content, through `complete` and `incomplete` props.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -95,6 +81,27 @@ Use `design` prop to set the look and feel.
 Use `orientation` prop to set `horizontal|vertical` orientation.
 
 <Canvas of={stories.Orientation} />
+
+## API Reference
+
+<ArgTypes
+  of={ProgressTracker}
+  description="Contains all the progress tracker component parts."
+  subcomponents={{
+    'ProgressTracker.Step': {
+      of: ProgressTracker.Step,
+      description: 'Contains the button associated to a step.',
+    },
+    'ProgressTracker.StepLabel': {
+      of: ProgressTracker.StepLabel,
+      description: 'The label describing the step.',
+    },
+    'ProgressTracker.StepIndicator': {
+      of: ProgressTracker.StepIndicator,
+      description: 'Contains the custom content of a step, for complete and incomplete states.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/progress/src/Progress.doc.mdx
+++ b/packages/components/progress/src/Progress.doc.mdx
@@ -12,44 +12,31 @@ import * as stories from './Progress.stories'
 
 Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/progress
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Progress } from '@spark-ui/progress'
+
+export default () => <Progress />;
+
+// Or
+export default () => (
+  <Progress>
+    <Progress.Bar />
+    <Progress.Label />
+  </Progress>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Progress}
-  description="Contains all of the progress parts. It also makes progress accessible to assistive technologies."
-  subcomponents={{
-    'Progress.Bar': {
-      of: Progress.Bar,
-      description: 'Used to show the progress bar.',
-    },
-    'Progress.Label': {
-      of: Progress.Label,
-      description: 'Used to display a label for the progress.',
-    },
-    'Progress.Indicator': {
-      of: Progress.Indicator,
-      description: 'Used to show the progress. Automatically added by the progress bar.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Intent
 
@@ -93,13 +80,34 @@ Use `isIndeterminate` prop to represent an interdeterminate operation.
 
 <Canvas of={stories.Indeterminate} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Visible value
 
 Displaying the progress value as text is possible by composing the different components.
 
 <Canvas of={stories.VisibleValue} />
+
+## API Reference
+
+<ArgTypes
+  of={Progress}
+  description="Contains all of the progress parts. It also makes progress accessible to assistive technologies."
+  subcomponents={{
+    'Progress.Bar': {
+      of: Progress.Bar,
+      description: 'Used to show the progress bar.',
+    },
+    'Progress.Label': {
+      of: Progress.Label,
+      description: 'Used to display a label for the progress.',
+    },
+    'Progress.Indicator': {
+      of: Progress.Indicator,
+      description: 'Used to show the progress. Automatically added by the progress bar.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/radio-group/src/RadioGroup.doc.mdx
+++ b/packages/components/radio-group/src/RadioGroup.doc.mdx
@@ -11,38 +11,29 @@ import { Kbd } from '@spark-ui/kbd'
 
 Component used when only one choice may be selected in a series of options.
 
+Radio label can be multiline. Still you should care of not using elements (for the label) with greater line height than the radio input height, to preserve vertical alignment.
+
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/radio-group
 ```
 
-## Import
+## Anatomy
 
 ```ts
 import { RadioGroup } from '@spark-ui/radio-group'
+
+export default () => (
+  <RadioGroup>
+    <RadioGroup.Radio />
+  </RadioGroup>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={RadioGroup}
-  description="Contains all the parts of a radio group."
-  subcomponents={{
-    'RadioGroup.Radio': {
-      of: RadioGroup.Radio,
-      description: 'An item in the group that can be checked.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-Radio label can be multiline. Still you should care of not using elements (for the label) with greater line height than the radio input height, to preserve vertical alignment.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Uncontrolled
 
@@ -82,7 +73,7 @@ Use `orientation` prop to set the orientation of the checkbox group which could 
 
 <Canvas of={stories.Orientation} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Custom implementation
 
@@ -133,6 +124,20 @@ Use the `FormField.HelperMessage` component to provide a description to the inpu
 set the `state` prop of the `FormField` to `error` to indicate that the input is invalid. Optionally use the `FormField.ErrorMessage` to describe why the input is invalid.
 
 <Canvas of={stories.FieldInvalid} />
+
+## API Reference
+
+<ArgTypes
+  of={RadioGroup}
+  description="Contains all the parts of a radio group."
+  subcomponents={{
+    'RadioGroup.Radio': {
+      of: RadioGroup.Radio,
+      description: 'An item in the group that can be checked.',
+    },
+  }}
+/>
+
 
 ## Accessibility
 

--- a/packages/components/rating/src/Rating.doc.mdx
+++ b/packages/components/rating/src/Rating.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Kbd } from '@spark-ui/kbd'
 
 import { Rating } from '.'
@@ -11,7 +11,9 @@ import * as stories from './Rating.stories'
 
 # Rating
 
-Ratings lets users see and/or set a star rating for a product or other item.
+Ratings lets users see and/or set a star rating for a product or other item, on a scale from 0 to 5.
+
+<Canvas of={stories.Default} />
 
 ## Install
 
@@ -19,23 +21,15 @@ Ratings lets users see and/or set a star rating for a product or other item.
 npm install @spark-ui/rating
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Rating } from '@spark-ui/rating'
+
+export default () => <Rating />;
 ```
 
-## Props
-
-<ArgTypes of={Rating} />
-
-## Usage
-
-### Default
-
-Rating control lets user see and/or set a star rating on a scale from 0 to 5.
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Readonly
 
@@ -55,7 +49,7 @@ Use `size` prop to set the size of the rating control stars.
 
 <Canvas of={stories.Size} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Rounded values
 
@@ -67,6 +61,10 @@ The **Rating** component includes a simple rounding mechanism to guarantee a nic
 <Canvas of={stories.Rounded} />
 
 If for any reason you need some specific rounding mechanisms, feel free to define yours and provide your rounded value.
+
+## API Reference
+
+<ArgTypes of={Rating} />
 
 ## Accessibility
 

--- a/packages/components/select/src/Select.doc.mdx
+++ b/packages/components/select/src/Select.doc.mdx
@@ -17,60 +17,37 @@ It saves space on the interface by concealing the options until the user interac
 
 Displays a **closed** list of options for the user to pick triggered by a button.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/select
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Select } from '@spark-ui/select'
+
+export default () => (
+  <Select>
+    <Select.Trigger>
+      <Select.LeadingIcon />
+      <Select.Value />
+    </Select.Trigger>
+    <Select.Items>
+      <Select.Placeholder />
+      <Select.Group>
+        <Select.Label />
+        <Select.Item />
+      </Select.Group>
+    </Select.Items>
+  </Select>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Select}
-  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
-  subcomponents={{
-    'Select.Trigger': {
-      of: Select.Trigger,
-      description:
-        'The button that toggles the select. The Select.Items will position itself by aligning over the trigger.',
-    },
-    'Select.Value': {
-      of: Select.Value,
-      description:
-        "The part that reflects the selected value. By default the selected item's text will be rendered. if you require more control, you can instead control the select and pass your own children. It should not be styled to ensure correct positioning. An optional placeholder prop is also available for when the select has no value.",
-    },
-    'Select.LeadingIcon': {
-      of: Select.LeadingIcon,
-      description: 'Prepend a decorative icon inside the input (to the left).',
-    },
-    'Select.Items': {
-      of: Select.Items,
-      description: 'The wrapper which contains all the options.',
-    },
-    'Select.Item': { of: Select.Item, description: 'Each option of the element field' },
-    'Select.Group': {
-      of: Select.Group,
-      description:
-        'A wrapper for grouping a subset of options (Select.Item) when needed. Use in conjunction with Select.Label to ensure good accessibility via automatic labelling.',
-    },
-    'Select.Label': {
-      of: Select.Label,
-      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -155,6 +132,43 @@ Apply `readOnly` to the wrapping `FormField` to indicate the Select is only read
 Set the `state` prop of the `FormField` to `error` to indicate that the Select is invalid. Optionally use the `FormField.ErrorMessage` to describe why the Select is invalid.
 
 <Canvas of={stories.FormFieldValidation} />
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Select}
+  description="A form input used for selecting a value: when collapsed it shows the currently selected option and when expanded, it shows a scrollable list of predefined options for the user to choose from."
+  subcomponents={{
+    'Select.Trigger': {
+      of: Select.Trigger,
+      description:
+        'The button that toggles the select. The Select.Items will position itself by aligning over the trigger.',
+    },
+    'Select.Value': {
+      of: Select.Value,
+      description:
+        "The part that reflects the selected value. By default the selected item's text will be rendered. if you require more control, you can instead control the select and pass your own children. It should not be styled to ensure correct positioning. An optional placeholder prop is also available for when the select has no value.",
+    },
+    'Select.LeadingIcon': {
+      of: Select.LeadingIcon,
+      description: 'Prepend a decorative icon inside the input (to the left).',
+    },
+    'Select.Items': {
+      of: Select.Items,
+      description: 'The wrapper which contains all the options.',
+    },
+    'Select.Item': { of: Select.Item, description: 'Each option of the element field' },
+    'Select.Group': {
+      of: Select.Group,
+      description:
+        'A wrapper for grouping a subset of options (Select.Item) when needed. Use in conjunction with Select.Label to ensure good accessibility via automatic labelling.',
+    },
+    'Select.Label': {
+      of: Select.Label,
+      description: "Used to render the label of a group. It won't be focusable using arrow keys.",
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/skeleton/src/Skeleton.doc.mdx
+++ b/packages/components/skeleton/src/Skeleton.doc.mdx
@@ -12,44 +12,29 @@ import * as stories from './Skeleton.stories'
 
 A skeleton gives feedback about loading state of some component.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/skeleton
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Skeleton } from '@spark-ui/skeleton'
+
+export default () => (
+  <Skeleton>
+    <Accordion.Rectangle />
+    <Accordion.Circle />
+    <Accordion.Line />
+  </Skeleton>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Skeleton}
-  description="A container for all Skeleton parts."
-  subcomponents={{
-    'Skeleton.Circle': {
-      of: Skeleton.Circle,
-      description: 'A specific Skeleton component, for circular content.',
-    },
-    'Skeleton.Rectangle': {
-      of: Skeleton.Rectangle,
-      description: 'A specific Skeleton component, for rectangular content.',
-    },
-    'Skeleton.Line': {
-      of: Skeleton.Line,
-      description: 'A specific Skeleton component, for "line-shaped" content (such as text).',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Sizing
 
@@ -72,13 +57,34 @@ Use `isAnimated` prop to display an animation on your `<Skeleton />` content.
 
 <Canvas of={stories.Animation} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Composing layouts
 
 For specific needs you may want to build an entire layout using skeleton items (eg. cards, ...). You may then simply add your own solution (such as a specific markup using flexbox or grid CSS modules) in your implementation.
 
 <Canvas of={stories.Layout} />
+
+## API Reference
+
+<ArgTypes
+  of={Skeleton}
+  description="A container for all Skeleton parts."
+  subcomponents={{
+    'Skeleton.Circle': {
+      of: Skeleton.Circle,
+      description: 'A specific Skeleton component, for circular content.',
+    },
+    'Skeleton.Rectangle': {
+      of: Skeleton.Rectangle,
+      description: 'A specific Skeleton component, for rectangular content.',
+    },
+    'Skeleton.Line': {
+      of: Skeleton.Line,
+      description: 'A specific Skeleton component, for "line-shaped" content (such as text).',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/slider/src/Slider.doc.mdx
+++ b/packages/components/slider/src/Slider.doc.mdx
@@ -13,40 +13,28 @@ import * as stories from './Slider.stories'
 
 An input where the user selects a value from within a given range.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/slider
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Slider } from '@spark-ui/slider'
+
+export default () => (
+  <Slider>
+    <Slider.Track /> 
+    <Slider.thumb /> 
+  </Slider>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Slider}
-  description="Contains all the slider component parts. It will render an input for each thumb when used within a form to ensure events propagate correctly."
-  subcomponents={{
-    'Slider.Thumb': {
-      of: Slider.Thumb,
-      description: 'A draggable thumb. You can render multiple thumbs.',
-    },
-    'Slider.Track': {
-      of: Slider.Track,
-      description: 'The track shows the range available for user selection.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Controlled
 
@@ -82,7 +70,7 @@ Use `disabled` prop to indicate that slider is disabled.
 
 <Canvas of={stories.Disabled} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Restricted values
 
@@ -100,6 +88,24 @@ To ensure **proper accessibility**, make sure to set the `aria-valuetext` attrib
 Here's an example to illustrate this:
 
 <Canvas of={stories.RestrictedValues} />
+
+## API Reference
+
+<ArgTypes
+  of={Slider}
+  description="Contains all the slider component parts. It will render an input for each thumb when used within a form to ensure events propagate correctly."
+  subcomponents={{
+    'Slider.Thumb': {
+      of: Slider.Thumb,
+      description: 'A draggable thumb. You can render multiple thumbs.',
+    },
+    'Slider.Track': {
+      of: Slider.Track,
+      description: 'The track shows the range available for user selection.',
+    },
+  }}
+/>
+
 
 ## Accessibility
 

--- a/packages/components/slot/src/Slot.doc.mdx
+++ b/packages/components/slot/src/Slot.doc.mdx
@@ -9,37 +9,27 @@ import { Slot, Slottable } from '.'
 
 Merges its props onto its immediate child.
 
+`Slot` props are merged with the child ones.
+
+<Canvas of={SlotStories.Default} />
+
 ## Install
 
 ```
 npm install @spark-ui/slot
 ```
 
-## Import
+## Anatomy
 
+```tsx
+import { Slot, Slottable } from "@spark-ui/slot"
+
+export default () => (
+  <Slot>
+    <Slottable />
+  </Slot>
+);
 ```
-import { Slot } from "@spark-ui/slot"
-```
-
-## Props
-
-<ExtendedArgTypes
-  of={Slot}
-  description="Merges its props onto its immediate child."
-  subcomponents={{
-    Slottable: {
-      of: Slottable,
-      description:
-        'Wraps the elements on a fragment appending all other slot descendant elements not wrapped into it.',
-    },
-  }}
-/>
-
-## Default
-
-`Slot` props are merged with the child ones.
-
-<Canvas of={SlotStories.Default} />
 
 ## Prop Merge Techniques
 
@@ -97,3 +87,17 @@ A `Slot` can have multiple descendant elements as children, but only one of them
 All non Slottable direct Slot children descendant elements will be appended to the Slottable unique children Element.
 
 <Canvas of={SlotStories.Append} />
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Slot}
+  description="Merges its props onto its immediate child."
+  subcomponents={{
+    Slottable: {
+      of: Slottable,
+      description:
+        'Wraps the elements on a fragment appending all other slot descendant elements not wrapped into it.',
+    },
+  }}
+/>

--- a/packages/components/snackbar/src/Snackbar.doc.mdx
+++ b/packages/components/snackbar/src/Snackbar.doc.mdx
@@ -14,52 +14,6 @@ import * as stories from './Snackbar.stories'
 
 Display brief, temporary notifications of actions, errors, or other events in an application.
 
-## Install
-
-```sh
-npm install @spark-ui/snackbar
-```
-
-## Import
-
-```tsx
-import { Snackbar, addSnackbar } from '@spark-ui/snackbar'
-```
-
-## Props & Options
-
-<ArgTypes
-  of={Snackbar}
-  description="A container for queued snackbars. It should be placed at the root of the app."
-  exclude={['position', 'priority']}
-  subcomponents={{
-    'Snackbar.Item': {
-      of: Snackbar.Item,
-      description: "The component that display each snackbar's content.",
-    },
-    'Snackbar.ItemIcon': {
-      of: Snackbar.ItemIcon,
-      description: 'The component that prepend an icon in the snackbar.',
-    },
-    'Snackbar.ItemAction': {
-      of: Snackbar.ItemAction,
-      description: 'The component that renders a button which action is safe to ignore.',
-    },
-    'Snackbar.ItemClose': {
-      of: Snackbar.ItemClose,
-      description: 'The component that closes the snackbar.',
-    },
-    addSnackbar: {
-      of: addSnackbar,
-      description: 'The function that triggers snackbars by adding them to a global queue.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
 To get started, render a `<Snackbar />` provider **at the root of your app**. It will manage the snackbar queue and state for the whole app. Then, to display a snackbar message from any part of the app, you would simply call the `addSnackbar` function.
 
 Customizing each snackbar is made easy using the `addSnackbar` function options. Additionally, you can define global attributes for all snackbars by using the compound API with `<Snackbar.Item />` as children of the `<Snackbar />` component (refer to detailed examples below).
@@ -67,6 +21,23 @@ Customizing each snackbar is made easy using the `addSnackbar` function options.
 Please note that `addSnackbar` options will always take precedence over `<Snackbar.Item />` (and its subcomponents) props. Conversely, any element defined using the compound component, such as close or action buttons, will consistently appear on the `Snackbar` item. Additionally, their optional props will override `addSnackbar` options in this specific scenario.
 
 <Canvas of={stories.Default} />
+
+
+## Install
+
+```sh
+npm install @spark-ui/snackbar
+```
+
+## Anatomy
+
+```tsx
+import { Snackbar, addSnackbar } from '@spark-ui/snackbar'
+
+export default () => <Snackbar/>;
+```
+
+## Examples
 
 ### Design
 
@@ -108,13 +79,43 @@ For accessibility reasons **snackbars won't dismiss automatically when an action
 
 <Canvas of={stories.Action} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Force action/close button
 
 To always render snackbars with their associated action and/or close buttons, you simply need to declare them within a custom `<Snackbar.Item>` implementation.
 
 <Canvas of={stories.AdvancedActionClose} />
+
+## API Reference
+
+<ArgTypes
+  of={Snackbar}
+  description="A container for queued snackbars. It should be placed at the root of the app."
+  exclude={['position', 'priority']}
+  subcomponents={{
+    'Snackbar.Item': {
+      of: Snackbar.Item,
+      description: "The component that display each snackbar's content.",
+    },
+    'Snackbar.ItemIcon': {
+      of: Snackbar.ItemIcon,
+      description: 'The component that prepend an icon in the snackbar.',
+    },
+    'Snackbar.ItemAction': {
+      of: Snackbar.ItemAction,
+      description: 'The component that renders a button which action is safe to ignore.',
+    },
+    'Snackbar.ItemClose': {
+      of: Snackbar.ItemClose,
+      description: 'The component that closes the snackbar.',
+    },
+    addSnackbar: {
+      of: addSnackbar,
+      description: 'The function that triggers snackbars by adding them to a global queue.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/spinner/src/Spinner.doc.mdx
+++ b/packages/components/spinner/src/Spinner.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Spinner } from '.'
 import * as stories from './Spinner.stories'
 
@@ -10,27 +10,23 @@ import * as stories from './Spinner.stories'
 
 Spinners provide a visual cue that an action is processing awaiting a course of change or a result.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/spinner
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Spinner } from '@spark-ui/spinner'
+
+export default () => <Spinner />;
 ```
 
-## Props
-
-<ArgTypes of={Spinner} />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Background
 
@@ -55,6 +51,10 @@ Use `label` prop for accessibility, it is important to add a fallback loading te
 Use `size` prop to set the size of the spinner. If you want to set the `full` size for the spinner, don't forget to add a wrapping container with its own size.
 
 <Canvas of={stories.Sizes} />
+
+## API Reference
+
+<ArgTypes of={Spinner} />
 
 ## Accessibility
 

--- a/packages/components/stepper/src/Stepper.doc.mdx
+++ b/packages/components/stepper/src/Stepper.doc.mdx
@@ -13,58 +13,29 @@ import * as stories from './Stepper.stories'
 
 Stepper allows a user to enter a number, and increment or decrement the value using dedicated buttons.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/stepper
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Stepper } from '@spark-ui/stepper'
+
+export default () => (
+  <Stepper>
+    <Stepper.DecrementButton />
+    <Stepper.Input />
+    <Stepper.IncrementButton />
+  </Stepper>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Stepper}
-  description="A container for all the stepper component parts."
-  exclude={[
-    'onPress',
-    'onPressStart',
-    'onPressEnd',
-    'onPressChange',
-    'onPressUp',
-    'onFocusChange',
-    'aria-labelledby',
-    'aria-describedby',
-    'aria-details',
-    'onKeyDown',
-    'onKeyUp',
-    'placeholder',
-  ]}
-  subcomponents={{
-    'Stepper.Input': {
-      of: Stepper.Input,
-      description: 'The input field to display and change the value.',
-    },
-    'Stepper.IncrementButton': {
-      of: Stepper.IncrementButton,
-      description: 'The button to increment the value of the input.',
-    },
-    'Stepper.DecrementButton': {
-      of: Stepper.DecrementButton,
-      description: 'The button to decrement the value of the input.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Uncontrolled
 
@@ -120,7 +91,7 @@ Use `formatOptions` prop to adapt your value display to your needs (percentages,
 
 <Canvas of={stories.FormatOptions} />
 
-## Advanced usage
+## Advanced Examples
 
 ### Custom implementation
 
@@ -133,6 +104,41 @@ Below is an implementation of a `Stepper` with custom **increment** and **decrem
 When using the `Stepper` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.
 
 <Canvas of={stories.WithFormField} />
+
+## API Reference
+
+<ArgTypes
+  of={Stepper}
+  description="A container for all the stepper component parts."
+  exclude={[
+    'onPress',
+    'onPressStart',
+    'onPressEnd',
+    'onPressChange',
+    'onPressUp',
+    'onFocusChange',
+    'aria-labelledby',
+    'aria-describedby',
+    'aria-details',
+    'onKeyDown',
+    'onKeyUp',
+    'placeholder',
+  ]}
+  subcomponents={{
+    'Stepper.Input': {
+      of: Stepper.Input,
+      description: 'The input field to display and change the value.',
+    },
+    'Stepper.IncrementButton': {
+      of: Stepper.IncrementButton,
+      description: 'The button to increment the value of the input.',
+    },
+    'Stepper.DecrementButton': {
+      of: Stepper.DecrementButton,
+      description: 'The button to decrement the value of the input.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/switch/src/Switch.doc.mdx
+++ b/packages/components/switch/src/Switch.doc.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta } from '@storybook/blocks'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { A11yReport } from '@docs/helpers/A11yReport'
 import { Kbd } from '@spark-ui/kbd'
 import { Switch } from '.'
@@ -11,25 +11,23 @@ import * as stories from './Switch.stories'
 
 A control that allows the user to toggle between checked and not checked.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/switch
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Switch } from '@spark-ui/switch'
+
+export default () => <Switch />;
 ```
 
-## Props
-
-<ArgTypes of={Switch} />
-
-## Usage
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Uncontrolled
 
@@ -84,6 +82,10 @@ Use the `FormField.HelperMessage` component to provide a description to the swit
 set the `state` prop of the `FormField` to `error` to indicate that the input is invalid. Optionally use the `FormField.ErrorMessage` to describe why the input is invalid.
 
 <Canvas of={stories.FieldInvalid} />
+
+## API Reference
+
+<ArgTypes of={Switch} />
 
 ## Accessibility
 

--- a/packages/components/tabs/src/Tabs.doc.mdx
+++ b/packages/components/tabs/src/Tabs.doc.mdx
@@ -12,44 +12,30 @@ import * as stories from './Tabs.stories'
 
 A set of layered sections of content—known as tab panels—that are displayed one at a time.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```
 npm install @spark-ui/tabs
 ```
 
-## Import
+## Anatomy
 
-```
+```tsx
 import { Tabs } from "@spark-ui/tabs"
+
+export default () => (
+  <Tabs>
+    <Tabs.List> 
+      <Tabs.Trigger />
+    </Tabs.List>
+    <Tabs.Content />
+  </Tabs.Content>
+);
 ```
 
-## Props
-
-<ArgTypes
-  of={Tabs}
-  description="Contains all the tabs component parts."
-  subcomponents={{
-    'Tabs.List': {
-      of: Tabs.List,
-      description: 'Contains the triggers that are aligned along the edge of the active content.',
-    },
-    'Tabs.Trigger': {
-      of: Tabs.Trigger,
-      description: 'The button that activates its associated content.',
-    },
-    'Tabs.Content': {
-      of: Tabs.Content,
-      description: 'Contains the content associated with each trigger.',
-    },
-  }}
-/>
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Disabled
 
@@ -94,6 +80,27 @@ Use `forceMount` on `Tabs` when you want the content of your inactive tabs to re
 This can be useful if your tabs load heavy resources on mount, such as heavy images, videos, iframes, etc...
 
 <Canvas of={stories.ForceMount} />
+
+## API Reference
+
+<ArgTypes
+  of={Tabs}
+  description="Contains all the tabs component parts."
+  subcomponents={{
+    'Tabs.List': {
+      of: Tabs.List,
+      description: 'Contains the triggers that are aligned along the edge of the active content.',
+    },
+    'Tabs.Trigger': {
+      of: Tabs.Trigger,
+      description: 'The button that activates its associated content.',
+    },
+    'Tabs.Content': {
+      of: Tabs.Content,
+      description: 'Contains the content associated with each trigger.',
+    },
+  }}
+/>
 
 ## Accessibility
 

--- a/packages/components/tag/src/Tag.doc.mdx
+++ b/packages/components/tag/src/Tag.doc.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Tag } from '.'
 import * as TagStories from './Tag.stories'
 
@@ -11,27 +11,23 @@ import * as TagStories from './Tag.stories'
 A **Tag** is a visual indicator generally appearing inside or in close-proximity to another larger interface component,
 representing or highlighting its status, property, or some other metadata for quick recognition.
 
+<Canvas of={TagStories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/tag
 ```
 
-## Import
+## Anatomy
 
 ```js
 import { Tag } from '@spark-ui/tag'
+
+export default () => <Tag />;
 ```
 
-## Props
-
-<ArgTypes of={Tag} />
-
-## Usage
-
-### Default
-
-<Canvas of={TagStories.Default} />
+## Examples
 
 ### Design
 
@@ -50,6 +46,10 @@ Compose the content of the tag using the `Icon` component to add an icon to the 
 Use `intent` prop to set the color intent of a tag.
 
 <Canvas of={TagStories.Intent} />
+
+## API Reference
+
+<ArgTypes of={Tag} />
 
 ## Accessibility
 

--- a/packages/components/text-link/src/TextLink.doc.mdx
+++ b/packages/components/text-link/src/TextLink.doc.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
-import { ArgTypes } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Kbd } from '@spark-ui/kbd'
 import { Callout } from '@docs/helpers/Callout'
 
@@ -12,7 +12,9 @@ import * as stories from './TextLink.stories'
 
 # TextLink
 
-TextLink is an accessible element for navigation.
+TextLink is an inline link (`a` tag) to use on your pages.
+
+<Canvas of={stories.Default} />
 
 ## Install
 
@@ -20,23 +22,15 @@ TextLink is an accessible element for navigation.
 npm install @spark-ui/text-link
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { TextLink } from '@spark-ui/text-link'
+
+export default () => <TextLink />;
 ```
 
-## Props
-
-This component support [all HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes) supported by the `a` tag.
-
-<ArgTypes of={TextLink} />
-
-## Usage
-
-### Default
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Bold
 
@@ -64,7 +58,7 @@ Simply use css classes to set a difference size if necessary.
 
 <Canvas of={stories.Sizes} />
 
-## Advanced Usage
+## Advanced Examples
 
 ### Icons
 
@@ -94,6 +88,12 @@ By default `TextLink` shows an underline. It can be disabled to only be shown wh
 </Callout>
 
 <Canvas of={stories.Underline} />
+
+## API Reference
+
+This component support [all HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes) supported by the `a` tag.
+
+<ArgTypes of={TextLink} />
 
 ## Accessibility
 

--- a/packages/components/textarea/src/Textarea.doc.mdx
+++ b/packages/components/textarea/src/Textarea.doc.mdx
@@ -12,44 +12,32 @@ import * as stories from './Textarea.stories'
 
 The textarea component allows you to easily create multi-line text inputs.
 
+<Canvas of={stories.Default} />
+
 ## Install
 
 ```sh
 npm install @spark-ui/textarea
 ```
 
-## Import
+## Anatomy
 
 ```tsx
 import { Textarea, TextareaGroup } from '@spark-ui/textarea'
+
+export default () => <Textarea />;
+
+// Or inside a TextareaGroup
+export default () => (
+  <TextareaGroup>
+    <TextareaGroup.LeadingIcon />
+    <Textarea />
+    <TextareaGroup.TrailingIcon />
+  </TextareaGroup>
+);
 ```
 
-## Props
-
-<ExtendedArgTypes
-  of={Textarea}
-  description="The textarea component allows you to easily create multi-line text inputs."
-  subcomponents={{
-    TextareaGroup: {
-      of: TextareaGroup,
-      description:
-        'Use this wrapper whenever you need a more complex textarea. For example if you need to have leading/trailing icons.',
-    },
-    'TextareaGroup.LeadingIcon': {
-      of: TextareaGroup.LeadingIcon,
-      description: 'Prepend a decorative icon inside the textarea (to the left).',
-    },
-    'TextareaGroup.TrailingIcon': {
-      of: TextareaGroup.TrailingIcon,
-      description:
-        'Append a decorative icon inside the textarea (to the right). This element will be replaced by a status indicator whenever the textarea is in error/alert/success state.',
-    },
-  }}
-/>
-
-## Usage
-
-<Canvas of={stories.Default} />
+## Examples
 
 ### Uncontrolled
 
@@ -132,6 +120,30 @@ Use the `isRequired` prop of the `FormField` to indicate that the textarea is re
 set the `state` prop of the `FormField` to `error` to indicate that the input is invalid. Optionally use the `FormField.ErrorMessage` to describe why the input is invalid.
 
 <Canvas of={stories.FieldInvalid} />
+
+## API Reference
+
+<ExtendedArgTypes
+  of={Textarea}
+  description="The textarea component allows you to easily create multi-line text inputs."
+  subcomponents={{
+    TextareaGroup: {
+      of: TextareaGroup,
+      description:
+        'Use this wrapper whenever you need a more complex textarea. For example if you need to have leading/trailing icons.',
+    },
+    'TextareaGroup.LeadingIcon': {
+      of: TextareaGroup.LeadingIcon,
+      description: 'Prepend a decorative icon inside the textarea (to the left).',
+    },
+    'TextareaGroup.TrailingIcon': {
+      of: TextareaGroup.TrailingIcon,
+      description:
+        'Append a decorative icon inside the textarea (to the right). This element will be replaced by a status indicator whenever the textarea is in error/alert/success state.',
+    },
+  }}
+/>
+
 
 ## Accessibility
 

--- a/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
+++ b/packages/components/visually-hidden/src/VisuallyHidden.doc.mdx
@@ -11,23 +11,23 @@ Hides content from the screen in an accessible way.
 `VisuallyHidden` hides content from visual client, but keep it readable for screen readers.
 It is useful in certain scenarios as an alternative to traditional labelling with aria-label or aria-labelledby and it is the logical opposite of the aria-hidden attribute.
 
+A button without text can be absolutely mysterious for someone using screen reader. They might be announced simply as "button". We can solve this problem without compromising on our design. A VisuallyHidden component will allow us to place text inside this button that will only be made available to people using screen readers.
+
+<Canvas of={VisuallyHiddenStories.Default} />
+
 ## Install
 
 ```
 npm install @spark-ui/visually-hidden
 ```
 
-## Import
+## Anatomy
 
 ```
 import { VisuallyHidden } from "@spark-ui/visually-hidden"
+
+export default () => <VisuallyHidden />;
 ```
-
-## Default
-
-A button without text can be absolutely mysterious for someone using screen reader. They might be announced simply as "button". We can solve this problem without compromising on our design. A VisuallyHidden component will allow us to place text inside this button that will only be made available to people using screen readers.
-
-<Canvas of={VisuallyHiddenStories.Default} />
 
 ## Accessibility
 


### PR DESCRIPTION
### Description, Motivation and Context

Improved docs page layout:

- moved default example to the top of each page
- moved props table into a drawer, section is at the bottom of each page above "Accessibility"
- "Import" has been replaced with "Anatomy", showcasing how a component's parts should be used together.

### Types of changes
- [x] 🧾 Documentation
