### PR TITLE
fix(components): cursor pointer on chip clear buttons

### DIFF
--- a/packages/components/src/chip/ChipClearButton.styles.tsx
+++ b/packages/components/src/chip/ChipClearButton.styles.tsx
@@ -63,6 +63,9 @@ export const chipClearButtonStyles = cva(
         false: ['cursor-pointer'],
       },
     },
+    defaultVariants: {
+      disabled: false,
+    },
   }
 )
 


### PR DESCRIPTION
### Description, Motivation and Context

`disabled` attribute applies `cursor-pointer` when `false`, but its default value was `undefined` so the class was not applied.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
