### PR TITLE
fix(components): better typing of toast manager for type inference

### DIFF
--- a/packages/components/src/toast/index.tsx
+++ b/packages/components/src/toast/index.tsx
@@ -91,6 +91,8 @@ export function ToastTrigger({
   )
 }
 
-export const createToastManager = BaseToast.createToastManager
+export type ToastManager = ReturnType<typeof BaseToast.createToastManager>
+
+export const createToastManager: () => ToastManager = BaseToast.createToastManager
 
 export { useToastManager }


### PR DESCRIPTION
### Description, Motivation and Context

Importing `createToastManager` could not properly infer the return type from Base UI.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
