### PR TITLE
fix(components): avatar, improving error detection on image

### DIFF
--- a/packages/components/src/avatar/AvatarImage.tsx
+++ b/packages/components/src/avatar/AvatarImage.tsx
@@ -12,9 +12,17 @@ export const AvatarImage = ({ className, asChild, src, ...props }: AvatarImagePr
   const { username, isOnline, onlineText } = useAvatarContext()
   const Comp = asChild ? Slot : 'img'
 
-  const [isVisible, setIsVisible] = useState(false)
+  const [isVisible, setIsVisible] = useState(true)
 
   const accessibleName = isOnline && onlineText ? `${username} (${onlineText})` : username
+
+  const handleError = (event: any) => {
+    setIsVisible(false)
+    // Call the original onError if provided
+    if (props.onError) {
+      props.onError(event)
+    }
+  }
 
   return (
     <Comp
@@ -29,9 +37,7 @@ export const AvatarImage = ({ className, asChild, src, ...props }: AvatarImagePr
       )}
       alt={accessibleName}
       src={src}
-      onLoad={() => {
-        setIsVisible(true)
-      }}
+      onError={handleError}
       {...props}
     />
   )


### PR DESCRIPTION
### Description, Motivation and Context

The `onLoad` event used on `Avatar.Image` to reveal the image is never triggered when using an image fetched in server-side-rendering. I reverse the logic to always display the image, unless an error happens on load (client-side only)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
