### PR TITLE
feat(components): carousel pagePicker can now be inside the carousel

### DIFF
--- a/packages/components/src/carousel/Carousel.doc.mdx
+++ b/packages/components/src/carousel/Carousel.doc.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
 import { Kbd } from '@spark-ui/components/kbd'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { Callout } from '@docs/helpers/Callout'
 
 import { Carousel } from '.'
 
@@ -70,6 +71,21 @@ The page corresponds to the scroll snap position index based on the layout. It d
 To customize spacing between slides, set the `gap` property. Value in pixels (integer).
 
 <Canvas of={stories.Gap} />
+
+### Inset page picker
+
+To inset the page picker from the edges of the carousel, pass the `pagePickerInset` prop to `Carousel`.
+
+Each `Carousel.PageIndicator` can have an `intent` prop to customize its appearance, either `basic` or `surface`.
+
+<Callout kind="warning" marginY="large">
+  <p>
+    <span className="font-bold">a11y</span>: When using images in carousel slides, ensure proper contrast between page indicators and background. Add a gradient overlay or shadow to maintain accessibility standards.
+    Check the code example to see how to do it.
+  </p>
+</Callout>
+
+<Canvas of={stories.InsetPagePicker} />
 
 ### Loop
 

--- a/packages/components/src/carousel/Carousel.stories.tsx
+++ b/packages/components/src/carousel/Carousel.stories.tsx
@@ -267,6 +267,41 @@ export const Gap: StoryFn = _args => {
   )
 }
 
+export const InsetPagePicker: StoryFn = _args => {
+  return (
+    <Carousel pagePickerInset>
+      <Carousel.Viewport>
+        <Carousel.Slides>
+          {Array.from({ length: 11 }).map((_, i) => (
+            <Carousel.Slide key={i} aria-label={`Slide ${i}`} className="flex items-center">
+              {/* Custom gradient element to ensure the contrast ratio is met */}
+              <div className="h-sz-36 to-surface-inverse/dim-2 pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-b/oklch from-transparent" />
+              <RandomImage imgHeight={600} imgWidth={600} className="h-sz-256 object-cover" />
+            </Carousel.Slide>
+          ))}
+        </Carousel.Slides>
+        <Carousel.Controls>
+          <Carousel.PrevButton aria-label="Previous group of items" />
+          <Carousel.NextButton aria-label="Next group of items" />
+        </Carousel.Controls>
+      </Carousel.Viewport>
+
+      <Carousel.PagePicker>
+        {({ pages }) =>
+          pages.map(page => (
+            <Carousel.PageIndicator
+              key={page}
+              index={page}
+              intent="surface"
+              aria-label={`Go to page ${page + 1}`}
+            />
+          ))
+        }
+      </Carousel.PagePicker>
+    </Carousel>
+  )
+}
+
 export const DefaultPage: StoryFn = _args => {
   return (
     <Carousel defaultPage={2}>

--- a/packages/components/src/carousel/Carousel.tsx
+++ b/packages/components/src/carousel/Carousel.tsx
@@ -17,6 +17,7 @@ export const Carousel = ({
   snapStop = 'always',
   scrollBehavior = 'smooth',
   slidesPerMove = 'auto',
+  pagePickerInset = false,
   slidesPerPage = 1,
   loop = false,
   children,
@@ -35,6 +36,7 @@ export const Carousel = ({
     snapStop,
     snapType,
     page,
+    pagePickerInset,
     onPageChange,
   })
 

--- a/packages/components/src/carousel/CarouselPageIndicator.tsx
+++ b/packages/components/src/carousel/CarouselPageIndicator.tsx
@@ -9,6 +9,7 @@ interface Props {
   index: number
   className?: string
   unstyled?: boolean
+  intent?: 'basic' | 'surface'
 }
 
 export const CarouselPageIndicator = ({
@@ -17,6 +18,7 @@ export const CarouselPageIndicator = ({
   index,
   'aria-label': ariaLabel,
   className,
+  intent = 'basic',
 }: Props) => {
   const ctx = useCarouselContext()
 
@@ -37,8 +39,10 @@ export const CarouselPageIndicator = ({
   const dotsStyles = cx(
     'before:rounded-sm before:block before:size-md',
     'before:absolute before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/2',
-    'data-[state=active]:before:w-sz-32 data-[state=active]:before:bg-basic',
-    'data-[state=inactive]:before:bg-on-surface/dim-3'
+    'data-[state=active]:before:w-sz-32',
+    intent === 'surface'
+      ? 'data-[state=active]:before:bg-surface data-[state=inactive]:before:bg-surface/dim-2'
+      : 'data-[state=active]:before:bg-basic data-[state=inactive]:before:bg-on-surface/dim-2'
   )
 
   return (

--- a/packages/components/src/carousel/CarouselPagePicker.tsx
+++ b/packages/components/src/carousel/CarouselPagePicker.tsx
@@ -23,6 +23,7 @@ export const CarouselPagePicker = ({ children, className }: Props) => {
         {...ctx.getIndicatorGroupProps()}
         className={cx(
           'default:min-h-sz-16 flex w-full flex-wrap items-center justify-center',
+          ctx.pagePickerInset && 'bottom-sz-12 absolute inset-x-0',
           className
         )}
       >

--- a/packages/components/src/carousel/types.ts
+++ b/packages/components/src/carousel/types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, Ref, RefObject, KeyboardEvent } from 'react'
+import { CSSProperties, KeyboardEvent, Ref, RefObject } from 'react'
 
 export const DATA_SCOPE = 'carousel' as const
 export const DIRECTION = 'ltr' as const
@@ -46,6 +46,7 @@ export interface UseCarouselProps {
   loop?: boolean
   scrollBehavior?: 'instant' | 'smooth'
   onPageChange?: (pageIndex: number) => void
+  pagePickerInset?: boolean
 }
 
 export interface ComputedRootProps {
@@ -145,6 +146,7 @@ export interface CarouselAPI extends AnatomyPropsSetters {
   gap: number
   page: number
   pageSnapPoints: number[]
+  pagePickerInset: boolean
   canScrollNext: boolean
   canScrollPrev: boolean
   scrollTo: (pageIndex: number, behavior: 'instant' | 'smooth') => void

--- a/packages/components/src/carousel/useCarousel.ts
+++ b/packages/components/src/carousel/useCarousel.ts
@@ -39,6 +39,7 @@ export const useCarousel = ({
   slidesPerMove = 'auto',
   scrollBehavior = 'smooth',
   loop = false,
+  pagePickerInset = false,
   // state control
   page: controlledPage,
   onPageChange: onPageChangeProp,
@@ -170,6 +171,7 @@ export const useCarousel = ({
     slidesPerMove,
     scrollBehavior,
     loop,
+    pagePickerInset,
     // computed state
     page: pageState,
     pageSnapPoints,


### PR DESCRIPTION


- Closes [LBCSPARK-279](https://jira.ets.mpi-internal.com/browse/LBCSPARK-279)
- Closes [LBCSPARK-337](https://jira.ets.mpi-internal.com/browse/LBCSPARK-337)

### Description, Motivation and Context

- `Carousel.PageIndicator` has a new `intent` prop (`basic (default)`or `surface (new)`).
- `Carousel` has a new `pagePickerInset` (boolean) prop to render the `PagePicker` inside the carousel viewport, at the bottom of the slide area.
- This new feature means it can be tricky to offer sufficient contrast between the content of the slide and the PagePicker, especially when the slide's content is an image, so I added guidance in the doc on techniques to improve contrast (such as adding an element with a gradient background, but it could be done differently).

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Screenshots - Animations
![Capture d’écran 2025-06-27 à 14 36 30](https://github.com/user-attachments/assets/50653c82-e45e-479c-8ace-4e748aa27764)

