### PR TITLE
fix(components): fixed drawer page crashing

### DIFF
--- a/packages/components/src/drawer/Drawer.doc.mdx
+++ b/packages/components/src/drawer/Drawer.doc.mdx
@@ -107,12 +107,6 @@ To use inside of Popover.Content. Sticky footer to be rendered in the open drawe
 
 <ArgTypes of={Drawer.Footer} /> 
 
-### _.Close
-
-An abstract button that closes the drawer, meant for usage inside the content to attach closing behavior to.
-
-<ArgTypes of={Drawer.Close} />
-
 ### _.CloseButton
 
 An icon button with a cross icon that closes the drawer and is located in the top right corner of the drawer.

--- a/packages/components/src/skeleton/Skeleton.doc.mdx
+++ b/packages/components/src/skeleton/Skeleton.doc.mdx
@@ -26,9 +26,9 @@ import { Skeleton } from '@spark-ui/components/skeleton'
 
 export default () => (
   <Skeleton>
-    <Accordion.Rectangle />
-    <Accordion.Circle />
-    <Accordion.Line />
+    <Skeleton.Rectangle />
+    <Skeleton.Circle />
+    <Skeleton.Line />
   </Skeleton>
 );
 ```


### PR DESCRIPTION
Closes #2842 

### Description, Motivation and Context

- Invalid reference of `Accordion` in the Skeleton documentation.
- Invalid use of `ArgTypes` on `Drawer.Close` (no longer exposed) was crashing the page.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧾 Documentation
