### PR TITLE
fix(components): avoid using global resize event in scrolling list

### DIFF
--- a/packages/components/src/dialog/DialogBody.tsx
+++ b/packages/components/src/dialog/DialogBody.tsx
@@ -25,7 +25,7 @@ export const Body = ({
 
   const { withFade } = useDialog()
 
-  const overflow = useScrollOverflow(scrollAreaRef)
+  const { overflow } = useScrollOverflow(scrollAreaRef)
 
   return (
     <div

--- a/packages/components/src/drawer/DrawerBody.tsx
+++ b/packages/components/src/drawer/DrawerBody.tsx
@@ -23,7 +23,7 @@ export const DrawerBody = ({
 
   const { withFade } = useDrawer()
 
-  const overflow = useScrollOverflow(scrollAreaRef)
+  const { overflow } = useScrollOverflow(scrollAreaRef)
 
   return (
     <div

--- a/packages/components/src/scrolling-list/ScrollingList.tsx
+++ b/packages/components/src/scrolling-list/ScrollingList.tsx
@@ -84,7 +84,9 @@ export const ScrollingList = ({
 
   const snapCarouselAPI = useSnapCarousel()
 
-  const overflow = useScrollOverflow(scrollAreaRef, { precisionTreshold: 1 })
+  const { overflow, refresh: refreshOverflow } = useScrollOverflow(scrollAreaRef, {
+    precisionTreshold: 1,
+  })
 
   const { activePageIndex, pages, refresh } = snapCarouselAPI
 
@@ -113,10 +115,10 @@ export const ScrollingList = ({
       // Use requestAnimationFrame to ensure proper timing with the render cycle
       // This prevents race conditions that occur when the console is closed
       requestAnimationFrame(() => {
-        window.dispatchEvent(new Event('resize'))
+        refreshOverflow()
       })
     }
-  }, [children])
+  }, [children, refreshOverflow])
 
   const skipKeyboardNavigation = () => {
     skipAnchorRef.current?.focus()

--- a/packages/hooks/src/use-scroll-overflow/index.ts
+++ b/packages/hooks/src/use-scroll-overflow/index.ts
@@ -1,3 +1,3 @@
 export { useScrollOverflow } from './useScrollOverflow'
 
-export type { ScrollOverflow } from './useScrollOverflow'
+export type { ScrollOverflow, UseScrollOverflowReturn } from './useScrollOverflow'


### PR DESCRIPTION
the overflow calculation is now done programatically

### Description, Motivation and Context

Removing the global `resize` event dispatched on `window` whenever `children` is updated in `ScrollingList`.

#### Why it was introduced in the first place ?

The scrolling list display previous/next buttons for `a11y` whenever there is a scroll overflow to the left/right. Some developers had dynamic scrolling list, where items could be added/removed on the fly. It means the overflow needed to be updated to reconsider hiding/showing the navigation controls. 

For this reason a `resize` event had been added to force `useScrollOverflow` to recalculate.

#### Why it was causing bugs.

The bug, while not visible in Storybook/Stackblitz, happens whenever a `ScrollingList` is used inside a page that is using `resize` to update some state, causing the whole tree to rerender.

#### The fix

Call a new refresh method exposed by `useScrollOverflow` to recalculate instead of triggering a global `resize` event.


### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
