### PR TITLE
fix: revert esm build only

### DIFF
--- a/config/component.ts
+++ b/config/component.ts
@@ -1,0 +1,50 @@
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+
+import terser from '@rollup/plugin-terser'
+import react from '@vitejs/plugin-react'
+import browserslistToEsbuild from 'browserslist-to-esbuild'
+import dts from 'vite-plugin-dts'
+
+import sparkDocgen from './plugins/sparkDocgen'
+
+const require = createRequire(import.meta.url)
+
+const rootPkg = require('../package.json')
+const rootDeps = Object.keys(rootPkg.dependencies || {})
+const rootDevDeps = Object.keys(rootPkg.devDependencies || {})
+
+export function buildComponentConfig(
+  path: string,
+  preserveModules: boolean,
+  external: string[] = []
+) {
+  const pkg = require(join(path, '/package.json'))
+  const deps = [...Object.keys(pkg.dependencies || {}), ...external]
+  const devDeps = Object.keys(pkg.devDependencies || {})
+
+  return {
+    build: {
+      target: browserslistToEsbuild(),
+      lib: {
+        entry: 'src/index.ts',
+        formats: ['es', 'cjs'],
+        fileName: '[name]',
+      },
+      rollupOptions: {
+        external: [...deps, ...rootDeps, ...devDeps, ...rootDevDeps],
+        plugins: [terser(), sparkDocgen()],
+        preserveModules,
+      },
+    },
+    plugins: [
+      dts({
+        /** To avoid bundling types into a package/components folder inside of dist */
+        entryRoot: './src',
+      }),
+      react({
+        jsxRuntime: 'classic',
+      }),
+    ],
+  }
+}

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,0 +1,17 @@
+import merge from 'deepmerge'
+
+import { buildComponentConfig } from './component'
+
+export function getComponentConfiguration(path: string, name: string, options: any = {}) {
+  return getConfiguration(
+    buildComponentConfig(path, options.preserveModules, options.external),
+    options,
+    name
+  )
+}
+
+function getConfiguration(configuration: Record<string, unknown>, options = {}, name?: string) {
+  const result = merge.all([configuration, name ? { build: { lib: { name } } } : {}, options], {})
+
+  return result
+}

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -10,7 +10,7 @@ import {
 export default defineConfig(() => {
   return {
     entryPoints: ['src/*/index.(ts|tsx)'],
-    format: ['esm'],
+    format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
     external: ['react', '@spark-ui/components/form-field'],

--- a/packages/hooks/tsup.config.ts
+++ b/packages/hooks/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig(() => {
   return {
     entryPoints: ['src/*/index.(ts|tsx)'],
-    format: ['esm'],
+    format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
     external: ['react'],

--- a/packages/icons/tsup.config.ts
+++ b/packages/icons/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig(options => ({
   entryPoints: ['src/index.(ts|tsx)', 'src/icons/*.(ts|tsx)'],
-  format: ['esm'],
+  format: ['cjs', 'esm'],
   dts: true,
   sourcemap: true,
   external: ['react'],

--- a/packages/utils/cli/src/generate/templates/util/[vite.config.ts].js
+++ b/packages/utils/cli/src/generate/templates/util/[vite.config.ts].js
@@ -7,7 +7,7 @@ export default {
     target: browserslistToEsbuild(),
     lib: {
       entry: 'src/index.ts',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
       fileName: 'index',
     },
     rollupOptions: {

--- a/packages/utils/internal-utils/package.json
+++ b/packages/utils/internal-utils/package.json
@@ -2,15 +2,6 @@
   "name": "@spark-ui/internal-utils",
   "version": "11.1.0",
   "description": "package for sharing reusable code and resources across the codebase",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
-    }
-  },
   "publishConfig": {
     "access": "public"
   },
@@ -19,6 +10,9 @@
     "util",
     "utility"
   ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "vite build"
   },

--- a/packages/utils/internal-utils/vite.config.ts
+++ b/packages/utils/internal-utils/vite.config.ts
@@ -12,7 +12,7 @@ export default async () => {
       target: browserslistToEsbuild.default(),
       lib: {
         entry: 'src/index.ts',
-        formats: ['es'],
+        formats: ['es', 'cjs'],
         fileName: 'index',
       },
       rollupOptions: {


### PR DESCRIPTION
Reverts leboncoin/spark-web#2855

There is an issue with the ESM build making Spark import statement incompatible with Jest (CJS only), we can't delete ESM now as consumers still rely on it.