### PR TITLE
fix(components): align stepper base flex behavior with input

### DIFF
--- a/packages/components/src/stepper/Input.tsx
+++ b/packages/components/src/stepper/Input.tsx
@@ -15,7 +15,7 @@ export const Input = ({ className, ...props }: Props) => {
       data-spark-component="stepper-input"
       className={cx(
         // Base styles
-        'bg-surface text-on-surface h-sz-44 border-y-sm border-outline text-center',
+        'bg-surface text-on-surface px-lg h-sz-44 border-y-sm border-outline relative inline-flex w-full text-center',
         'first:border-l-sm first:rounded-l-lg',
         'last:border-r-sm last:rounded-r-lg',
         // State styles

--- a/packages/components/src/stepper/Root.tsx
+++ b/packages/components/src/stepper/Root.tsx
@@ -38,7 +38,10 @@ export const Root = ({
       {...(field.id && { id: field.id })}
       {...props}
     >
-      <NumberField.Group className={cx('group flex', className)} data-field-state={state}>
+      <NumberField.Group
+        className={cx('group relative inline-flex w-full', className)}
+        data-field-state={state}
+      >
         {children}
       </NumberField.Group>
     </NumberField.Root>

--- a/packages/components/src/stepper/Stepper.stories.tsx
+++ b/packages/components/src/stepper/Stepper.stories.tsx
@@ -1,3 +1,4 @@
+import { Input } from '@spark-ui/components/input'
 import { Tag } from '@spark-ui/components/tag'
 import { ArrowHorizontalDown } from '@spark-ui/icons/ArrowHorizontalDown'
 import { ArrowHorizontalUp } from '@spark-ui/icons/ArrowHorizontalUp'
@@ -96,6 +97,7 @@ export const Standalone: StoryFn = _args => (
       <Stepper>
         <Stepper.Input aria-label="Stepper without buttons" />
       </Stepper>
+      <Input aria-label="Stepper without buttons" />
     </div>
 
     <div>
@@ -105,7 +107,7 @@ export const Standalone: StoryFn = _args => (
         <Stepper.IncrementButton aria-label="Increment" />
       </Stepper>
     </div>
-    <div>
+    <div className="gap-md flex flex-col">
       <Tag className="mb-md flex">Decrement button only</Tag>
       <Stepper>
         <Stepper.DecrementButton aria-label="Decrement" />


### PR DESCRIPTION
### Description, Motivation and Context

Previous version of Stepper was derived from `InputGroup` and inherited its default styles, such as `inline-flex, w-full`.

The new version of the Stepper is decoupled from `InputGroup` and had its own styles, which introduced some visual regression on users codebases. The goal of this PR is to add the missing styles that allows it to not break existing implementations.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
