### PR TITLE
fix(components): keep placeholder in multiple combobox

### DIFF
--- a/packages/components/src/combobox/ComboboxContext.tsx
+++ b/packages/components/src/combobox/ComboboxContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 /* eslint-disable max-lines-per-function */
 import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/hooks/use-combined-state'
@@ -28,6 +27,7 @@ export interface ComboboxContextState extends DownshiftState {
   filteredItemsMap: ItemsMap
   highlightedItem: ComboboxItem | undefined
   hasPopover: boolean
+  areSelectedItemsInTrigger: boolean
   multiple: boolean
   disabled: boolean
   readOnly: boolean
@@ -35,6 +35,7 @@ export interface ComboboxContextState extends DownshiftState {
   state?: 'error' | 'alert' | 'success'
   lastInteractionType: 'mouse' | 'keyboard'
   setHasPopover: Dispatch<SetStateAction<boolean>>
+  setAreSelectedItemsInTrigger: Dispatch<SetStateAction<boolean>>
   setLastInteractionType: (type: 'mouse' | 'keyboard') => void
   setOnInputValueChange: Dispatch<SetStateAction<((v: string) => void) | null>>
   innerInputRef: RefObject<HTMLInputElement | null>
@@ -246,6 +247,9 @@ export const ComboboxProvider = ({
   const [hasPopover, setHasPopover] = useState<boolean>(
     hasChildComponent(children, 'Combobox.Popover')
   )
+
+  const [areSelectedItemsInTrigger, setAreSelectedItemsInTrigger] = useState(false)
+
   const [lastInteractionType, setLastInteractionType] = useState<'mouse' | 'keyboard'>('mouse')
 
   useEffect(() => {
@@ -426,6 +430,8 @@ export const ComboboxProvider = ({
         multiple,
         disabled,
         readOnly,
+        areSelectedItemsInTrigger,
+        setAreSelectedItemsInTrigger,
         hasPopover,
         setHasPopover,
         state,

--- a/packages/components/src/combobox/ComboboxInput.tsx
+++ b/packages/components/src/combobox/ComboboxInput.tsx
@@ -89,7 +89,9 @@ export const Input = ({
     ref: inputRef,
   })
 
-  const hasPlaceholder = ctx.multiple ? ctx.selectedItems.length === 0 : ctx.selectedItem === null
+  const hasPlaceholder = ctx.multiple
+    ? !ctx.areSelectedItemsInTrigger || ctx.selectedItems.length === 0
+    : ctx.selectedItem === null
 
   function mergeHandlers<T extends SyntheticEvent>(
     handlerA?: (event: T) => void,

--- a/packages/components/src/combobox/ComboboxTrigger.tsx
+++ b/packages/components/src/combobox/ComboboxTrigger.tsx
@@ -55,6 +55,11 @@ export const Trigger = ({ className, children, ref: forwardedRef }: TriggerProps
 
   useWidthIncreaseCallback(scrollableAreaRef, scrollToRight)
 
+  const hasSelectedItems = !!selectedItems
+  useEffect(() => {
+    ctx.setAreSelectedItemsInTrigger(hasSelectedItems)
+  }, [hasSelectedItems])
+
   useEffect(() => {
     const resizeObserver = new ResizeObserver(scrollToRight)
 

--- a/packages/components/src/combobox/tests/multipleSelection.test.tsx
+++ b/packages/components/src/combobox/tests/multipleSelection.test.tsx
@@ -373,6 +373,47 @@ describe('Combobox', () => {
       expect(getItem('Pride and Prejudice')).toHaveAttribute('aria-selected', 'true')
     })
 
+    describe('placeholder', () => {
+      it('should hide placeholder with selected items in trigger', () => {
+        render(
+          <Combobox multiple value={['book-1']}>
+            <Combobox.Trigger>
+              <Combobox.SelectedItems />
+              <Combobox.Input aria-label="Book" placeholder="Pick a book" />
+            </Combobox.Trigger>
+            <Combobox.Popover>
+              <Combobox.Items>
+                <Combobox.Item value="book-1">War and Peace</Combobox.Item>
+                <Combobox.Item value="book-2">1984</Combobox.Item>
+                <Combobox.Item value="book-3">Pride and Prejudice</Combobox.Item>
+              </Combobox.Items>
+            </Combobox.Popover>
+          </Combobox>
+        )
+
+        expect(getInput('Book')).not.toHaveAttribute('placeholder')
+      })
+
+      it('should display placeholder without selected items in trigger', () => {
+        render(
+          <Combobox multiple value={['book-1']}>
+            <Combobox.Trigger>
+              <Combobox.Input aria-label="Book" placeholder="Pick a book" />
+            </Combobox.Trigger>
+            <Combobox.Popover>
+              <Combobox.Items>
+                <Combobox.Item value="book-1">War and Peace</Combobox.Item>
+                <Combobox.Item value="book-2">1984</Combobox.Item>
+                <Combobox.Item value="book-3">Pride and Prejudice</Combobox.Item>
+              </Combobox.Items>
+            </Combobox.Popover>
+          </Combobox>
+        )
+
+        expect(getInput('Book')).toHaveAttribute('placeholder', 'Pick a book')
+      })
+    })
+
     describe('blur behaviour', () => {
       it('should not clear input value when custom value is allowed', async () => {
         const user = userEvent.setup()


### PR DESCRIPTION
when selected items chips are not rendered inside the combobox, placeholder should remain visible

<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [LBCSPARK-502](https://jira.ets.mpi-internal.com/browse/LBCSPARK-502)

### Description, Motivation and Context

Currently, when a multiple selection combobox is not using `SelectedItems`, the placeholder is still hidden. 
It should be hidden only when `SelectedItems` is rendered with the combobox trigger to make room for the individual selected values chips, but not when it has room to be displayed.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
