### PR TITLE
feat(components): added gradients to card component

### DIFF
--- a/packages/components/src/badge/Badge.stories.tsx
+++ b/packages/components/src/badge/Badge.stories.tsx
@@ -1,7 +1,9 @@
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { Meta, StoryFn } from '@storybook/react-vite'
+import { useState } from 'react'
 
 import { Button } from '../button'
+import { Switch } from '../switch'
 import { Badge, type BadgeProps } from '.'
 
 const meta: Meta<typeof Badge> = {
@@ -37,22 +39,33 @@ const fakeAvatar = <div className="size-sz-40 bg-outline rounded-sm" />
 
 export const Default: StoryFn = _args => <Badge count={1}>{fakeAvatar}</Badge>
 
-export const Intents: StoryFn = _args => (
-  <div className="gap-xl grid grid-cols-2 sm:grid-cols-5">
-    {intents.map(intent => (
-      <div key={intent} className="flex flex-col items-center">
-        <StoryLabel className="mb-xl">{`
-            ${intent}
-            ${intent === 'danger' ? ' (default)' : ''}
-          `}</StoryLabel>
+export const Intents: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(false)
 
-        <Badge intent={intent} count={1}>
-          {fakeAvatar}
-        </Badge>
+  return (
+    <div className="gap-xl flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
       </div>
-    ))}
-  </div>
-)
+      <div className="gap-xl grid grid-cols-2 sm:grid-cols-5">
+        {intents.map(intent => (
+          <div key={intent} className="flex flex-col items-center">
+            <StoryLabel className="mb-xl">{`
+                ${intent}
+                ${intent === 'danger' ? ' (default)' : ''}
+              `}</StoryLabel>
+
+            <Badge intent={intent} count={1} withGradient={withGradient}>
+              {fakeAvatar}
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 export const Standalone: StoryFn = _args => (
   <Button design="tinted">

--- a/packages/components/src/badge/BadgeItem.styles.tsx
+++ b/packages/components/src/badge/BadgeItem.styles.tsx
@@ -51,11 +51,72 @@ export const styles = cva(
         relative: ['absolute right-0 border-md', 'translate-x-1/2 -translate-y-1/2'],
         standalone: [],
       },
+      /**
+       * Whether the badge should have a gradient background.
+       */
+      withGradient: {
+        true: [],
+        false: [],
+      },
     },
+    compoundVariants: [
+      // FILLED with gradient
+      {
+        intent: 'main',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-main'],
+      },
+      {
+        intent: 'support',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-support'],
+      },
+      {
+        intent: 'accent',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-accent'],
+      },
+      {
+        intent: 'success',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-success'],
+      },
+      {
+        intent: 'alert',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-alert'],
+      },
+      {
+        intent: 'danger',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-error'],
+      },
+      {
+        intent: 'info',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-info'],
+      },
+      {
+        intent: 'neutral',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-neutral'],
+      },
+      {
+        intent: 'surface',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-surface'],
+      },
+      {
+        intent: 'basic',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-basic'],
+      },
+    ],
     defaultVariants: {
       intent: 'danger',
       size: 'md',
       type: 'relative',
+      withGradient: false,
     },
   }
 )

--- a/packages/components/src/badge/BadgeItem.tsx
+++ b/packages/components/src/badge/BadgeItem.tsx
@@ -26,6 +26,10 @@ export interface BadgeItemProps
    * @default 'relative'
    */
   type?: 'relative' | 'standalone'
+  /**
+   * Whether the badge should have a gradient background.
+   */
+  withGradient?: boolean
   ref?: Ref<HTMLSpanElement>
 }
 
@@ -36,6 +40,7 @@ export const BadgeItem = ({
   count,
   overflowCount = 99,
   'aria-label': label,
+  withGradient,
   className,
   ...others
 }: BadgeItemProps) => {
@@ -46,11 +51,13 @@ export const BadgeItem = ({
   return (
     <span
       data-spark-component="badge"
+      data-with-gradient={withGradient || undefined}
       role="status"
       className={styles({
         intent,
         size,
         type,
+        withGradient,
         className,
       })}
       {...props}

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -75,12 +75,18 @@ export const Shapes: StoryFn = _args => (
 
 export const DesignAndIntentTable: StoryFn = _args => {
   const [underline, setUnderline] = useState(false)
+  const [withGradient, setWithGradient] = useState(false)
 
   return (
     <div className="gap-lg flex flex-col">
-      <Switch checked={underline} onClick={() => setUnderline(!underline)}>
-        Show underline
-      </Switch>
+      <div className="gap-lg flex items-center">
+        <Switch checked={underline} onClick={() => setUnderline(!underline)}>
+          Show underline
+        </Switch>
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
+      </div>
       <table className="border-collapse">
         <thead>
           <tr>
@@ -106,7 +112,12 @@ export const DesignAndIntentTable: StoryFn = _args => {
               <td className="border-outline p-md bg-surface text-on-surface border">{intent}</td>
               {designs.map(design => (
                 <td key={`${intent}-${design}`} className={'border-outline p-lg border'}>
-                  <Button intent={intent} design={design} underline={underline}>
+                  <Button
+                    intent={intent}
+                    design={design}
+                    underline={underline}
+                    withGradient={withGradient}
+                  >
                     Click me
                   </Button>
                 </td>

--- a/packages/components/src/button/Button.styles.tsx
+++ b/packages/components/src/button/Button.styles.tsx
@@ -34,9 +34,9 @@ export const buttonStyles = cva(
        *
        */
       design: makeVariants<'design', ['filled', 'outlined', 'tinted', 'ghost', 'contrast']>({
-        filled: [],
+        filled: ['data-[with-gradient=true]:hover:u-filled-gradient-hovered'],
         outlined: ['bg-transparent', 'border-sm', 'border-current'],
-        tinted: [],
+        tinted: ['data-[with-gradient=true]:hover:u-tinted-gradient-hovered'],
         ghost: ['default:-mx-md px-md hover:bg-main/dim-5'],
         contrast: [],
       }),
@@ -97,6 +97,13 @@ export const buttonStyles = cva(
         true: ['cursor-not-allowed', 'opacity-dim-3'],
         false: ['cursor-pointer'],
       },
+      /**
+       * Whether the button should have a gradient background.
+       */
+      withGradient: {
+        true: [],
+        false: [],
+      },
     },
     compoundVariants: [
       ...filledVariants,
@@ -110,6 +117,7 @@ export const buttonStyles = cva(
       intent: 'main',
       size: 'md',
       shape: 'rounded',
+      withGradient: false,
     },
   }
 )

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -25,6 +25,10 @@ export interface ButtonProps
    * **Please note that using this can result in layout shifting when the Button goes from loading state to normal state.**
    */
   loadingText?: string
+  /**
+   * Whether the button should have a gradient background.
+   */
+  withGradient?: boolean
   ref?: Ref<HTMLButtonElement>
 }
 
@@ -60,6 +64,7 @@ export const Button = ({
   asChild,
   className,
   underline = false,
+  withGradient,
   ref,
   ...others
 }: ButtonProps) => {
@@ -86,6 +91,7 @@ export const Button = ({
   return (
     <Component
       data-spark-component="button"
+      data-with-gradient={withGradient || undefined}
       {...(Component === 'button' && { type: 'button' })}
       ref={ref}
       className={buttonStyles({
@@ -96,6 +102,7 @@ export const Button = ({
         shape,
         size,
         underline,
+        withGradient,
       })}
       disabled={!!disabled}
       aria-busy={isLoading}

--- a/packages/components/src/button/variants/filled.ts
+++ b/packages/components/src/button/variants/filled.ts
@@ -6,6 +6,7 @@ export const filledVariants = [
     intent: 'main',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-main',
       'bg-main',
       'text-on-main',
       'hover:bg-main-hovered',
@@ -18,6 +19,7 @@ export const filledVariants = [
     intent: 'support',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-support',
       'bg-support',
       'text-on-support',
       'hover:bg-support-hovered',
@@ -30,6 +32,7 @@ export const filledVariants = [
     intent: 'accent',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-accent',
       'bg-accent',
       'text-on-accent',
       'hover:bg-accent-hovered',
@@ -42,6 +45,7 @@ export const filledVariants = [
     intent: 'basic',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-basic',
       'bg-basic',
       'text-on-basic',
       'hover:bg-basic-hovered',
@@ -54,6 +58,7 @@ export const filledVariants = [
     intent: 'success',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-success',
       'bg-success',
       'text-on-success',
       'hover:bg-success-hovered',
@@ -66,6 +71,7 @@ export const filledVariants = [
     intent: 'alert',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-alert',
       'bg-alert',
       'text-on-alert',
       'hover:bg-alert-hovered',
@@ -78,6 +84,7 @@ export const filledVariants = [
     intent: 'danger',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-error',
       'text-on-error bg-error',
       'hover:bg-error-hovered enabled:active:bg-error-hovered',
       'focus-visible:bg-error-hovered',
@@ -88,6 +95,7 @@ export const filledVariants = [
     intent: 'info',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-info',
       'text-on-error bg-info',
       'hover:bg-info-hovered enabled:active:bg-info-hovered',
       'focus-visible:bg-info-hovered',
@@ -98,6 +106,7 @@ export const filledVariants = [
     intent: 'neutral',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-neutral',
       'bg-neutral',
       'text-on-neutral',
       'hover:bg-neutral-hovered',
@@ -110,6 +119,7 @@ export const filledVariants = [
     intent: 'surface',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-surface',
       'bg-surface',
       'text-on-surface',
       'hover:bg-surface-hovered',
@@ -121,6 +131,7 @@ export const filledVariants = [
     intent: 'surfaceInverse',
     design: 'filled',
     class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-surface-inverse',
       'bg-surface-inverse',
       'text-on-surface-inverse',
       'hover:bg-surface-inverse-hovered',

--- a/packages/components/src/button/variants/tinted.ts
+++ b/packages/components/src/button/variants/tinted.ts
@@ -5,6 +5,7 @@ export const tintedVariants = [
     intent: 'main',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-main-container',
       'bg-main-container',
       'text-on-main-container',
       'hover:bg-main-container-hovered',
@@ -16,6 +17,7 @@ export const tintedVariants = [
     intent: 'support',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-support-container',
       'bg-support-container',
       'text-on-support-container',
       'hover:bg-support-container-hovered',
@@ -27,6 +29,7 @@ export const tintedVariants = [
     intent: 'accent',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-accent-container',
       'bg-accent-container',
       'text-on-accent-container',
       'hover:bg-accent-container-hovered',
@@ -38,6 +41,7 @@ export const tintedVariants = [
     intent: 'basic',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-basic-container',
       'bg-basic-container',
       'text-on-basic-container',
       'hover:bg-basic-container-hovered',
@@ -49,6 +53,7 @@ export const tintedVariants = [
     intent: 'success',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-success-container',
       'bg-success-container',
       'text-on-success-container',
       'hover:bg-success-container-hovered',
@@ -60,6 +65,7 @@ export const tintedVariants = [
     intent: 'alert',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-alert-container',
       'bg-alert-container',
       'text-on-alert-container',
       'hover:bg-alert-container-hovered',
@@ -71,6 +77,7 @@ export const tintedVariants = [
     intent: 'danger',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-error-container',
       'bg-error-container',
       'text-on-error-container',
       'hover:bg-error-container-hovered',
@@ -82,6 +89,7 @@ export const tintedVariants = [
     intent: 'info',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-info-container',
       'bg-info-container',
       'text-on-info-container',
       'hover:bg-info-container-hovered',
@@ -93,6 +101,7 @@ export const tintedVariants = [
     intent: 'neutral',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-neutral-container',
       'bg-neutral-container',
       'text-on-neutral-container',
       'hover:bg-neutral-container-hovered',
@@ -104,6 +113,7 @@ export const tintedVariants = [
     intent: 'surface',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-surface',
       'bg-surface',
       'text-on-surface',
       'hover:bg-surface-hovered',
@@ -115,6 +125,7 @@ export const tintedVariants = [
     intent: 'surfaceInverse',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-surface-inverse',
       'bg-surface-inverse',
       'text-on-surface-inverse',
       'hover:bg-surface-inverse-hovered',

--- a/packages/components/src/card/Backdrop.tsx
+++ b/packages/components/src/card/Backdrop.tsx
@@ -3,7 +3,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const backdropStyles = cva(
   [
-    'default:bg-surface default:bg-gradient-to-r absolute inset-x-0 top-0',
+    'default:bg-surface default:bg-gradient-to-r absolute inset-x-0 top-0 z-hide',
     'h-sz-16',
     'default:rounded-t-lg',
     'bg-[length:200%_100%] bg-position-[0%_0%]',

--- a/packages/components/src/card/Card.doc.mdx
+++ b/packages/components/src/card/Card.doc.mdx
@@ -72,6 +72,24 @@ It gives you more control over the content inside the card and its layout.
 
 <Canvas of={CardStories.InsetContent} />
 
+### With Gradient
+
+The `withGradient` prop adds gradient backgrounds to cards while preserving good contrast.
+
+**Filled design**: Uses color stops and gradient logic optimized for solid color backgrounds.
+The gradient maintains the original color intensity while adding visual depth.
+
+**Tinted design**: Uses different color stops and gradient logic specifically designed for 
+container backgrounds. This ensures the gradient preserves the subtle, tinted appearance 
+while maintaining excellent readability and contrast.
+
+Use tailwind classes to:
+- customize the orientation of the gradient (ex: `bg-linear-to-tl`)
+- customize the start/end color stops (ex: `from-main to-accent`)
+
+
+<Canvas of={CardStories.WithGradient} />
+
 ## Advanced Examples
 
 ### Link

--- a/packages/components/src/card/Card.stories.tsx
+++ b/packages/components/src/card/Card.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { Divider } from '@spark-ui/components/divider'
 import { Icon } from '@spark-ui/components/icon'
 import { IconButton } from '@spark-ui/components/icon-button'
@@ -48,22 +49,24 @@ const designs: CardProps['design'][] = ['filled', 'tinted', 'outlined']
 export const Default: StoryObj = {
   render: _args => {
     return (
-      <Card className="max-w-sz-320">
-        <Card.Backdrop />
-        <Card.Content className="gap-md flex flex-col items-start">
-          <div className="h-sz-144 relative w-full">
-            <img
-              src={pandaImg}
-              alt="Panda"
-              className="relative size-full rounded-lg object-cover"
-            />
-          </div>
-          <div>
-            <p className="text-headline-2">All about pandas</p>
-            <p>Read about Panda and Red Panda</p>
-          </div>
-        </Card.Content>
-      </Card>
+      <div>
+        <Card className="max-w-sz-320">
+          <Card.Backdrop />
+          <Card.Content className="gap-md flex flex-col items-start">
+            <div className="h-sz-144 relative w-full">
+              <img
+                src={pandaImg}
+                alt="Panda"
+                className="relative size-full rounded-lg object-cover"
+              />
+            </div>
+            <div>
+              <p className="text-headline-2">All about pandas</p>
+              <p>Read about Panda and Red Panda</p>
+            </div>
+          </Card.Content>
+        </Card>
+      </div>
     )
   },
 }
@@ -100,6 +103,7 @@ export const Backdrop: StoryFn = _args => {
 export const DesignAndIntentTable: StoryFn = _args => {
   const [withShadows, setWithShadows] = useState(true)
   const [withBackdrop, setWithBackdrop] = useState(true)
+  const [withGradient, setWithGradient] = useState(false)
   const [disabled, setDisabled] = useState(false)
 
   return (
@@ -111,6 +115,10 @@ export const DesignAndIntentTable: StoryFn = _args => {
         <Divider orientation="vertical" />
         <Switch checked={withBackdrop} onCheckedChange={setWithBackdrop}>
           With backdrop
+        </Switch>
+        <Divider orientation="vertical" />
+        <Switch checked={withGradient} onCheckedChange={setWithGradient}>
+          With gradient
         </Switch>
         <Divider orientation="vertical" />
         <Switch checked={disabled} onCheckedChange={setDisabled}>
@@ -143,6 +151,7 @@ export const DesignAndIntentTable: StoryFn = _args => {
                   <Card
                     intent={intent}
                     design={design}
+                    withGradient={withGradient}
                     className={cx('w-sz-208', withShadows && 'shadow-md')}
                     asChild
                   >
@@ -257,6 +266,109 @@ export const WithLinkBox: StoryFn = _args => {
           </Card.Content>
         </Card>
       </LinkBox>
+    </div>
+  )
+}
+
+/**
+ * The `withGradient` prop adds gradient backgrounds to cards while preserving good contrast.
+ *
+ * **Filled design**: Uses color stops and gradient logic optimized for solid color backgrounds.
+ * The gradient maintains the original color intensity while adding visual depth.
+ *
+ * **Tinted design**: Uses different color stops and gradient logic specifically designed for
+ * container backgrounds. This ensures the gradient preserves the subtle, tinted appearance
+ * while maintaining excellent readability and contrast.
+ */
+export const WithGradient: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(true)
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch
+          checked={withGradient}
+          onCheckedChange={setWithGradient}
+          id="with-gradient-toggle"
+        />
+        <label htmlFor="with-gradient-toggle" className="text-body-2">
+          Enable gradient background
+        </label>
+      </div>
+
+      <div className="gap-lg grid grid-cols-2">
+        <div>
+          <Tag className="mb-md">
+            Filled + Main + {withGradient ? 'withGradient' : 'no gradient'}
+          </Tag>
+          <Card intent="main" design="filled" withGradient={withGradient} className="min-w-sz-160">
+            <Card.Content className="gap-md flex flex-col items-start">
+              <div>
+                <p className="text-headline-2">Lorem Ipsum</p>
+                <p className="text-body-2">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                  exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </div>
+            </Card.Content>
+          </Card>
+        </div>
+
+        <div>
+          <Tag className="mb-md">
+            Tinted + Main + {withGradient ? 'withGradient' : 'no gradient'}
+          </Tag>
+          <Card intent="main" design="tinted" withGradient={withGradient} className="min-w-sz-160">
+            <Card.Content className="gap-md flex flex-col items-start">
+              <div>
+                <p className="text-headline-2">Lorem Ipsum</p>
+                <p className="text-body-2">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                  exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </div>
+            </Card.Content>
+          </Card>
+        </div>
+
+        <div>
+          <Tag className="mb-md">
+            Filled + Main + {withGradient ? 'withGradient' : 'no gradient'} + custom direction
+          </Tag>
+          <Card intent="main" design="filled" withGradient={withGradient} className="min-w-sz-160">
+            <Card.Content className="gap-md flex flex-col items-start bg-linear-to-l">
+              <div>
+                <p className="text-headline-2">Lorem Ipsum</p>
+                <p className="text-body-2">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                  exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </div>
+            </Card.Content>
+          </Card>
+        </div>
+
+        <div>
+          <Tag className="mb-md">
+            Filled + Main + {withGradient ? 'withGradient' : 'no gradient'} + custom end color
+          </Tag>
+          <Card intent="main" design="filled" withGradient={withGradient} className="min-w-sz-160">
+            <Card.Content className="gap-md to-accent! flex flex-col items-start">
+              <div>
+                <p className="text-headline-2">Lorem Ipsum</p>
+                <p className="text-body-2">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                  exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </div>
+            </Card.Content>
+          </Card>
+        </div>
+      </div>
     </div>
   )
 }

--- a/packages/components/src/card/Card.tsx
+++ b/packages/components/src/card/Card.tsx
@@ -14,6 +14,10 @@ export interface CardProps extends ComponentProps<'div'>, CardStylesProps {
    * Whether the card should have an inset padding.
    */
   inset?: boolean
+  /**
+   * Whether the card content should have a gradient background.
+   */
+  withGradient?: boolean
 }
 
 export const Card = ({
@@ -22,6 +26,7 @@ export const Card = ({
   intent = 'surface',
   inset = false,
   asChild,
+  withGradient,
   className,
   ref,
   ...props
@@ -38,6 +43,7 @@ export const Card = ({
         hasBackdrop: backdropDetected,
         inset,
         isInteractive: interactiveDetected,
+        withGradient,
       }}
     >
       <Component

--- a/packages/components/src/card/Content.styles.tsx
+++ b/packages/components/src/card/Content.styles.tsx
@@ -5,6 +5,7 @@ export const contentStyles = cva(
   [
     'relative h-full default:rounded-lg w-full focus-visible:u-outline',
     'default:transition-colors default:duration-200 ease-linear',
+    'before:content-[""] before:absolute before:inset-0 before:rounded-lg before:bg-surface before:z-hide',
   ],
   {
     variants: {
@@ -12,14 +13,18 @@ export const contentStyles = cva(
         false: ['default:p-lg'],
       },
       design: {
-        filled: [],
+        filled: [
+          'group-not-disabled:group-data-[interactive=true]:group-hover:data-[with-gradient=true]:u-filled-gradient-hovered',
+        ],
         outlined: [
           'default:bg-surface group-focus:bg-surface-hovered group-not-disabled:group-data-[interactive=true]:group-hover:bg-surface-hovered',
         ],
-        tinted: [],
+        tinted: [
+          'group-not-disabled:group-data-[interactive=true]:group-hover:data-[with-gradient=true]:u-tinted-gradient-hovered',
+        ],
       },
       hasBackdrop: {
-        true: ['rounded-t-[16px_8px] '],
+        true: ['rounded-t-[16px_8px] before:rounded-t-[16px_8px]'],
       },
       intent: makeVariants<
         'intent',
@@ -56,6 +61,7 @@ export const contentStyles = cva(
         intent: 'main',
         design: 'filled',
         class: tw([
+          'data-[with-gradient=true]:u-filled-gradient-main',
           'bg-main text-on-main group-focus:bg-main-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-main-hovered',
         ]),
@@ -64,7 +70,9 @@ export const contentStyles = cva(
         intent: 'support',
         design: 'filled',
         class: tw([
-          'bg-support text-on-support group-focus:bg-support-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-support',
+          'bg-support',
+          'text-on-support group-focus:bg-support-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-support-hovered',
         ]),
       },
@@ -72,7 +80,9 @@ export const contentStyles = cva(
         intent: 'accent',
         design: 'filled',
         class: tw([
-          'bg-accent text-on-accent group-focus:bg-accent-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-accent',
+          'bg-accent',
+          'text-on-accent group-focus:bg-accent-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-accent-hovered',
         ]),
       },
@@ -80,7 +90,9 @@ export const contentStyles = cva(
         intent: 'basic',
         design: 'filled',
         class: tw([
-          'bg-basic text-on-basic group-focus:bg-basic-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-basic',
+          'bg-basic',
+          'text-on-basic group-focus:bg-basic-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-basic-hovered',
         ]),
       },
@@ -88,7 +100,9 @@ export const contentStyles = cva(
         intent: 'success',
         design: 'filled',
         class: tw([
-          'bg-success text-on-success group-focus:bg-success-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-success',
+          'bg-success',
+          'text-on-success group-focus:bg-success-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-success-hovered',
         ]),
       },
@@ -96,7 +110,9 @@ export const contentStyles = cva(
         intent: 'alert',
         design: 'filled',
         class: tw([
-          'bg-alert text-on-alert group-focus:bg-alert-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-alert',
+          'bg-alert',
+          'text-on-alert group-focus:bg-alert-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-alert-hovered',
         ]),
       },
@@ -104,7 +120,9 @@ export const contentStyles = cva(
         intent: 'danger',
         design: 'filled',
         class: tw([
-          'text-on-error bg-error group-focus:bg-error-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-error',
+          'bg-error',
+          'text-on-error group-focus:bg-error-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-error-hovered',
         ]),
       },
@@ -112,7 +130,9 @@ export const contentStyles = cva(
         intent: 'info',
         design: 'filled',
         class: tw([
-          'text-on-error bg-info group-focus:bg-info-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-info',
+          'bg-info',
+          'text-on-error group-focus:bg-info-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-info-hovered',
         ]),
       },
@@ -120,7 +140,9 @@ export const contentStyles = cva(
         intent: 'neutral',
         design: 'filled',
         class: tw([
-          'bg-neutral text-on-neutral group-focus:bg-neutral-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-neutral',
+          'bg-neutral',
+          'text-on-neutral group-focus:bg-neutral-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-neutral-hovered',
         ]),
       },
@@ -128,7 +150,9 @@ export const contentStyles = cva(
         intent: 'surface',
         design: 'filled',
         class: tw([
-          'bg-surface text-on-surface group-focus:bg-surface-hovered',
+          'data-[with-gradient=true]:u-filled-gradient-surface',
+          'bg-surface',
+          'text-on-surface group-focus:bg-surface-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-surface-hovered',
         ]),
       },
@@ -141,15 +165,20 @@ export const contentStyles = cva(
         intent: 'main',
         design: 'tinted',
         class: tw([
-          'bg-main-container text-on-main-container group-focus:bg-main-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-main-container',
+          'bg-main-container',
+          'text-on-main-container group-focus:bg-main-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-main-container-hovered',
+          'group-not-disabled:group-data-[interactive=true]:group-hover:data-[with-gradient=true]:bg-surface-inverse',
         ]),
       },
       {
         intent: 'support',
         design: 'tinted',
         class: tw([
-          'bg-support-container text-on-support-container group-focus:bg-support-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-support-container',
+          'bg-support-container',
+          'text-on-support-container group-focus:bg-support-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-support-container-hovered',
         ]),
       },
@@ -157,7 +186,9 @@ export const contentStyles = cva(
         intent: 'accent',
         design: 'tinted',
         class: tw([
-          'bg-accent-container text-on-accent-container group-focus:bg-accent-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-accent-container',
+          'bg-accent-container',
+          'text-on-accent-container group-focus:bg-accent-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-accent-container-hovered',
         ]),
       },
@@ -165,14 +196,19 @@ export const contentStyles = cva(
         intent: 'basic',
         design: 'tinted',
         class: tw([
-          'bg-basic-container text-on-basic-container group-focus:bg-basic-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-basic-container',
+          'bg-basic-container',
+          'text-on-basic-container group-focus:bg-basic-container-hovered',
+          'group-not-disabled:group-data-[interactive=true]:group-hover:bg-basic-container-hovered',
         ]),
       },
       {
         intent: 'success',
         design: 'tinted',
         class: tw([
-          'bg-success-container text-on-success-container group-focus:bg-success-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-success-container',
+          'bg-success-container',
+          'text-on-success-container group-focus:bg-success-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-success-container-hovered',
         ]),
       },
@@ -180,7 +216,9 @@ export const contentStyles = cva(
         intent: 'alert',
         design: 'tinted',
         class: tw([
-          'bg-alert-container text-on-alert-container group-focus:bg-alert-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-alert-container',
+          'bg-alert-container',
+          'text-on-alert-container group-focus:bg-alert-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-alert-container-hovered',
         ]),
       },
@@ -188,7 +226,9 @@ export const contentStyles = cva(
         intent: 'danger',
         design: 'tinted',
         class: tw([
-          'bg-error-container text-on-error-container group-focus:bg-error-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-error-container',
+          'bg-error-container',
+          'text-on-error-container group-focus:bg-error-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-error-container-hovered',
         ]),
       },
@@ -196,7 +236,9 @@ export const contentStyles = cva(
         intent: 'info',
         design: 'tinted',
         class: tw([
-          'bg-info-container text-on-info-container group-focus:bg-info-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-info-container',
+          'bg-info-container',
+          'text-on-info-container group-focus:bg-info-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-info-container-hovered',
         ]),
       },
@@ -204,7 +246,9 @@ export const contentStyles = cva(
         intent: 'neutral',
         design: 'tinted',
         class: tw([
-          'bg-neutral-container text-on-neutral-container group-focus:bg-neutral-container-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-neutral-container',
+          'bg-neutral-container',
+          'text-on-neutral-container group-focus:bg-neutral-container-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-neutral-container-hovered',
         ]),
       },
@@ -212,7 +256,9 @@ export const contentStyles = cva(
         intent: 'surface',
         design: 'tinted',
         class: tw([
-          'bg-surface text-on-surface group-focus:bg-surface-hovered',
+          'data-[with-gradient=true]:u-tinted-gradient-surface',
+          'bg-surface',
+          'text-on-surface group-focus:bg-surface-hovered',
           'group-not-disabled:group-data-[interactive=true]:group-hover:bg-surface-hovered',
         ]),
       },

--- a/packages/components/src/card/Content.tsx
+++ b/packages/components/src/card/Content.tsx
@@ -17,23 +17,26 @@ export interface ContentProps extends ComponentProps<'div'> {
 
 export const Content = ({ children, inset, asChild, className, ref, ...props }: ContentProps) => {
   const Component = asChild ? Slot : 'div'
-  const { design, intent, hasBackdrop } = useCardContext()
+  const { design, intent, hasBackdrop, withGradient } = useCardContext()
 
   return (
-    <Component
-      data-spark-component="card-content"
-      ref={ref}
-      className={contentStyles({
-        className,
-        design,
-        intent,
-        inset,
-        hasBackdrop,
-      })}
-      {...props}
-    >
-      {children}
-    </Component>
+    <>
+      <Component
+        data-spark-component="card-content"
+        data-with-gradient={withGradient || undefined}
+        ref={ref}
+        className={contentStyles({
+          className,
+          design,
+          intent,
+          inset,
+          hasBackdrop,
+        })}
+        {...props}
+      >
+        {children}
+      </Component>
+    </>
   )
 }
 

--- a/packages/components/src/card/context.tsx
+++ b/packages/components/src/card/context.tsx
@@ -8,6 +8,7 @@ export interface CardContextValue {
   hasBackdrop: boolean
   inset: boolean
   isInteractive: boolean
+  withGradient?: boolean
 }
 
 const CardContext = createContext<CardContextValue | undefined>(undefined)

--- a/packages/components/src/chip/Chip.stories.tsx
+++ b/packages/components/src/chip/Chip.stories.tsx
@@ -10,6 +10,7 @@ import { ComponentProps, useRef, useState } from 'react'
 import { Icon } from '../icon'
 import { Input as SparkInput, InputGroup } from '../input'
 import { Label } from '../label'
+import { Switch } from '../switch'
 import { VisuallyHidden } from '../visually-hidden'
 import { Chip } from '.'
 import { ChipLeadingIcon } from './ChipLeadingIcon'
@@ -320,67 +321,103 @@ export const Input: StoryFn = () => {
   )
 }
 
-export const DefaultIntent: StoryFn = _args => (
-  <div className="gap-md flex flex-col flex-wrap">
-    {designs.map(design => (
-      <div key={design} className="gap-md flex flex-wrap">
-        {intents.map(intent => (
-          <Chip
-            onClear={() => console.log('clear')}
-            design={design}
-            key={`${design}-${intent}`}
-            intent={intent}
-          >
-            <Chip.Content>{intent}</Chip.Content>
-            <Chip.ClearButton label="clear" />
-          </Chip>
-        ))}
-      </div>
-    ))}
-  </div>
-)
+export const DefaultIntent: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(false)
 
-export const ActionIntent: StoryFn = _args => (
-  <div className="gap-md flex flex-col flex-wrap">
-    {designs.map(design => (
-      <div key={design} className="gap-md flex flex-wrap">
-        {intents.map(intent => (
-          <Chip
-            design={design}
-            key={`${design}-${intent}`}
-            intent={intent}
-            onClick={() => console.log(`click ${design} ${intent}`)}
-            onClear={() => console.log('clear')}
-          >
-            <Chip.Content>{intent}</Chip.Content>
-            <Chip.ClearButton label="clear" />
-          </Chip>
+  return (
+    <div className="gap-md flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
+      </div>
+      <div className="gap-md flex flex-col flex-wrap">
+        {designs.map(design => (
+          <div key={design} className="gap-md flex flex-wrap">
+            {intents.map(intent => (
+              <Chip
+                onClear={() => console.log('clear')}
+                design={design}
+                key={`${design}-${intent}`}
+                intent={intent}
+                withGradient={withGradient}
+              >
+                <Chip.Content>{intent}</Chip.Content>
+                <Chip.ClearButton label="clear" />
+              </Chip>
+            ))}
+          </div>
         ))}
       </div>
-    ))}
-  </div>
-)
+    </div>
+  )
+}
 
-export const SelectionIntent: StoryFn = _args => (
-  <div className="gap-md flex flex-col flex-wrap">
-    {designs.map(design => (
-      <div key={design} className="gap-md flex flex-wrap">
-        {intents.map(intent => (
-          <Chip
-            defaultPressed={true}
-            design={design}
-            key={`${design}-${intent}`}
-            intent={intent}
-            onClear={() => console.log('clear')}
-          >
-            <Chip.Content>{intent}</Chip.Content>
-            <Chip.ClearButton label="clear" />
-          </Chip>
+export const ActionIntent: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(false)
+
+  return (
+    <div className="gap-md flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
+      </div>
+      <div className="gap-md flex flex-col flex-wrap">
+        {designs.map(design => (
+          <div key={design} className="gap-md flex flex-wrap">
+            {intents.map(intent => (
+              <Chip
+                design={design}
+                key={`${design}-${intent}`}
+                intent={intent}
+                onClick={() => console.log(`click ${design} ${intent}`)}
+                onClear={() => console.log('clear')}
+                withGradient={withGradient}
+              >
+                <Chip.Content>{intent}</Chip.Content>
+                <Chip.ClearButton label="clear" />
+              </Chip>
+            ))}
+          </div>
         ))}
       </div>
-    ))}
-  </div>
-)
+    </div>
+  )
+}
+
+export const SelectionIntent: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(false)
+
+  return (
+    <div className="gap-md flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
+      </div>
+      <div className="gap-md flex flex-col flex-wrap">
+        {designs.map(design => (
+          <div key={design} className="gap-md flex flex-wrap">
+            {intents.map(intent => (
+              <Chip
+                defaultPressed={true}
+                design={design}
+                key={`${design}-${intent}`}
+                intent={intent}
+                onClear={() => console.log('clear')}
+                withGradient={withGradient}
+              >
+                <Chip.Content>{intent}</Chip.Content>
+                <Chip.ClearButton label="clear" />
+              </Chip>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 export const Disabled: StoryFn = _args => (
   <div>

--- a/packages/components/src/chip/Chip.styles.tsx
+++ b/packages/components/src/chip/Chip.styles.tsx
@@ -68,12 +68,85 @@ export const chipStyles = cva(
         true: [],
         false: [],
       },
+      /**
+       * Whether the chip should have a gradient background.
+       */
+      withGradient: {
+        true: [],
+        false: [],
+      },
       // 'pl-[calc(var(--spacing-md)-(var(--border-width-sm)))]'
     },
-    compoundVariants: [...outlinedVariants, ...tintedVariants, ...dashedVariants],
+    compoundVariants: [
+      ...outlinedVariants,
+      ...tintedVariants,
+      ...dashedVariants,
+      // FILLED with gradient (for outlined design)
+      {
+        intent: 'main',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-main'],
+      },
+      {
+        intent: 'support',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-support'],
+      },
+      {
+        intent: 'basic',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-basic'],
+      },
+      {
+        intent: 'accent',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-accent'],
+      },
+      {
+        intent: 'success',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-success'],
+      },
+      {
+        intent: 'alert',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-alert'],
+      },
+      {
+        intent: 'danger',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-error'],
+      },
+      {
+        intent: 'info',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-info'],
+      },
+      {
+        intent: 'neutral',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-neutral'],
+      },
+      {
+        intent: 'surface',
+        design: 'outlined',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-surface'],
+      },
+    ],
     defaultVariants: {
       design: 'outlined',
       intent: 'basic',
+      withGradient: false,
     },
   }
 )

--- a/packages/components/src/chip/Chip.tsx
+++ b/packages/components/src/chip/Chip.tsx
@@ -30,6 +30,10 @@ export interface ChipProps extends ChipPrimitiveProps, Omit<ChipStylesProps, 'ha
    * Clear chip handler
    */
   onClear?: (event?: MouseEvent<HTMLButtonElement>) => void
+  /**
+   * Whether the chip should have a gradient background.
+   */
+  withGradient?: boolean
   ref?: Ref<HTMLButtonElement | HTMLDivElement>
 }
 
@@ -44,6 +48,7 @@ export const Chip = ({
   className,
   onClick,
   onClear,
+  withGradient,
   ref: forwardedRef,
   ...otherProps
 }: ChipProps) => {
@@ -69,12 +74,14 @@ export const Chip = ({
     <ChipContext.Provider value={{ disabled, design, intent, onClear }}>
       <ChipElement
         ref={forwardedRef}
+        data-with-gradient={withGradient || undefined}
         className={chipStyles({
           className,
           design,
           disabled,
           intent,
           hasClearButton: !!clearButton,
+          withGradient,
         })}
         {...{
           ...chipProps,

--- a/packages/components/src/chip/variants/tinted.ts
+++ b/packages/components/src/chip/variants/tinted.ts
@@ -6,6 +6,7 @@ export const tintedVariants = [
     intent: 'main',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-main-container',
       'bg-main-container',
       'enabled:hover:bg-main-container-hovered',
       'enabled:active:bg-main-container-hovered',
@@ -18,6 +19,7 @@ export const tintedVariants = [
     intent: 'support',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-support-container',
       'bg-support-container',
       'enabled:hover:bg-support-container-hovered',
       'enabled:active:bg-support-container-hovered',
@@ -30,6 +32,7 @@ export const tintedVariants = [
     intent: 'basic',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-basic-container',
       'bg-basic-container',
       'enabled:hover:bg-basic-container-hovered',
       'enabled:active:bg-basic-container-hovered',
@@ -42,6 +45,7 @@ export const tintedVariants = [
     intent: 'accent',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-accent-container',
       'bg-accent-container',
       'enabled:hover:bg-accent-container-hovered',
       'enabled:active:bg-accent-container-hovered',
@@ -54,6 +58,7 @@ export const tintedVariants = [
     intent: 'success',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-success-container',
       'bg-success-container',
       'enabled:hover:bg-success-container-hovered',
       'enabled:active:bg-success-container-hovered',
@@ -66,6 +71,7 @@ export const tintedVariants = [
     intent: 'alert',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-alert-container',
       'bg-alert-container',
       'enabled:hover:bg-alert-container-hovered',
       'enabled:active:bg-alert-container-hovered',
@@ -78,6 +84,7 @@ export const tintedVariants = [
     intent: 'danger',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-error-container',
       'bg-error-container',
       'enabled:hover:bg-error-container-hovered',
       'enabled:active:bg-error-container-hovered',
@@ -90,6 +97,7 @@ export const tintedVariants = [
     intent: 'info',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-info-container',
       'bg-info-container',
       'enabled:hover:bg-info-container-hovered',
       'enabled:active:bg-info-container-hovered',
@@ -102,6 +110,7 @@ export const tintedVariants = [
     intent: 'neutral',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-neutral-container',
       'bg-neutral-container',
       'enabled:hover:bg-neutral-container-hovered',
       'enabled:active:bg-neutral-container-hovered',
@@ -114,6 +123,7 @@ export const tintedVariants = [
     intent: 'surface',
     design: 'tinted',
     class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-surface',
       'bg-surface/dim-1',
       'enabled:hover:bg-surface-hovered/dim-1',
       'enabled:active:bg-surface-hovered/dim-1',

--- a/packages/components/src/tag/Tag.stories.tsx
+++ b/packages/components/src/tag/Tag.stories.tsx
@@ -1,8 +1,9 @@
 import { Check } from '@spark-ui/icons/Check'
 import { Meta, StoryFn } from '@storybook/react-vite'
-import { type ComponentProps } from 'react'
+import { type ComponentProps, useState } from 'react'
 
 import { Icon } from '../icon'
+import { Switch } from '../switch'
 import { Tag } from '.'
 
 const meta: Meta<typeof Tag> = {
@@ -48,29 +49,38 @@ export const Design: StoryFn = _args => (
   </div>
 )
 
-export const Intent: StoryFn = _args => (
-  <div className="gap-md flex flex-col">
-    {designs.map(design => (
-      <div key={design} className="gap-md flex flex-row">
-        {intents.map(intent => {
-          if (design !== 'filled' && intent === 'surface') {
-            return (
-              <span key={intent} className="text-small self-center">
-                N/A
-              </span>
-            )
-          }
+export const Intent: StoryFn = _args => {
+  const [withGradient, setWithGradient] = useState(false)
 
-          return (
-            <Tag key={intent} design={design} intent={intent as any}>
-              {intent} tag
-            </Tag>
-          )
-        })}
+  return (
+    <div className="gap-md flex flex-col">
+      <div className="gap-md flex items-center">
+        <Switch checked={withGradient} onClick={() => setWithGradient(!withGradient)}>
+          With gradient
+        </Switch>
       </div>
-    ))}
-  </div>
-)
+      {designs.map(design => (
+        <div key={design} className="gap-md flex flex-row">
+          {intents.map(intent => {
+            if (design !== 'filled' && intent === 'surface') {
+              return (
+                <span key={intent} className="text-small self-center">
+                  N/A
+                </span>
+              )
+            }
+
+            return (
+              <Tag key={intent} design={design} intent={intent as any} withGradient={withGradient}>
+                {intent} tag
+              </Tag>
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}
 
 export const Icons: StoryFn = _args => (
   <div className="gap-md flex flex-wrap">

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -60,13 +60,141 @@ export const tagStyles = cva(
         neutral: [],
         surface: [],
       }),
+      /**
+       * Whether the tag should have a gradient background.
+       */
+      withGradient: {
+        true: [],
+        false: [],
+      },
     },
-    compoundVariants: [...filledVariants, ...outlinedVariants, ...tintedVariants],
+    compoundVariants: [
+      ...filledVariants,
+      ...outlinedVariants,
+      ...tintedVariants,
+      // FILLED with gradient
+      {
+        intent: 'main',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-main'],
+      },
+      {
+        intent: 'support',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-support'],
+      },
+      {
+        intent: 'accent',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-accent'],
+      },
+      {
+        intent: 'basic',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-basic'],
+      },
+      {
+        intent: 'success',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-success'],
+      },
+      {
+        intent: 'alert',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-alert'],
+      },
+      {
+        intent: 'danger',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-error'],
+      },
+      {
+        intent: 'info',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-info'],
+      },
+      {
+        intent: 'neutral',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-neutral'],
+      },
+      {
+        intent: 'surface',
+        design: 'filled',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-filled-gradient-surface'],
+      },
+      // TINTED with gradient
+      {
+        intent: 'main',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-main-container'],
+      },
+      {
+        intent: 'support',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-support-container'],
+      },
+      {
+        intent: 'accent',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-accent-container'],
+      },
+      {
+        intent: 'basic',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-basic-container'],
+      },
+      {
+        intent: 'success',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-success-container'],
+      },
+      {
+        intent: 'alert',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-alert-container'],
+      },
+      {
+        intent: 'danger',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-error-container'],
+      },
+      {
+        intent: 'info',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-info-container'],
+      },
+      {
+        intent: 'neutral',
+        design: 'tinted',
+        withGradient: true,
+        class: ['data-[with-gradient=true]:u-tinted-gradient-neutral-container'],
+      },
+    ],
     defaultVariants: {
       design: 'filled',
       intent: 'basic',
       size: 'md',
       shape: 'pill',
+      withGradient: false,
     },
   }
 )

--- a/packages/components/src/tag/Tag.tsx
+++ b/packages/components/src/tag/Tag.tsx
@@ -10,6 +10,10 @@ interface BaseTagProps
    * Change the component to the HTML tag or custom component of the only child.
    */
   asChild?: boolean
+  /**
+   * Whether the tag should have a gradient background.
+   */
+  withGradient?: boolean
 }
 
 interface FilteredDesignIntent<
@@ -35,6 +39,7 @@ export const Tag = ({
   shape = 'pill',
   asChild,
   className,
+  withGradient,
   ref,
   ...others
 }: TagProps) => {
@@ -43,6 +48,7 @@ export const Tag = ({
   return (
     <Component
       data-spark-component="tag"
+      data-with-gradient={withGradient || undefined}
       ref={ref}
       className={tagStyles({
         className,
@@ -50,6 +56,7 @@ export const Tag = ({
         intent,
         size,
         shape,
+        withGradient,
       })}
       {...others}
     />

--- a/packages/components/src/tag/variants/filled.ts
+++ b/packages/components/src/tag/variants/filled.ts
@@ -4,51 +4,71 @@ export const filledVariants = [
   {
     intent: 'main',
     design: 'filled',
-    class: tw(['bg-main', 'text-on-main']),
+    class: tw(['data-[with-gradient=true]:u-filled-gradient-main', 'bg-main', 'text-on-main']),
   },
   {
     intent: 'support',
     design: 'filled',
-    class: tw(['bg-support', 'text-on-support']),
+    class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-support',
+      'bg-support',
+      'text-on-support',
+    ]),
   },
   {
     intent: 'accent',
     design: 'filled',
-    class: tw(['bg-accent', 'text-on-accent']),
+    class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-accent',
+      'bg-accent',
+      'text-on-accent',
+    ]),
   },
   {
     intent: 'basic',
     design: 'filled',
-    class: tw(['bg-basic', 'text-on-basic']),
+    class: tw(['data-[with-gradient=true]:u-filled-gradient-basic', 'bg-basic', 'text-on-basic']),
   },
   {
     intent: 'success',
     design: 'filled',
-    class: tw(['bg-success', 'text-on-success']),
+    class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-success',
+      'bg-success',
+      'text-on-success',
+    ]),
   },
   {
     intent: 'alert',
     design: 'filled',
-    class: tw(['bg-alert', 'text-on-alert']),
+    class: tw(['data-[with-gradient=true]:u-filled-gradient-alert', 'bg-alert', 'text-on-alert']),
   },
   {
     intent: 'danger',
     design: 'filled',
-    class: tw(['bg-error', 'text-on-error']),
+    class: tw(['data-[with-gradient=true]:u-filled-gradient-error', 'bg-error', 'text-on-error']),
   },
   {
     intent: 'info',
     design: 'filled',
-    class: tw(['bg-info', 'text-on-info']),
+    class: tw(['data-[with-gradient=true]:u-filled-gradient-info', 'bg-info', 'text-on-info']),
   },
   {
     intent: 'neutral',
     design: 'filled',
-    class: tw(['bg-neutral', 'text-on-neutral']),
+    class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-neutral',
+      'bg-neutral',
+      'text-on-neutral',
+    ]),
   },
   {
     intent: 'surface',
     design: 'filled',
-    class: tw(['bg-surface', 'text-on-surface']),
+    class: tw([
+      'data-[with-gradient=true]:u-filled-gradient-surface',
+      'bg-surface',
+      'text-on-surface',
+    ]),
   },
 ] as const

--- a/packages/components/src/tag/variants/tinted.ts
+++ b/packages/components/src/tag/variants/tinted.ts
@@ -4,46 +4,82 @@ export const tintedVariants = [
   {
     intent: 'main',
     design: 'tinted',
-    class: tw(['bg-main-container', 'text-on-main-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-main-container',
+      'bg-main-container',
+      'text-on-main-container',
+    ]),
   },
   {
     intent: 'support',
     design: 'tinted',
-    class: tw(['bg-support-container', 'text-on-support-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-support-container',
+      'bg-support-container',
+      'text-on-support-container',
+    ]),
   },
   {
     intent: 'accent',
     design: 'tinted',
-    class: tw(['bg-accent-container', 'text-on-accent-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-accent-container',
+      'bg-accent-container',
+      'text-on-accent-container',
+    ]),
   },
   {
     intent: 'basic',
     design: 'tinted',
-    class: tw(['bg-basic-container', 'text-on-basic-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-basic-container',
+      'bg-basic-container',
+      'text-on-basic-container',
+    ]),
   },
   {
     intent: 'success',
     design: 'tinted',
-    class: tw(['bg-success-container', 'text-on-success-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-success-container',
+      'bg-success-container',
+      'text-on-success-container',
+    ]),
   },
   {
     intent: 'alert',
     design: 'tinted',
-    class: tw(['bg-alert-container', 'text-on-alert-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-alert-container',
+      'bg-alert-container',
+      'text-on-alert-container',
+    ]),
   },
   {
     intent: 'danger',
     design: 'tinted',
-    class: tw(['bg-error-container', 'text-on-error-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-error-container',
+      'bg-error-container',
+      'text-on-error-container',
+    ]),
   },
   {
     intent: 'info',
     design: 'tinted',
-    class: tw(['bg-info-container', 'text-on-info-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-info-container',
+      'bg-info-container',
+      'text-on-info-container',
+    ]),
   },
   {
     intent: 'neutral',
     design: 'tinted',
-    class: tw(['bg-neutral-container', 'text-on-neutral-container']),
+    class: tw([
+      'data-[with-gradient=true]:u-tinted-gradient-neutral-container',
+      'bg-neutral-container',
+      'text-on-neutral-container',
+    ]),
   },
 ] as const

--- a/packages/utils/theme/src/utilities.css
+++ b/packages/utils/theme/src/utilities.css
@@ -144,3 +144,50 @@
   outline-width: 2px;
   outline-offset: calc(2px * -1);
 }
+
+/*
+  u-gradient-*: A utility to apply a gradient to a background.
+  For elements whose background is using a base color (strong color, not like the *-container colors)
+*/
+@utility u-filled-gradient-* {
+  /* prettier-ignore */
+  --tw-gradient-from: --value(--color-*);
+
+  /* prettier-ignore */
+  --tw-gradient-to: --value(--color-*);
+
+  background-image: linear-gradient(
+    var(--tw-gradient-position, to top right in oklab),
+    var(--tw-gradient-from) 25%,
+    --alpha(var(--tw-gradient-to) / var(--opacity-dim-1)) 100%
+  );
+  background-color: --alpha(var(--color-surface) / 0);
+  background-blend-mode: overlay;
+}
+
+@utility u-filled-gradient-hovered {
+  background-color: --alpha(var(--color-surface) / var(--opacity-dim-4));
+}
+
+/*
+  u-tinted-gradient-*: A utility to apply a gradient to a background.
+  For elements whose background is using a *-container color.
+*/
+@utility u-tinted-gradient-* {
+  /* prettier-ignore */
+  --tw-gradient-from: --value(--color-*);
+  --tw-gradient-to: var(--color-surface);
+
+  background: linear-gradient(
+    var(--tw-gradient-position, to top right in oklab),
+    --alpha(var(--tw-gradient-from) / var(--opacity-dim-1)) 0%,
+    var(--tw-gradient-from) 25%,
+    --alpha(var(--tw-gradient-to) / var(--opacity-dim-4)) 100%
+  );
+  background-color: --alpha(var(--color-surface) / 0);
+  background-blend-mode: overlay;
+}
+
+@utility u-tinted-gradient-hovered {
+  background-color: --alpha(var(--color-surface) / var(--opacity-dim-2));
+}


### PR DESCRIPTION
### Description, Motivation and Context

API proposal for gradients in Spark components.

Added 2 utilities: 
- `@utility u-filled-gradient-*`
- `@utility u-tinted-gradient-*`

For both type of `design` that most Spark components supports: `filled` and `tinted`.

Those utilities will make sure gradients have minimal impact on contrast ratio between background and foreground/text.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Screenshots - Animations

https://github.com/user-attachments/assets/40fc61a2-c43d-4eb6-8f44-064388efbdde



