### PR TITLE
feat(components): toast compact mode

### DIFF
--- a/packages/components/src/toast/Toast.doc.mdx
+++ b/packages/components/src/toast/Toast.doc.mdx
@@ -152,6 +152,11 @@ These are the options for the `add`, `update`, and `promise` methods.
       <td>Whether to display an extra close button.</td>
     </tr>
     <tr>
+      <td><code>data.compact</code></td>
+      <td><code>boolean</code></td>
+      <td>When <code>true</code>, displays the action button and close button inline to the right of the toast instead of vertically stacked.</td>
+    </tr>
+    <tr>
       <td><code>data.action</code></td>
       <td><code>`{ label: string; onClick: () => void }`</code></td>
       <td>The action button configuration.</td>
@@ -189,6 +194,12 @@ The type string matches these states to change the styling. Each of the states a
 This example showcases all available design variants (filled and tinted) combined with all intent colors.
 
 <Canvas of={stories.DesignAndIntents} />
+
+### Compact Layout
+
+When `data.compact` is set to `true`, the toast uses a compact layout where the action button and close button are displayed inline to the right of the toast content, rather than stacked vertically. This is useful for toasts with shorter content where you want to maximize horizontal space efficiency.
+
+<Canvas of={stories.Compact} />
 
 
 

--- a/packages/components/src/toast/Toast.stories.tsx
+++ b/packages/components/src/toast/Toast.stories.tsx
@@ -175,3 +175,49 @@ export const WithPromise: StoryFn = () => {
 
   return <Button onClick={runPromise}>Run Promise Toast</Button>
 }
+
+export const Compact: StoryFn = () => {
+  const toastManager = useToastManager()
+
+  const openCompactToast = () => {
+    toastManager.add({
+      title: 'Compact toast',
+      description: 'This toast uses the compact layout with inline action and close buttons.',
+      timeout: 0,
+      data: {
+        isClosable: true,
+        compact: true,
+        icon: <AlertOutline />,
+        action: {
+          close: true,
+          label: 'Undo',
+          onClick: () => console.log('Action clicked'),
+        },
+      },
+    })
+  }
+
+  const openDefaultToast = () => {
+    toastManager.add({
+      title: 'Default toast',
+      description: 'This toast uses the default layout with action button below.',
+      timeout: 0,
+      data: {
+        isClosable: true,
+        icon: <AlertOutline />,
+        action: {
+          close: true,
+          label: 'Undo',
+          onClick: () => console.log('Action clicked'),
+        },
+      },
+    })
+  }
+
+  return (
+    <div className="gap-md flex">
+      <Button onClick={openCompactToast}>Open Compact Toast</Button>
+      <Button onClick={openDefaultToast}>Open Default Toast</Button>
+    </div>
+  )
+}

--- a/packages/components/src/toast/Toast.styles.ts
+++ b/packages/components/src/toast/Toast.styles.ts
@@ -2,7 +2,7 @@ import { cva, VariantProps } from 'class-variance-authority'
 
 export const toastStyles = cva(
   [
-    'gap-lg p-lg flex w-max !w-[min(400px,calc(100vw-2rem))] flex-col rounded-lg',
+    'gap-lg p-md flex w-max !w-[min(400px,calc(100vw-2rem))] flex-col rounded-lg',
     'absolute right-0 bottom-0 left-auto mr-0',
     'bg-clip-padding shadow-md select-none',
     'focus-visible:ring-focus focus-visible:ring-2 focus-visible:outline-none',

--- a/packages/components/src/toast/index.tsx
+++ b/packages/components/src/toast/index.tsx
@@ -39,7 +39,7 @@ export function ToastProvider({ children, limit = 3 }: ToastProviderProps) {
 interface ToastTriggerProps
   extends React.ComponentPropsWithRef<'button'>,
     Pick<ToastObject, 'priority'>,
-    Pick<ToastData, 'design' | 'intent' | 'icon' | 'isClosable' | 'action'> {
+    Pick<ToastData, 'design' | 'intent' | 'icon' | 'isClosable' | 'action' | 'compact'> {
   children: React.ReactNode
   asChild?: boolean
   title: string
@@ -59,6 +59,7 @@ export function ToastTrigger({
   isClosable = true,
   icon,
   action,
+  compact,
   priority = 'low',
 }: ToastTriggerProps) {
   const toastManager = BaseToast.useToastManager()
@@ -78,6 +79,7 @@ export function ToastTrigger({
         isClosable,
         ...(icon && { icon }),
         action,
+        ...(compact !== undefined && { compact }),
       },
     })
   }

--- a/packages/components/src/toast/types.ts
+++ b/packages/components/src/toast/types.ts
@@ -23,6 +23,7 @@ export interface ToastData {
   intent?: ToastIntent
   isClosable?: boolean
   closeLabel?: string
+  compact?: boolean
   action?: {
     close?: boolean
     label: string


### PR DESCRIPTION
### Description, Motivation and Context

- `Toast` action button now is the same intent (color) as the toast itself.
- `compact` mode introduced. Inlines the action and close button with the content.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles


### Screenshots - Animations
<img width="500" height="462" alt="Capture d’écran 2025-11-04 à 16 59 24" src="https://github.com/user-attachments/assets/1494a8b9-5060-40e5-a2e8-936fd1642014" />


