### PR TITLE
feat(theme-utils): introducing surface-dark color token

### DIFF
--- a/documentation/helpers/TokenPreview/index.tsx
+++ b/documentation/helpers/TokenPreview/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 export const getCssVariable = (varName: string) =>
   getComputedStyle(document.documentElement).getPropertyValue(varName)
 
@@ -25,7 +26,7 @@ export const ColorPreview = ({ bg }: { bg: string }) => {
 }
 
 export const BackgroundColorPreview = () => {
-  const bgColors = {
+  const mainColors = {
     'bg-main': {
       token: '--color-main',
       styles: 'bg-main text-on-main hover:bg-main-hovered',
@@ -58,6 +59,9 @@ export const BackgroundColorPreview = () => {
       token: '--color-basic-container',
       styles: 'bg-basic-container text-on-basic-container hover:bg-basic-container-hovered',
     },
+  }
+
+  const feedBackColors = {
     'bg-success': {
       token: '--color-success',
       styles: 'bg-success text-on-success hover:bg-success-hovered',
@@ -98,6 +102,18 @@ export const BackgroundColorPreview = () => {
       token: '--color-neutral-container',
       styles: 'bg-neutral-container text-on-neutral-container hover:bg-neutral-container-hovered',
     },
+  }
+
+  const baseColors = {
+    'bg-background': {
+      token: '--color-background',
+      styles: 'bg-background text-on-background hover:bg-background-hovered',
+    },
+    'bg-background-variant': {
+      token: '--color-background-variant',
+      styles:
+        'bg-background-variant text-on-background-variant hover:bg-background-variant-hovered',
+    },
     'bg-surface': {
       token: '--color-surface',
       styles: 'bg-surface text-on-surface hover:bg-surface-hovered',
@@ -106,18 +122,63 @@ export const BackgroundColorPreview = () => {
       token: '--color-surface-container',
       styles: 'bg-surface-container text-on-surface-container hover:bg-surface-container-hovered',
     },
+    'bg-surface-inverse': {
+      token: '--color-surface-inverse',
+      styles: 'bg-surface-inverse text-on-surface-inverse hover:bg-surface-inverse-hovered',
+    },
+    'bg-surface-dark': {
+      token: '--color-surface-dark',
+      styles: 'bg-surface-dark text-on-surface-dark hover:bg-surface-dark-hovered',
+    },
   }
 
   return (
-    <div className="sb-unstyled">
-      <div className="gap-lg grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] flex-wrap">
-        {Object.entries(bgColors).map(([bg, { token, styles }]) => (
-          <div className="gap-sm flex flex-col">
-            <div className={`w-sz-160 h-sz-56 relative rounded-lg shadow-sm ${styles}`}></div>
-            <p className="text-body-1">{bg}</p>
-            <p className="text-body-2 opacity-dim-1">{getCssVariable(token)}</p>
-          </div>
-        ))}
+    <div className="sb-unstyled gap-lg flex flex-col">
+      <div className="border-sm border-outline p-lg gap-lg flex flex-col rounded-lg">
+        <p>
+          Main colors represent the visual identity of your theme and should be vivid/strong. They
+          are used for important elements of your interfaces, such as the main call to actions and
+          elements that makes your website identity (logo, illustrations, etc)
+        </p>
+        <div className="gap-lg grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] flex-wrap">
+          {Object.entries(mainColors).map(([bg, { token, styles }]) => (
+            <div className="gap-sm flex flex-col">
+              <div className={`w-sz-160 h-sz-56 relative rounded-lg shadow-sm ${styles}`}></div>
+              <p className="text-body-1">{bg}</p>
+              <p className="text-body-2 opacity-dim-1">{getCssVariable(token)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-sm border-outline p-lg gap-lg flex flex-col rounded-lg">
+        <p>Use Feedback colors to clearly convey an intent status.</p>
+        <div className="gap-lg grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] flex-wrap">
+          {Object.entries(feedBackColors).map(([bg, { token, styles }]) => (
+            <div className="gap-sm flex flex-col">
+              <div className={`w-sz-160 h-sz-56 relative rounded-lg shadow-sm ${styles}`}></div>
+              <p className="text-body-1">{bg}</p>
+              <p className="text-body-2 opacity-dim-1">{getCssVariable(token)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-sm border-outline p-lg gap-lg flex flex-col rounded-lg">
+        <p>
+          Use Base colors as the foundation for surfaces, backgrounds, text, and separators within
+          the UI. These colors are fundamental in defining its overall aesthetic and readability.
+        </p>
+
+        <div className="gap-lg grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] flex-wrap">
+          {Object.entries(baseColors).map(([bg, { token, styles }]) => (
+            <div className="gap-sm flex flex-col">
+              <div className={`w-sz-160 h-sz-56 relative rounded-lg shadow-sm ${styles}`}></div>
+              <p className="text-body-1">{bg}</p>
+              <p className="text-body-2 opacity-dim-1">{getCssVariable(token)}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/packages/utils/theme/src/dark-theme-more-contrast.css
+++ b/packages/utils/theme/src/dark-theme-more-contrast.css
@@ -84,6 +84,9 @@
   --color-surface-inverse: #f9f9f9;
   --color-on-surface-inverse: #1a1a1a;
   --color-surface-inverse-hovered: #e1e1e1;
+  --color-surface-dark: #2c2c2c;
+  --color-on-surface-dark: #f9f9f9;
+  --color-surface-dark-hovered: #000000;
 
   --color-outline: #c1c1c1;
   --color-outline-high: #f9f9f9;

--- a/packages/utils/theme/src/dark-theme.css
+++ b/packages/utils/theme/src/dark-theme.css
@@ -1,11 +1,13 @@
 [data-theme='dark'] {
   --color-focus: #d1d1ff;
+
   --color-basic: #c2e0fa;
   --color-on-basic: #152233;
   --color-basic-hovered: #9fcef7;
   --color-basic-container: #094171;
   --color-on-basic-container: #f4f9fe;
   --color-basic-container-hovered: #152233;
+
   --color-accent: #cfa3f5;
   --color-on-accent: #1b052e;
   --color-accent-hovered: #ac7ddd;
@@ -15,6 +17,7 @@
   --color-accent-variant: #b775f0;
   --color-on-accent-variant: #1b052e;
   --color-accent-variant-hovered: #b775f0;
+
   --color-main: #f07b42;
   --color-on-main: #2f1305;
   --color-main-hovered: #ec5a13;
@@ -24,6 +27,7 @@
   --color-main-variant: #f49d71;
   --color-on-main-variant: #2f1305;
   --color-main-variant-hovered: #f07b42;
+
   --color-support: #c2e0fa;
   --color-on-support: #152233;
   --color-support-hovered: #9fcef7;
@@ -33,46 +37,57 @@
   --color-support-variant: #e6f2fd;
   --color-on-support-variant: #152233;
   --color-support-variant-hovered: #c2e0fa;
+
   --color-success: #8ecdae;
   --color-on-success: #0c291b;
   --color-success-hovered: #64bc90;
   --color-success-container: #1d6340;
   --color-on-success-container: #f5fbf8;
   --color-success-container-hovered: #14422b;
+
   --color-alert: #ffcc66;
   --color-on-alert: #332200;
   --color-alert-hovered: #ffbb33;
   --color-alert-container: #664400;
   --color-on-alert-container: #fff6e5;
   --color-alert-container-hovered: #332200;
+
   --color-error: #e8867d;
   --color-on-error: #2b0b08;
   --color-error-hovered: #e05d52;
   --color-error-container: #822017;
   --color-on-error-container: #fbeceb;
   --color-error-container-hovered: #57150f;
+
   --color-info: #9fcef7;
   --color-on-info: #152233;
   --color-info-hovered: #69b2f3;
   --color-info-container: #0c5291;
   --color-on-info-container: #f4f9fe;
   --color-info-container-hovered: #094171;
+
   --color-neutral: #d0d7df;
   --color-on-neutral: #202730;
   --color-neutral-hovered: #acb8c7;
   --color-neutral-container: #3a4757;
   --color-on-neutral-container: #f6f8f9;
   --color-neutral-container-hovered: #2b3441;
+
   --color-background: #202730;
   --color-on-background: #f6f8f9;
   --color-background-variant: #13171d;
   --color-on-background-variant: #f6f8f9;
+
   --color-surface: #202730;
   --color-on-surface: #f6f8f9;
   --color-surface-hovered: #2b3441;
   --color-surface-inverse: #f6f8f9;
   --color-on-surface-inverse: #2b3441;
   --color-surface-inverse-hovered: #f0f2f5;
+  --color-surface-dark: #202730;
+  --color-on-surface-dark: #f6f8f9;
+  --color-surface-dark-hovered: #2b3441;
+
   --color-outline: #6c819d;
   --color-outline-high: #f0f2f5;
   --color-overlay: #3a4757;

--- a/packages/utils/theme/src/light-theme-more-contrast.css
+++ b/packages/utils/theme/src/light-theme-more-contrast.css
@@ -83,6 +83,9 @@
   --color-surface-inverse: #1a1a1a;
   --color-on-surface-inverse: #f9f9f9;
   --color-surface-inverse-hovered: #3a3a3a;
+  --color-surface-dark: #1a1a1a;
+  --color-on-surface-dark: #f9f9f9;
+  --color-surface-dark-hovered: #3a3a3a;
 
   --color-outline: #4f4f4f;
   --color-outline-high: #000000;

--- a/packages/utils/theme/src/light-theme.css
+++ b/packages/utils/theme/src/light-theme.css
@@ -73,6 +73,9 @@
   --color-surface-inverse: #2b3441;
   --color-on-surface-inverse: #ffffff;
   --color-surface-inverse-hovered: #3a4757;
+  --color-surface-dark: #2b3441;
+  --color-on-surface-dark: #ffffff;
+  --color-surface-dark-hovered: #3a4757;
   --color-outline: #acb8c7;
   --color-outline-high: #202730;
   --color-overlay: #202730;

--- a/packages/utils/theme/src/theme.css
+++ b/packages/utils/theme/src/theme.css
@@ -114,6 +114,9 @@
   --color-surface-inverse: #2b3441;
   --color-on-surface-inverse: #ffffff;
   --color-surface-inverse-hovered: #3a4757;
+  --color-surface-dark: #2b3441;
+  --color-on-surface-dark: #ffffff;
+  --color-surface-dark-hovered: #3a4757;
   --color-outline: #acb8c7;
   --color-outline-high: #202730;
   --color-overlay: #202730;


### PR DESCRIPTION
### Description, Motivation and Context

An issue with the current `surface-inverse` token is that it is supposed to contrast strongly against `surface`, meaning:
- in light theme, `surface` is light and `surface-inverse` is dark.
- in dark theme `surface` is dark and `surface-inverse` is light.

On a page in dark theme, a large area using `surface-inverse` is too bright, which cancels the benefits of having a dark mode.

Introducing `surface-dark` solves this issue by offering a surface (background) that is dark in both `light` and `dark` themes.


### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles


