### PR TITLE
fix(components): removed margin from hidden carousel dots

### DIFF
--- a/packages/components/src/carousel/CarouselPageIndicator.tsx
+++ b/packages/components/src/carousel/CarouselPageIndicator.tsx
@@ -47,7 +47,7 @@ export const CarouselPageIndicator = ({
             'w-sz-8 h-sz-8',
             'data-[state=active]:w-sz-32 data-[state=active]:h-sz-8',
             'data-[state=edge]:w-sz-4 data-[state=edge]:h-sz-4',
-            'data-[state=hidden]:size-0',
+            'data-[state=hidden]:m-0 data-[state=hidden]:size-0',
             intent === 'surface'
               ? 'data-[state=active]:bg-surface bg-surface/dim-2'
               : 'data-[state=active]:bg-basic bg-on-surface/dim-2'


### PR DESCRIPTION
### Description, Motivation and Context

Hidden carousel dots (`Carousel.PageIndicator`) were still taking horizontal space because of a margin (`m-sm`), I forgot to disable the margin while they are hidden.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
