### PR TITLE
feat(components): toast component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,11 +15,13 @@ interface Props extends DocsContainerProps {
 
 const ExampleContainer = ({ children, ...props }: Props) => {
   const [shouldDisplayExperimentalBanner, setShouldDisplayExperimentalBanner] = useState(false)
+  const [shouldDisplaydeprecatedBanner, setShouldDisplayDeprecatedBanner] = useState(false)
 
   useEffect(() => {
     const primaryStoryTitle = props.context.componentStories()[0]?.title
 
     setShouldDisplayExperimentalBanner(primaryStoryTitle?.startsWith('Experimental') || false)
+    setShouldDisplayDeprecatedBanner(primaryStoryTitle?.startsWith('Deprecated') || false)
   }, [props.context?.channel])
 
   return (
@@ -31,6 +33,15 @@ const ExampleContainer = ({ children, ...props }: Props) => {
               <WarningOutline />
             </Icon>
             This component is still experimental. Avoid usage in production features
+          </p>
+        )}
+
+        {shouldDisplaydeprecatedBanner && (
+          <p className="gap-md py-sm px-lg z-sticky bg-alert-container text-on-alert-container border-l-alert sticky top-0 flex items-center border-l-[4px] font-bold">
+            <Icon size="lg" label="warning" intent="alert">
+              <WarningOutline />
+            </Icon>
+            This component is deprecated. Avoid usage in production features
           </p>
         )}
 

--- a/packages/components/src/snackbar/Snackbar.doc.mdx
+++ b/packages/components/src/snackbar/Snackbar.doc.mdx
@@ -1,6 +1,8 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
+import { Callout } from '@docs/helpers/Callout'
 import { Kbd } from '@spark-ui/components/kbd'
+import { TextLink } from '@spark-ui/components/text-link'
 import { Source } from '@storybook/addon-docs/blocks'
 
 import { Snackbar, addSnackbar } from '.'
@@ -9,7 +11,17 @@ import * as stories from './Snackbar.stories'
 
 <Meta of={stories} />
 
+<Callout kind="error" marginY="large">
+  <p>This component is deprecated. Use the <TextLink intent="info" href="/?path=/docs/components-toast--docs">Toast component</TextLink> instead.</p>
+  <ul>
+    <li>Snackbar could only display one toast at a time, Toast can display multiple toasts at the same time.</li>
+    <li>Toast has a more flexible API, allowing for more customization of the toast's content and behavior.</li>
+  </ul>
+</Callout>
+
 # Snackbar
+
+
 
 Display brief, temporary notifications of actions, errors, or other events in an application.
 

--- a/packages/components/src/snackbar/Snackbar.stories.tsx
+++ b/packages/components/src/snackbar/Snackbar.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '../button'
 import { addSnackbar, type AddSnackbarArgs, Snackbar } from '.'
 
 const meta: Meta<typeof Snackbar> = {
-  title: 'Components/Snackbar',
+  title: 'Deprecated/Snackbar',
   component: Snackbar,
   tags: ['overlays'],
   parameters: {

--- a/packages/components/src/toast/Toast.doc.mdx
+++ b/packages/components/src/toast/Toast.doc.mdx
@@ -1,0 +1,212 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks'
+import { A11yReport } from '@docs/helpers/A11yReport'
+import { AriaRoles } from '@docs/helpers/AriaRoles'
+import { Kbd } from '../kbd'
+import { ToastProvider, useToastManager } from '.'
+
+import * as stories from './Toast.stories'
+
+<Meta of={stories} />
+
+# Toast
+
+Generates toast notifications.
+
+
+<Canvas of={stories.Default} />
+
+## Install
+
+```sh
+npm install @spark-ui/components
+```
+
+## Anatomy
+
+This component is highly programmatic, you can use the `useToastManager` hook to manage the toast list programmatically.
+
+Be careful that the `ToastProvider` component must be used only once in your app, as it manages the toast list state.
+
+```tsx
+import { ToastProvider, ToastTrigger, useToastManager } from "@spark-ui/components/toast"
+
+export default () => (
+  <ToastProvider>
+    <ToastTrigger />
+  </ToastProvider>
+);
+```
+
+
+
+## API Reference
+
+### ToastProvider
+
+Provides a context for creating and managing toasts.
+
+<ArgTypes of={ToastProvider} />
+
+## useToastManager
+
+Manages toasts, called inside of a `ToastProvider`.
+
+### Return value
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>toasts</code></td>
+      <td><code>ToastObject[]</code></td>
+      <td>The array of toast objects.</td>
+    </tr>
+    <tr>
+      <td><code>add</code></td>
+      <td><code>(options: AddOptions) => string</code></td>
+      <td>Adds a new toast and returns its ID</td>
+    </tr>
+    <tr>
+      <td><code>update</code></td>
+      <td><code>(toastId: string, options: Partial&lt;AddOptions&gt;) => void</code></td>
+      <td>Updates an existing toast by ID</td>
+    </tr>
+    <tr>
+      <td><code>promise</code></td>
+      <td><code>&lt;Value&gt;(promise: Promise&lt;Value&gt;, options: PromiseOptions&lt;Value&gt;) => Promise&lt;Value&gt;</code></td>
+      <td>Handles promise-based toast notifications with loading, success, and error states</td>
+    </tr>
+    <tr>
+      <td><code>closeAll</code></td>
+      <td><code>() => void</code></td>
+      <td>Closes all active toasts</td>
+    </tr>
+  </tbody>
+</table>
+
+### Method options
+
+These are the options for the `add`, `update`, and `promise` methods.
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>title</code></td>
+      <td><code>string</code></td>
+      <td>The title of the toast.</td>
+    </tr>
+    <tr>
+      <td><code>description</code></td>
+      <td><code>string</code></td>
+      <td>The description of the toast.</td>
+    </tr>
+    <tr>
+      <td><code>timeout</code></td>
+      <td><code>number</code></td>
+      <td>The amount of time (in ms) before the toast is auto dismissed.</td>
+    </tr>
+    <tr>
+      <td><code>priority</code></td>
+      <td><code>'low' | 'high'</code></td>
+      <td>
+        <p><code>low</code> - The toast will be announced politely.</p>
+        <p><code>high</code> - The toast will be announced urgently.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>onClose</code></td>
+      <td><code>() => void</code></td>
+      <td>A callback invoked when the toast is closed.</td>
+    </tr>
+    <tr>
+      <td><code>onRemove</code></td>
+      <td><code>() => void</code></td>
+      <td>A callback invoked when the toast is removed from the list after animations complete when closed.</td>
+    </tr>
+    <tr>
+      <td><code>data.design</code></td>
+      <td><code>'filled' | 'tinted'</code></td>
+      <td>The design of the toast.</td>
+    </tr>
+    <tr>
+      <td><code>data.intent</code></td>
+      <td><code>'main' | 'support' | 'accent' | 'basic' | 'success' | 'alert' | 'error' | 'info' | 'neutral' | 'surface' | 'surfaceInverse'</code></td>
+      <td>The intent of the toast.</td>
+    </tr>
+    <tr>
+      <td><code>data.isClosable</code></td>
+      <td><code>boolean</code></td>
+      <td>Whether to display an extra close button.</td>
+    </tr>
+    <tr>
+      <td><code>data.action</code></td>
+      <td><code>`{ label: string; onClick: () => void }`</code></td>
+      <td>The action button configuration.</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Examples
+
+### add/update/close methods
+
+Manages toasts, called inside of a Toast.Provider.
+
+The `useToastManager` hook is used to manage the toast list programmatically.
+
+The following example showcases a toast that programatically:
+- opens itself.
+- updates it's description a few times to display a countdown  
+- closes itself when the countdown reaches 0.
+
+<Canvas of={stories.ToastManager} />
+
+### promise method
+
+An asynchronous toast can be created with three possible states: `loading`, `success`, and `error`. 
+The type string matches these states to change the styling. Each of the states also accepts the method options object for more granular control.
+
+<Canvas of={stories.WithPromise} />
+
+
+
+### Design and Intents
+
+This example showcases all available design variants (filled and tinted) combined with all intent colors.
+
+<Canvas of={stories.DesignAndIntents} />
+
+
+
+
+
+
+## Accessibility
+
+<A11yReport of="toast" />
+
+Adheres to the [Alert WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alert).
+
+### Keyboard Interactions
+
+- <Kbd>F6</Kbd>: Focuses snackbar region viewport.
+- <Kbd>Tab</Kbd>: Moves focus to the next focusable element.
+- <Kbd>Shift+Tab</Kbd>: Moves focus to the previous focusable element.
+- <Kbd>Enter</Kbd>: When focus is on a `Snackbar.ItemAction` or `Snackbar.ItemClose`, closes the
+  toast.
+- <Kbd>Space</Kbd>: When focus is on a `Snackbar.ItemAction` or `Snackbar.ItemClose`, closes the
+  toast.

--- a/packages/components/src/toast/Toast.stories.tsx
+++ b/packages/components/src/toast/Toast.stories.tsx
@@ -1,0 +1,160 @@
+import { Button } from '@spark-ui/components/button'
+import { AlertOutline } from '@spark-ui/icons/AlertOutline'
+import { Meta, StoryFn } from '@storybook/react-vite'
+
+import { ToastProvider, ToastTrigger, useToastManager } from '.'
+
+const meta: Meta<typeof ToastProvider> = {
+  title: 'Components/Toast',
+  component: ToastProvider,
+  tags: ['data-display'],
+  decorators: [
+    Story => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+}
+
+export default meta
+
+export const Default: StoryFn = () => {
+  return (
+    <ToastTrigger
+      title="Toast with action"
+      description="This toast contains an action button and can be closed. Use F6 to access it with the keyboard."
+      icon={<AlertOutline />}
+      action={{
+        close: true,
+        label: 'Cancel',
+        onClick: () => console.log('Action canceled'),
+      }}
+      asChild
+    >
+      <Button>Open a toast</Button>
+    </ToastTrigger>
+  )
+}
+
+export const DesignAndIntents: StoryFn = () => {
+  const intents = [
+    'success',
+    'alert',
+    'error',
+    'info',
+    'neutral',
+    'main',
+    'basic',
+    'support',
+    'accent',
+    'surface',
+    'surfaceInverse',
+  ]
+  const designs = ['filled', 'tinted']
+
+  return (
+    <div className="gap-md flex flex-wrap">
+      {intents.map(intent =>
+        designs.map(design => {
+          const buttonIntent = intent === 'error' ? 'danger' : intent
+
+          return (
+            <ToastTrigger
+              key={`${intent}-${design}`}
+              title={`Toast ${intent} ${design}`}
+              description={'Some content'}
+              intent={intent as any}
+              design={design as any}
+              action={{
+                close: true,
+                label: 'Cancel',
+                onClick: () => console.log('Action canceled'),
+              }}
+              asChild
+            >
+              <Button intent={buttonIntent as any} design={design as any}>
+                {intent} + {design}
+              </Button>
+            </ToastTrigger>
+          )
+        })
+      )}
+    </div>
+  )
+}
+
+export const ToastManager: StoryFn = () => {
+  const toastManager = useToastManager()
+
+  const toggleToast = () => {
+    if (toastManager.toasts.length === 0) {
+      const newToastId = toastManager.add({
+        title: 'Hello world!',
+        description: 'This toast will close in 5s',
+        timeout: 0,
+        data: {
+          intent: 'accent',
+        },
+      })
+
+      let countdown = 5
+      const id = setInterval(() => {
+        countdown--
+        if (countdown > 0) {
+          toastManager.update(newToastId, {
+            description: `This toast will close in ${countdown}s`,
+          })
+        } else {
+          toastManager.close(newToastId)
+          clearInterval(id)
+        }
+      }, 1000)
+    }
+  }
+
+  return (
+    <div>
+      <Button onClick={toggleToast}>Open toast</Button>
+    </div>
+  )
+}
+
+export const WithPromise: StoryFn = () => {
+  const toastManager = useToastManager()
+
+  function runPromise() {
+    toastManager.promise<string>(
+      // Simulate an API request with a promise that resolves after 2 seconds
+      new Promise((resolve, reject) => {
+        const shouldSucceed = Math.random() > 0.3 // 70% success rate
+        setTimeout(() => {
+          if (shouldSucceed) {
+            resolve('operation completed')
+          } else {
+            reject(new Error('operation failed'))
+          }
+        }, 2000)
+      }),
+      {
+        loading: { title: 'Loading data...', data: { design: 'tinted' } },
+        success: data => ({
+          title: `Success: ${data}`,
+          data: {
+            intent: 'success',
+            design: 'tinted',
+          },
+        }),
+        error: (err: Error) => ({
+          title: `Error: ${err.message}`,
+          data: {
+            intent: 'error',
+            design: 'tinted',
+          },
+        }),
+      }
+    )
+  }
+
+  return <Button onClick={runPromise}>Run Promise Toast</Button>
+}

--- a/packages/components/src/toast/Toast.styles.ts
+++ b/packages/components/src/toast/Toast.styles.ts
@@ -1,0 +1,202 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const toastStyles = cva(
+  [
+    'gap-lg p-lg flex w-max !w-[min(400px,calc(100vw-2rem))] flex-col rounded-lg',
+    'absolute right-0 bottom-0 left-auto mr-0',
+    'bg-clip-padding shadow-md select-none',
+    'focus-visible:ring-focus focus-visible:ring-2 focus-visible:outline-none',
+    'z-[calc(1000-var(--toast-index))]',
+    "after:absolute after:bottom-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-['']",
+    // Stack effect while not focused
+    '[transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+calc(min(var(--toast-index),10)*-16px)))_scale(calc(max(0,1-(var(--toast-index)*0.1))))]',
+    // Scale and translate
+    'ease-standard [transition-property:opacity,transform]',
+    'duration-400',
+    // Present when the toast is animating in.
+    'data-[starting-style]:[transform:translateY(150%)]',
+    // Expanded: Present when the toast is expanded in the viewport.
+    'data-[expanded]:[transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-offset-y)*-1+calc(var(--toast-index)*var(--gap)*-1)+var(--toast-swipe-movement-y)))]',
+    // Present when the toast is animating out.
+    'data-[ending-style]:duration-250',
+    'data-[ending-style]:opacity-0',
+    'data-[ending-style]:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]',
+    'data-[ending-style]:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]',
+    'data-[expanded]:data-[ending-style]:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]',
+    // Limited: Present when the toast was removed due to exceeding the limit.
+    'data-[limited]:opacity-0',
+  ],
+  {
+    variants: {
+      design: {
+        filled: '',
+        tinted: '',
+      },
+      intent: {
+        success: '',
+        alert: '',
+        error: '',
+        info: '',
+        neutral: '',
+        main: '',
+        basic: '',
+        support: '',
+        accent: '',
+        surface: '',
+        surfaceInverse: '',
+      },
+    },
+    compoundVariants: [
+      // Filled variants
+      {
+        design: 'filled',
+        intent: 'success',
+        class: ['bg-success text-on-success'],
+      },
+      {
+        design: 'filled',
+        intent: 'alert',
+        class: ['bg-alert text-on-alert'],
+      },
+      {
+        design: 'filled',
+        intent: 'error',
+        class: ['bg-error text-on-error'],
+      },
+      {
+        design: 'filled',
+        intent: 'info',
+        class: ['bg-info text-on-info'],
+      },
+      {
+        design: 'filled',
+        intent: 'neutral',
+        class: ['bg-neutral text-on-neutral'],
+      },
+      {
+        design: 'filled',
+        intent: 'main',
+        class: ['bg-main text-on-main'],
+      },
+      {
+        design: 'filled',
+        intent: 'basic',
+        class: ['bg-basic text-on-basic'],
+      },
+      {
+        design: 'filled',
+        intent: 'support',
+        class: ['bg-support text-on-support'],
+      },
+      {
+        design: 'filled',
+        intent: 'accent',
+        class: ['bg-accent text-on-accent'],
+      },
+      {
+        design: 'filled',
+        intent: 'surface',
+        class: ['bg-surface text-on-surface'],
+      },
+      {
+        design: 'filled',
+        intent: 'surfaceInverse',
+        class: ['bg-surface-inverse text-on-surface-inverse'],
+      },
+
+      // Tinted variants
+      {
+        design: 'tinted',
+        intent: 'success',
+        class: ['bg-success-container text-on-success-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'alert',
+        class: ['bg-alert-container text-on-alert-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'error',
+        class: ['bg-error-container text-on-error-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'info',
+        class: ['bg-info-container text-on-info-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'neutral',
+        class: ['bg-neutral-container text-on-neutral-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'main',
+        class: ['bg-main-container text-on-main-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'basic',
+        class: ['bg-basic-container text-on-basic-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'support',
+        class: ['bg-support-container text-on-support-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'accent',
+        class: ['bg-accent-container text-on-accent-container'],
+      },
+      {
+        design: 'tinted',
+        intent: 'surface',
+        class: ['bg-surface text-on-surface'],
+      },
+      {
+        design: 'tinted',
+        intent: 'surfaceInverse',
+        class: ['bg-surface-inverse text-on-surface-inverse'],
+      },
+    ],
+    defaultVariants: {
+      design: 'filled',
+      intent: 'neutral',
+    },
+  }
+)
+
+export const snackbarItemVariantContent = cva(
+  [
+    'inline-grid items-center',
+    'col-start-1 row-start-1',
+    'pl-md pr-lg', // applying padding on the parent prevents VoiceOver on Safari from reading snackbar content 🤷
+  ],
+  {
+    variants: {
+      /**
+       * Force action button displaying on a new line
+       * @default false
+       */
+      actionOnNewline: {
+        true: [
+          'grid-rows-[52px_1fr_52px]',
+          'grid-cols-[min-content_1fr_min-content]',
+          "[grid-template-areas:'icon_message_close'_'._message_.'_'action_action_action']",
+        ],
+        false: [
+          'grid-cols-[min-content_1fr_min-content_min-content]',
+          "[grid-template-areas:'icon_message_action_close']",
+        ],
+      },
+    },
+    defaultVariants: {
+      actionOnNewline: false,
+    },
+  }
+)
+
+export type ToastVariantProps = VariantProps<typeof toastStyles>
+export type SnackbarItemVariantContentProps = VariantProps<typeof snackbarItemVariantContent>

--- a/packages/components/src/toast/Toast.test.tsx
+++ b/packages/components/src/toast/Toast.test.tsx
@@ -1,0 +1,115 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ToastProvider, ToastTrigger, useToastManager } from '.'
+
+const DEFAULT_TIMEOUT = 5000
+
+const advanceTimers = (duration: number) => {
+  act(() => {
+    vi.advanceTimersByTime(duration)
+  })
+}
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('ToastTrigger', () => {
+    it('should render a toast and close it after the timeout', async () => {
+      // Given a basic toast
+      render(
+        <ToastProvider>
+          <ToastTrigger
+            asChild
+            title="Success"
+            description="You are now subscribed to our newsletter"
+          >
+            <button type="button">Show me a toast</button>
+          </ToastTrigger>
+        </ToastProvider>
+      )
+
+      expect(screen.queryByRole('dialog', { name: 'Success' })).not.toBeInTheDocument()
+
+      // When the user opens the toast
+      fireEvent.click(screen.getByText('Show me a toast'))
+
+      const toast = screen.getByRole('dialog', { name: 'Success' })
+
+      // Then the toast is opened and accessible
+      expect(toast).toBeInTheDocument()
+      expect(toast).toHaveAccessibleDescription('You are now subscribed to our newsletter')
+
+      // Given we wait 4999 milliseconds
+      advanceTimers(DEFAULT_TIMEOUT - 1)
+
+      // Then the toast should be opened still
+      expect(toast).toBeInTheDocument()
+
+      // Given we wait 1 millisecond
+      advanceTimers(1)
+
+      // Then the toast should be closed
+      expect(toast).not.toBeInTheDocument()
+    })
+  })
+
+  describe('useToastManager', () => {
+    describe('add', () => {
+      it('should render a toast programmatically and close it after the timeout', async () => {
+        const Implementation = () => {
+          const toastManager = useToastManager()
+
+          return (
+            <button
+              type="button"
+              onClick={() =>
+                toastManager.add({
+                  title: 'Success',
+                  description: 'You are now subscribed to our newsletter',
+                })
+              }
+            >
+              Show me a toast
+            </button>
+          )
+        }
+        // Given a basic toast
+        render(
+          <ToastProvider>
+            <Implementation />
+          </ToastProvider>
+        )
+
+        expect(screen.queryByRole('dialog', { name: 'Success' })).not.toBeInTheDocument()
+
+        // When the user opens the toast
+        fireEvent.click(screen.getByText('Show me a toast'))
+
+        const toast = screen.getByRole('dialog', { name: 'Success' })
+
+        // Then the toast is opened and accessible
+        expect(toast).toBeInTheDocument()
+        expect(toast).toHaveAccessibleDescription('You are now subscribed to our newsletter')
+
+        // Given we wait 4999 milliseconds
+        advanceTimers(DEFAULT_TIMEOUT - 1)
+
+        // Then the toast should be opened still
+        expect(toast).toBeInTheDocument()
+
+        advanceTimers(1)
+
+        // Then the toast should be closed
+        expect(toast).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/packages/components/src/toast/Toast.tsx
+++ b/packages/components/src/toast/Toast.tsx
@@ -1,0 +1,102 @@
+import { Toast as BaseToast } from '@base-ui-components/react/toast'
+import { Button, ButtonProps } from '@spark-ui/components/button'
+import { Icon } from '@spark-ui/components/icon'
+import { IconButton } from '@spark-ui/components/icon-button'
+import { Close } from '@spark-ui/icons/Close'
+import { cx } from 'class-variance-authority'
+
+import { toastStyles } from './Toast.styles'
+import type { ToastData, ToastDesign, ToastIntent, ToastObject } from './types'
+
+function getButtonIntent(intent?: ToastIntent): ButtonProps['intent'] {
+  if (intent === 'surfaceInverse') return 'surface'
+  if (intent === 'surface') return 'surfaceInverse'
+  if (intent === 'error') return 'danger'
+
+  return intent as ButtonProps['intent']
+}
+
+const getActionProps = (
+  action: ToastData['action'],
+  { toastDesign, toastIntent }: { toastDesign?: ToastDesign; toastIntent?: ToastIntent }
+): ButtonProps => {
+  if (!action) return {}
+
+  const { design, intent, className, onClick, ...rest } = action
+
+  return {
+    design: design ?? (toastDesign === 'filled' ? 'tinted' : 'filled'),
+    intent: intent ?? getButtonIntent(toastIntent),
+    className: cx('mt-md self-start', className),
+    onClick,
+    ...rest,
+  }
+}
+
+export function Toast({ toast }: { toast: ToastObject }) {
+  const {
+    icon: ToastIcon,
+    intent,
+    design,
+    action,
+    isClosable,
+    closeLabel = 'Close',
+  } = toast.data ?? {}
+
+  const ActionButton = action?.close ? BaseToast.Close : BaseToast.Action
+
+  const actionProps = getActionProps(action, {
+    toastDesign: design,
+    toastIntent: intent,
+  })
+
+  return (
+    <BaseToast.Root
+      key={toast.id}
+      swipeDirection={['down', 'right']}
+      toast={toast}
+      className={cx(
+        toastStyles({
+          design,
+          intent,
+        })
+      )}
+      style={{
+        ['--gap' as string]: 'var(--spacing-md)',
+        ['--offset-y' as string]:
+          'calc(var(--toast-offset-y) * -1 + (var(--toast-index) * var(--gap) * -1) + var(--toast-swipe-movement-y))',
+      }}
+    >
+      <div className="gap-lg flex items-center">
+        {ToastIcon && <Icon size="md">{ToastIcon}</Icon>}
+
+        <div className="gap-sm flex flex-col">
+          <BaseToast.Title className="text-headline-2" />
+          <BaseToast.Description className="text-body-1" />
+
+          {action && (
+            <ActionButton render={<Button {...actionProps} />}>{action.label}</ActionButton>
+          )}
+        </div>
+      </div>
+
+      {isClosable && (
+        <BaseToast.Close
+          className="top-sm right-sm absolute"
+          render={
+            <IconButton
+              aria-label={closeLabel}
+              design={design}
+              intent={getButtonIntent(intent)}
+              size="sm"
+            />
+          }
+        >
+          <Icon>
+            <Close />
+          </Icon>
+        </BaseToast.Close>
+      )}
+    </BaseToast.Root>
+  )
+}

--- a/packages/components/src/toast/index.tsx
+++ b/packages/components/src/toast/index.tsx
@@ -1,0 +1,92 @@
+import { Toast as BaseToast } from '@base-ui-components/react/toast'
+import { Slot } from '@spark-ui/components/slot'
+import { cx } from 'class-variance-authority'
+import * as React from 'react'
+
+import { Toast } from './Toast'
+import type { ToastData, ToastObject } from './types'
+import { useToastManager } from './useToastManager'
+
+export * from './types'
+
+function ToastList() {
+  const { toasts } = useToastManager()
+
+  return toasts.map(toast => <Toast key={toast.id} toast={toast} />)
+}
+
+interface ToastProviderProps extends React.ComponentProps<typeof BaseToast.Provider> {
+  children: React.ReactNode
+}
+
+export function ToastProvider({ children, limit = 3 }: ToastProviderProps) {
+  return (
+    <BaseToast.Provider limit={limit}>
+      <BaseToast.Portal>
+        <BaseToast.Viewport
+          className={cx(
+            'z-toast right-lg bottom-lg text-on-surfa- fixed top-auto mx-auto flex w-fit flex-col items-end'
+          )}
+        >
+          <ToastList />
+        </BaseToast.Viewport>
+      </BaseToast.Portal>
+      {children}
+    </BaseToast.Provider>
+  )
+}
+
+interface ToastTriggerProps
+  extends React.ComponentPropsWithRef<'button'>,
+    Pick<ToastObject, 'priority'>,
+    Pick<ToastData, 'design' | 'intent' | 'icon' | 'isClosable' | 'action'> {
+  children: React.ReactNode
+  asChild?: boolean
+  title: string
+  description?: string
+  timeout?: number
+}
+
+export function ToastTrigger({
+  children,
+  onClick,
+  asChild = false,
+  title,
+  description,
+  timeout = 5000,
+  design = 'filled',
+  intent = 'neutral',
+  isClosable = true,
+  icon,
+  action,
+  priority = 'low',
+}: ToastTriggerProps) {
+  const toastManager = BaseToast.useToastManager()
+
+  const Component = asChild ? Slot : 'button'
+
+  function createToast(e: React.MouseEvent<HTMLButtonElement>) {
+    onClick?.(e)
+    toastManager.add({
+      title,
+      description,
+      timeout,
+      priority,
+      data: {
+        design,
+        intent,
+        isClosable,
+        ...(icon && { icon }),
+        action,
+      },
+    })
+  }
+
+  return (
+    <Component {...(!asChild && { type: 'button' })} onClick={createToast}>
+      {children}
+    </Component>
+  )
+}
+
+export { useToastManager }

--- a/packages/components/src/toast/types.ts
+++ b/packages/components/src/toast/types.ts
@@ -1,0 +1,55 @@
+import { Toast as BaseToast } from '@base-ui-components/react/toast'
+import { ButtonProps } from '@spark-ui/components/button'
+import * as React from 'react'
+
+export type ToastIntent =
+  | 'main'
+  | 'support'
+  | 'accent'
+  | 'basic'
+  | 'success'
+  | 'alert'
+  | 'error'
+  | 'info'
+  | 'neutral'
+  | 'surface'
+  | 'surfaceInverse'
+
+export type ToastDesign = 'tinted' | 'filled'
+
+export interface ToastData {
+  icon?: React.ReactNode
+  design?: ToastDesign
+  intent?: ToastIntent
+  isClosable?: boolean
+  closeLabel?: string
+  action?: {
+    close?: boolean
+    label: string
+    onClick: () => void
+  } & ButtonProps
+}
+
+export type ToastObject = BaseToast.Root.ToastObject<ToastData>
+
+interface AddOptions extends Omit<ToastObject, 'id' | 'animation' | 'height' | 'ref' | 'limited'> {
+  id?: string
+}
+
+type UpdateOptions = Partial<AddOptions>
+
+interface PromiseOptions<Value> {
+  loading: string | UpdateOptions
+  success: string | UpdateOptions | ((result: Value) => string | UpdateOptions)
+  error: string | UpdateOptions | ((error: any) => string | UpdateOptions)
+}
+
+// extends Omit<BaseToast.useToastManager.ReturnValue, 'promise'>
+export interface UseToastManagerReturnValue {
+  toasts: ToastObject[]
+  add: (options: AddOptions) => string
+  update: (toastId: string, options: UpdateOptions) => void
+  close: (toastId: string) => void
+  promise: <Value>(promise: Promise<Value>, options: PromiseOptions<Value>) => Promise<Value>
+  closeAll: () => void
+}

--- a/packages/components/src/toast/useRenderSlot.tsx
+++ b/packages/components/src/toast/useRenderSlot.tsx
@@ -1,0 +1,7 @@
+import { Slot } from '../slot'
+
+export function useRenderSlot(asChild: boolean, defaultTag: string) {
+  const Component = asChild ? Slot : defaultTag
+
+  return asChild ? ({ ...props }) => <Component {...props} /> : undefined
+}

--- a/packages/components/src/toast/useToastManager.ts
+++ b/packages/components/src/toast/useToastManager.ts
@@ -1,0 +1,17 @@
+import { Toast as BaseToast } from '@base-ui-components/react/toast'
+import * as React from 'react'
+
+import type { UseToastManagerReturnValue } from './types'
+
+export function useToastManager(): UseToastManagerReturnValue {
+  const baseToastManager = BaseToast.useToastManager()
+
+  const closeAll = React.useCallback((): void => {
+    baseToastManager.toasts.forEach(({ id }) => baseToastManager.close(id))
+  }, [baseToastManager])
+
+  return {
+    ...baseToastManager,
+    closeAll,
+  }
+}


### PR DESCRIPTION
### Description, Motivation and Context

`Toast` component, based on Base UI Toast: https://base-ui.com/react/components/toast

This component will replace `Snackbar` which I will deprecate. Instead of updating Snackbar I prefer to ship this new component and avoid a breaking change. 

It's programmatic approach is more flexible and allows to update a specific toast internal state programatically.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
