### PR TITLE
fix(components): commit value of slider on lost pointer

### DIFF
--- a/packages/components/src/slider/Slider.stories.tsx
+++ b/packages/components/src/slider/Slider.stories.tsx
@@ -2,6 +2,7 @@ import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { Meta, StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
+import { Tag } from '../tag'
 import { Slider, type SliderProps } from '.'
 
 const meta: Meta<typeof Slider> = {
@@ -25,11 +26,27 @@ export const Default: StoryFn = _args => (
       <Slider.Track />
       <Slider.Thumb aria-label="Power" />
     </Slider>
+
+    <Slider
+      min={1}
+      max={10}
+      step={1}
+      defaultValue={[1, 10]}
+      onValueCommit={value => {
+        console.log('ON COMMIT', value)
+        // console.log(value)
+      }}
+    >
+      <Slider.Track />
+      <Slider.Thumb />
+      <Slider.Thumb />
+    </Slider>
   </form>
 )
 
 export const Controlled: StoryFn = _args => {
   const [value, setValue] = useState([0, 100])
+  const [commitedValue, setCommitedValue] = useState(value)
 
   return (
     <form>
@@ -41,9 +58,13 @@ export const Controlled: StoryFn = _args => {
         min={0}
         max={100}
         value={value}
-        onValueChange={setValue}
-        onValueCommit={() => {
-          console.log(value)
+        onValueChange={value => {
+          console.log('onValueChange', value)
+          setValue(value)
+        }}
+        onValueCommit={value => {
+          console.log('onValueCommit', value)
+          setCommitedValue(value)
         }}
         id="controlled-slider"
         name="controlled-slider"
@@ -52,6 +73,11 @@ export const Controlled: StoryFn = _args => {
         <Slider.Thumb aria-label="Power" />
         <Slider.Thumb aria-label="Power" />
       </Slider>
+
+      <div className="my-md gap-md flex">
+        <Tag intent="info">Editing value = [{value.join(', ')}]</Tag>
+        <Tag intent="info">Commited value = [{commitedValue.join(', ')}]</Tag>
+      </div>
     </form>
   )
 }


### PR DESCRIPTION
<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: https://jira.ets.mpi-internal.com/browse/SPA-573

### Description, Motivation and Context

Main:
- Slider -> `onValueCommit` was not always dispatched on Chromium using some trackpads. Issue is known on Radix but opened for a long time: https://github.com/radix-ui/primitives/issues/1760


### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
