### PR TITLE
feat(components): improves stepper empty value behavior with min/max limits

### DIFF
--- a/packages/components/src/stepper/Stepper.doc.mdx
+++ b/packages/components/src/stepper/Stepper.doc.mdx
@@ -32,7 +32,7 @@ export default () => (
     <Stepper.Input />
     <Stepper.IncrementButton />
   </Stepper>
-);
+)
 ```
 
 ## Examples
@@ -78,6 +78,8 @@ Use `step` prop to snap the value to certain increments, starting from the minim
 Use `minValue|maxValue` props to limit the entered value to a specific range. Ranges can be open ended by only providing either `minValue` or `maxValue` rather than both.
 
 Increment and decrement buttons will be disabled when the value is within one step value from the bounds.
+
+If the value is empty (unset or cleared) and `minValue|maxValue` set to limit value to strictly positive or negative values then increment and decrement buttons will be disabled accordingly.
 
 If the user types a value that is beyond range bounds and blurs the input, the value will be clamped.
 

--- a/packages/components/src/stepper/Stepper.stories.tsx
+++ b/packages/components/src/stepper/Stepper.stories.tsx
@@ -112,13 +112,23 @@ export const Step: StoryFn = _args => (
   </Stepper>
 )
 
-export const MinMaxValues: StoryFn = _args => (
-  <Stepper aria-label="Stepper with min/max values" minValue={0} maxValue={100} defaultValue={0}>
-    <Stepper.DecrementButton aria-label="Decrement" />
-    <Stepper.Input />
-    <Stepper.IncrementButton aria-label="Increment" />
-  </Stepper>
-)
+export const MinMaxValues: StoryFn = _args => {
+  const [value, setValue] = useState<number>()
+
+  return (
+    <Stepper
+      aria-label="Stepper with min/max values"
+      minValue={0}
+      maxValue={10}
+      value={value}
+      onValueChange={setValue}
+    >
+      <Stepper.DecrementButton aria-label="Decrement" />
+      <Stepper.Input />
+      <Stepper.IncrementButton aria-label="Increment" />
+    </Stepper>
+  )
+}
 
 export const FormatOptions: StoryFn = _args => (
   <div className="gap-xl grid grid-cols-2 md:grid-cols-3">

--- a/packages/components/src/stepper/Stepper.test.tsx
+++ b/packages/components/src/stepper/Stepper.test.tsx
@@ -317,9 +317,7 @@ describe('Stepper', () => {
       expect(input).toHaveValue('10')
     })
 
-    it('should set value to max if value is undefined and user clicks decrement', async () => {
-      const user = userEvent.setup()
-
+    it('should disable decrement button if value is empty and minValue is >= 0', () => {
       render(
         <Stepper {...defaultProps} defaultValue={undefined} minValue={0} maxValue={10}>
           <Stepper.DecrementButton aria-label="Decrement" />
@@ -328,10 +326,19 @@ describe('Stepper', () => {
         </Stepper>
       )
 
-      const input = screen.getByRole('textbox')
-      await user.click(screen.getByLabelText('Decrement'))
+      expect(screen.getByLabelText('Decrement')).toBeDisabled()
+    })
 
-      expect(input).toHaveValue('10')
+    it('should disable increment button if value is empty and maxValue is <= 0', () => {
+      render(
+        <Stepper {...defaultProps} defaultValue={undefined} maxValue={0}>
+          <Stepper.DecrementButton aria-label="Decrement" />
+          <Stepper.Input />
+          <Stepper.IncrementButton aria-label="Increment" />
+        </Stepper>
+      )
+
+      expect(screen.getByLabelText('Increment')).toBeDisabled()
     })
 
     it('should set value to min if value is undefined and user clicks increment', async () => {

--- a/packages/components/src/stepper/useStepper.ts
+++ b/packages/components/src/stepper/useStepper.ts
@@ -16,6 +16,18 @@ export const useStepper = ({
     locale,
   })
 
+  /**
+   * React Arias useNumberFieldState does not support the cases where value is unset (empty) and min/max constraints the value to positive or negative values only.
+   * Cf: https://github.com/adobe/react-spectrum/blob/b7f8ed1a9a311d89719b1a746b0a58204841b21a/packages/%40react-stately/numberfield/src/useNumberFieldState.ts#L251C3-L260C76
+   */
+  const canDecrement =
+    !(isNaN(state.numberValue) && state.minValue !== undefined && state.minValue >= 0) &&
+    state.canDecrement
+
+  const canIncrement =
+    !(isNaN(state.numberValue) && state.maxValue !== undefined && state.maxValue <= 0) &&
+    state.canIncrement
+
   const { groupProps, inputProps, incrementButtonProps, decrementButtonProps } = useNumberField(
     {
       isWheelDisabled: false,
@@ -24,7 +36,11 @@ export const useStepper = ({
       isReadOnly: rest.readOnly,
       isRequired: rest.required,
     },
-    state,
+    {
+      ...state,
+      canDecrement,
+      canIncrement,
+    },
     inputRef
   )
 


### PR DESCRIPTION
### Description, Motivation and Context
When `Stepper` inits with empty value and min|max values are set to limit accepted range to strictly positive or negative values, we shouldn't allow increment|decrement actions.

For example, if we have a controlled input with empty value that has a `minValue` set to `0`, we shouldn't have the possibility to decrement as it would lead to out of range value (as reference starting value is always 0). In the same way we want to adapt this logic when `maxValue` is set to `0` : then increment button should be disabled.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 🧪 Test
- [x] 🧠 Refactor