### PR TITLE
fix(components): render toast title as desc when desc is missing

### DIFF
--- a/packages/components/src/toast/Toast.tsx
+++ b/packages/components/src/toast/Toast.tsx
@@ -71,7 +71,7 @@ export function Toast({ toast }: { toast: ToastObject }) {
         {ToastIcon && <Icon size="md">{ToastIcon}</Icon>}
 
         <div className="gap-sm flex flex-col">
-          <BaseToast.Title className="text-headline-2" />
+          <BaseToast.Title className={toast.description ? 'text-headline-2' : 'text-body-1'} />
           <BaseToast.Description className="text-body-1" />
 
           {action && (


### PR DESCRIPTION
### Description, Motivation and Context

Because description is optional, title should have the styles of the description when description is not used.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
