### PR TITLE
ci: dependabot deprecated reviewers setting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,4 @@
-# Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in the repo.
-- @Powerplex @acd02 @soykje
+# Main owners
+@Powerplex @acd02 @soykje
 
-# Order is important. The last matching pattern has the most precedence.
-
-# So if a pull request only touches javascript files, only these owners
-
-# will be requested to review.
-
-# \*.js @octocat @github/js
-
-# You can also use email addresses if you prefer.
-
-# docs/\* docs@example.com

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - 'Powerplex'
     commit-message:
       prefix: 'build(npm)'
     groups:


### PR DESCRIPTION
### Description, Motivation and Context

Dependabot deprecated the `reviewers` key, they recommand using CODEOWNERS file instead

[Dependabot statement](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

[CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)

### Types of changes
- [x] 🛠️ Tool
