### PR TITLE
feat(theme-utils): js utilities to trigger spakr animations

### DIFF
--- a/documentation/styling/Animations.mdx
+++ b/documentation/styling/Animations.mdx
@@ -13,6 +13,11 @@ import { PauseOutline } from '@spark-ui/icons/PauseOutline'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { EaseCurvePreview } from './EaseCurvePreview'
 import { cx } from 'class-variance-authority'
+import { 
+  BasicSparkAnimateExample, 
+  HookSparkAnimateExample, 
+} from './SparkAnimateExamples'
+import { Tabs } from '@spark-ui/components/tabs'
 
 <Meta title="Styling/Animations" />
 
@@ -670,6 +675,70 @@ export const Playground = () => {
 }
 
 <Playground />
+
+## Usage with Javascript
+
+Use either `animate` or it's hook equivalent `useAnimate` to trigger animations.
+
+They both provide a way to trigger animations and clean up classes once the animation is complete.
+
+<Tabs defaultValue="animate">
+  <Tabs.List>
+    <Tabs.Trigger value="animate">animate()</Tabs.Trigger>
+    <Tabs.Trigger value="useAnimate">useAnimate()</Tabs.Trigger>
+  </Tabs.List>
+
+  <Tabs.Content value="animate">
+    <BasicSparkAnimateExample />
+    
+    ```tsx
+    import { useRef } from 'react'
+    import { animate } from '@spark-ui/theme-utils'
+    import { Button } from '@spark-ui/components/button'
+
+    export function MyComponent() {
+      const buttonRef = useRef<HTMLButtonElement>(null)
+
+
+      const handleClick = () => {
+        animate(buttonRef.current, 'animate-shake-x animation-duration-500')
+      }
+
+      return (
+          <Button ref={buttonRef} onClick={handleClick}>
+            Click me!
+          </Button>
+      )
+    }
+    ```
+  </Tabs.Content>
+
+  <Tabs.Content value="useAnimate">
+    <HookSparkAnimateExample />
+    
+    ```tsx
+    import { useRef } from 'react'
+    import { useAnimate } from '@spark-ui/theme-utils'
+    import { Button } from '@spark-ui/components/button'
+
+    export function MyComponent() {
+      const buttonRef = useRef<HTMLDivElement>(null)
+      const animateButton = useAnimate(buttonRef)
+
+      const handleClick = () => {
+        animateButton('animate-scale-in animation-duration-150')
+      }
+
+      return (
+        <Button ref={buttonRef} onClick={handleClick}>
+          Click me!
+        </Button>
+      )
+    }
+    ```
+  </Tabs.Content>
+</Tabs>
+
 
 ## Accessibility
 

--- a/documentation/styling/SparkAnimateExamples.tsx
+++ b/documentation/styling/SparkAnimateExamples.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@spark-ui/components/button'
+import { animate, useAnimate } from '@spark-ui/theme-utils'
+import { useRef } from 'react'
+
+// Example 1: Basic usage with animate function
+export function BasicSparkAnimateExample() {
+  const elementRef = useRef<HTMLButtonElement>(null)
+
+  const handleClick = () => {
+    animate(elementRef.current, 'animate-shake-x animation-duration-500')
+  }
+
+  return (
+    <Button ref={elementRef} onClick={handleClick}>
+      Click me!
+    </Button>
+  )
+}
+
+// Example 2: Using the useAnimate hook
+export function HookSparkAnimateExample() {
+  const elementRef = useRef<HTMLButtonElement>(null)
+  const triggerAnimation = useAnimate(elementRef)
+
+  const handleClick = () => {
+    triggerAnimation('animate-scale-in animation-duration-150')
+  }
+
+  return (
+    <Button
+      ref={elementRef}
+      className="bg-accent text-on-accent flex h-32 w-32 cursor-pointer items-center justify-center rounded-lg font-semibold"
+      onClick={handleClick}
+    >
+      Click me!
+    </Button>
+  )
+}

--- a/packages/utils/theme/src/animate/animate.test.ts
+++ b/packages/utils/theme/src/animate/animate.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { animate, useAnimate } from './index'
+
+describe('animate', () => {
+  let mockElement: HTMLElement
+  let mockAddEventListener: ReturnType<typeof vi.fn>
+  let mockRemoveEventListener: ReturnType<typeof vi.fn>
+  let mockClassList: {
+    add: ReturnType<typeof vi.fn>
+    remove: ReturnType<typeof vi.fn>
+    contains: ReturnType<typeof vi.fn>
+  }
+  let mockGetComputedStyle: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockAddEventListener = vi.fn()
+    mockRemoveEventListener = vi.fn()
+    mockClassList = {
+      add: vi.fn(),
+      remove: vi.fn(),
+      contains: vi.fn().mockReturnValue(true),
+    }
+    mockGetComputedStyle = vi.fn().mockReturnValue({
+      getPropertyValue: vi.fn().mockReturnValue('250'),
+    })
+
+    mockElement = {
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      classList: mockClassList,
+    } as unknown as HTMLElement
+
+    // Mock global getComputedStyle
+    Object.defineProperty(window, 'getComputedStyle', {
+      value: mockGetComputedStyle,
+      writable: true,
+    })
+
+    // Mock console.warn
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('should add single animation class to element', () => {
+    animate(mockElement, 'animate-shake-x')
+
+    expect(mockClassList.add).toHaveBeenCalledWith('animate-shake-x')
+  })
+
+  it('should add multiple animation classes to element', () => {
+    animate(mockElement, 'animate-shake-x animation-duration-1000')
+
+    expect(mockClassList.add).toHaveBeenCalledWith('animate-shake-x')
+    expect(mockClassList.add).toHaveBeenCalledWith('animation-duration-1000')
+  })
+
+  it('should handle classes with extra whitespace', () => {
+    animate(mockElement, '  animate-shake-x   animation-duration-1000  ')
+
+    expect(mockClassList.add).toHaveBeenCalledWith('animate-shake-x')
+    expect(mockClassList.add).toHaveBeenCalledWith('animation-duration-1000')
+  })
+
+  it('should add event listeners for animation end', () => {
+    animate(mockElement, 'animate-shake-x')
+
+    expect(mockAddEventListener).toHaveBeenCalledWith('animationend', expect.any(Function))
+    expect(mockAddEventListener).toHaveBeenCalledWith('animationcancel', expect.any(Function))
+  })
+
+  it('should call onStart callback when provided', () => {
+    const onStart = vi.fn()
+
+    animate(mockElement, 'animate-shake-x', { onStart })
+
+    expect(onStart).toHaveBeenCalled()
+  })
+
+  it('should remove single class and call onEnd when animation ends', () => {
+    const onEnd = vi.fn()
+
+    animate(mockElement, 'animate-shake-x', { onEnd })
+
+    // Get the event handler function
+    const eventHandler = mockAddEventListener.mock.calls.find(
+      call => call[0] === 'animationend'
+    )?.[1] as Function
+
+    // Simulate animation end
+    eventHandler()
+
+    expect(mockClassList.remove).toHaveBeenCalledWith('animate-shake-x')
+    expect(onEnd).toHaveBeenCalled()
+  })
+
+  it('should remove multiple classes and call onEnd when animation ends', () => {
+    const onEnd = vi.fn()
+
+    animate(mockElement, 'animate-shake-x animation-duration-1000', { onEnd })
+
+    // Get the event handler function
+    const eventHandler = mockAddEventListener.mock.calls.find(
+      call => call[0] === 'animationend'
+    )?.[1] as Function
+
+    // Simulate animation end
+    eventHandler()
+
+    expect(mockClassList.remove).toHaveBeenCalledWith('animate-shake-x', 'animation-duration-1000')
+    expect(onEnd).toHaveBeenCalled()
+  })
+
+  it('should not remove classes if removeAfterAnimation is false', () => {
+    animate(mockElement, 'animate-shake-x', { removeAfterAnimation: false })
+
+    // Get the event handler function
+    const eventHandler = mockAddEventListener.mock.calls.find(
+      call => call[0] === 'animationend'
+    )?.[1] as Function
+
+    // Simulate animation end
+    eventHandler()
+
+    expect(mockClassList.remove).not.toHaveBeenCalled()
+  })
+
+  it('should use CSS variable duration for fallback timeout', () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+
+    animate(mockElement, 'animate-shake-x')
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 250)
+  })
+
+  it('should warn when element is null', () => {
+    animate(null, 'animate-shake-x')
+
+    expect(console.warn).toHaveBeenCalledWith('animate: Element is null or undefined')
+  })
+
+  it('should warn when element is undefined', () => {
+    animate(undefined as any, 'animate-shake-x')
+
+    expect(console.warn).toHaveBeenCalledWith('animate: Element is null or undefined')
+  })
+
+  it('should clean up event listeners after animation end', () => {
+    animate(mockElement, 'animate-shake-x')
+
+    // Get the event handler function
+    const eventHandler = mockAddEventListener.mock.calls.find(
+      call => call[0] === 'animationend'
+    )?.[1] as Function
+
+    // Simulate animation end
+    eventHandler()
+
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('animationend', eventHandler)
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('animationcancel', eventHandler)
+  })
+
+  it('should handle fallback timeout with multiple classes', () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+    mockClassList.contains.mockImplementation((cls: string) => cls === 'animate-shake-x')
+
+    animate(mockElement, 'animate-shake-x animation-duration-1000')
+
+    // Get the timeout callback
+    const timeoutCall = setTimeoutSpy.mock.calls[0]
+    if (timeoutCall && timeoutCall[0]) {
+      const timeoutCallback = timeoutCall[0] as Function
+      timeoutCallback()
+
+      // Should only remove classes that are still present
+      expect(mockClassList.remove).toHaveBeenCalledWith('animate-shake-x')
+    }
+  })
+})
+
+describe('useAnimate', () => {
+  it('should return a function that calls animate', () => {
+    const mockRef = { current: document.createElement('div') }
+    const triggerAnimation = useAnimate(mockRef)
+
+    expect(typeof triggerAnimation).toBe('function')
+
+    // Mock animate to verify it's called
+    const originalSparkAnimate = require('./animate').animate
+    const mockSparkAnimate = vi.fn()
+    require('./animate').animate = mockSparkAnimate
+
+    triggerAnimation('animate-shake-x')
+
+    expect(mockSparkAnimate).toHaveBeenCalledWith(mockRef.current, 'animate-shake-x', undefined)
+
+    // Restore original function
+    require('./animate').animate = originalSparkAnimate
+  })
+
+  it('should pass options to animate', () => {
+    const mockRef = { current: document.createElement('div') }
+    const triggerAnimation = useAnimate(mockRef)
+    const options = { onStart: () => console.log('started') }
+
+    // Mock animate to verify it's called
+    const originalSparkAnimate = require('./animate').animate
+    const mockSparkAnimate = vi.fn()
+    require('./animate').animate = mockSparkAnimate
+
+    triggerAnimation('animate-shake-x', options)
+
+    expect(mockSparkAnimate).toHaveBeenCalledWith(mockRef.current, 'animate-shake-x', options)
+
+    // Restore original function
+    require('./animate').animate = originalSparkAnimate
+  })
+
+  it('should handle multiple classes in useAnimate', () => {
+    const mockRef = { current: document.createElement('div') }
+    const triggerAnimation = useAnimate(mockRef)
+
+    // Mock animate to verify it's called
+    const originalSparkAnimate = require('./animate').animate
+    const mockSparkAnimate = vi.fn()
+    require('./animate').animate = mockSparkAnimate
+
+    triggerAnimation('animate-shake-x animation-duration-1000')
+
+    expect(mockSparkAnimate).toHaveBeenCalledWith(
+      mockRef.current,
+      'animate-shake-x animation-duration-1000',
+      undefined
+    )
+
+    // Restore original function
+    require('./animate').animate = originalSparkAnimate
+  })
+})

--- a/packages/utils/theme/src/animate/index.ts
+++ b/packages/utils/theme/src/animate/index.ts
@@ -1,0 +1,79 @@
+import type { RefObject } from 'react'
+
+/**
+ * Utility function to animate an element with CSS animation classes
+ * and automatically remove the classes when the animation is complete.
+ *
+ * @param element - The HTML element to animate
+ * @param animationClasses - The CSS classes containing the animation (can be multiple classes)
+ * @param options - Optional configuration for the animation
+ */
+export function animate(
+  element: Element | null,
+  animationClasses: string,
+  options: {
+    /** Whether to remove the classes after animation (default: true) */
+    removeAfterAnimation?: boolean
+    /** Callback when animation starts */
+    onStart?: () => void
+    /** Callback when animation ends */
+    onEnd?: () => void
+  } = {}
+): void {
+  if (!element) {
+    // eslint-disable-next-line no-console
+    console.warn('animate: Element is null or undefined')
+
+    return
+  }
+
+  const { removeAfterAnimation = true, onStart, onEnd } = options
+
+  // Call onStart callback
+  onStart?.()
+
+  // Split classes and add them to the element
+  const classArray = animationClasses.trim().split(/\s+/)
+
+  // Add each class individually to avoid issues with spaces
+  for (let i = 0; i < classArray.length; i++) {
+    const className = classArray[i]
+    if (className && className.length > 0) {
+      element.classList.add(className)
+    }
+  }
+
+  // Set up the animation end listener
+  const handleAnimationEnd = () => {
+    if (removeAfterAnimation) {
+      // Remove each class individually to avoid issues with spaces
+      for (let i = 0; i < classArray.length; i++) {
+        const className = classArray[i]
+        if (className && className.length > 0) {
+          element.classList.remove(className)
+        }
+      }
+    }
+    onEnd?.()
+
+    // Clean up the event listener
+    element.removeEventListener('animationend', handleAnimationEnd)
+    element.removeEventListener('animationcancel', handleAnimationEnd)
+  }
+
+  // Listen for animation end
+  element.addEventListener('animationend', handleAnimationEnd)
+  element.addEventListener('animationcancel', handleAnimationEnd)
+}
+
+/**
+ * Hook-like function for React components that returns a function to trigger animations
+ *
+ * @param elementRef - React ref to the element to animate
+ * @returns Function to trigger the animation
+ */
+export function useAnimate(elementRef: RefObject<Element | null>) {
+  return (animationClasses: string, options?: Parameters<typeof animate>[2]) => {
+    animate(elementRef.current, animationClasses, options)
+  }
+}

--- a/packages/utils/theme/src/index.ts
+++ b/packages/utils/theme/src/index.ts
@@ -1,1 +1,3 @@
 import './theme.css'
+
+export { animate, useAnimate } from './animate'


### PR DESCRIPTION
### Description, Motivation and Context

Added `animate()` and `useAnimate()` to trigger Spark animation (tailwind classes) programatically.

Why:

When trigerring an animation (adding a class), it is then not possible to re-trigger the same animation unless the developer removes the class from the element and re-applies it. It implies adding some state to manage this and can become cumbersome.

How:

Both `animate()` and `useAnimate()` are watching the `animationend` event to cleanup the animation classes when it is over (the cleanup can be disabled with `removeAfterAnimation: false`). The cleanup mean the class may be re-applied to re-trigger the animation.


### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Screenshots - Animations

https://github.com/user-attachments/assets/8defa76e-d527-482e-9aa0-36df1284f246


