### PR TITLE
style(components): make buttons pill shaped and tags rounded

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "nx run-many -t build",
     "build:watch": "nx watch -- nx run-many -t build",
     "release": "nx release --yes",
-    "release:beta": "node bin/release-beta.js --dry-run",
+    "release:beta": "node bin/release-beta.js",
     "storybook:start": "storybook dev -p 6006",
     "storybook:build": "storybook build -o dist",
     "build-storybook": "storybook build -o dist",

--- a/packages/components/src/button/Button.doc.mdx
+++ b/packages/components/src/button/Button.doc.mdx
@@ -75,12 +75,6 @@ Alternatively, use `loadingText` if you prefer the loading text to be visible to
 
 <Canvas of={ButtonStories.LoadingWithText} />
 
-### Shapes
-
-Use `shape` prop to set the shape of a button.
-
-<Canvas of={ButtonStories.Shapes} />
-
 ### Sizes
 
 Use `size` prop to set the size of a button.

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -34,7 +34,6 @@ const intents: ButtonProps['intent'][] = [
   'surfaceInverse',
 ]
 const designs: ButtonProps['design'][] = ['filled', 'outlined', 'tinted', 'contrast', 'ghost']
-const shapes: ButtonProps['shape'][] = ['rounded', 'square', 'pill']
 
 export const Default: StoryObj = {
   render: _args => {
@@ -48,18 +47,6 @@ export const Sizes: StoryFn = _args => (
       return (
         <Button key={size} size={size}>
           Button {size}
-        </Button>
-      )
-    })}
-  </div>
-)
-
-export const Shapes: StoryFn = _args => (
-  <div className="gap-lg flex flex-wrap items-center">
-    {shapes.map(shape => {
-      return (
-        <Button key={shape} shape={shape}>
-          {shape} button
         </Button>
       )
     })}

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -64,7 +64,7 @@ export const Button = ({
   isLoading = false,
   loadingLabel,
   loadingText,
-  shape = 'rounded',
+  shape = 'pill',
   size = 'md',
   asChild,
   className,

--- a/packages/components/src/icon-button/IconButton.doc.mdx
+++ b/packages/components/src/icon-button/IconButton.doc.mdx
@@ -24,7 +24,7 @@ npm install @spark-ui/components
 ```tsx
 import { IconButton } from '@spark-ui/components/icon-button'
 
-export default () => <IconButton />;
+export default () => <IconButton />
 ```
 
 ## API Reference
@@ -40,6 +40,7 @@ A button that renders an icon.
 ### Design and Intent
 
 See all possible combinations of designs and intents in the table below.
+
 - Use `design` prop to set the different look and feels of a button.
 - Use `intent` prop to set the color intent of a button.
 
@@ -58,12 +59,6 @@ Use the isLoading prop to render the button in loading state. This will prepend 
 a11y tip: use loadingLabel to set an accessible aria-label for when the button is in loading state.
 
 <Canvas of={stories.Loading} />
-
-### Shapes
-
-Use `shape` prop to set the shape of a button.
-
-<Canvas of={stories.Shapes} />
 
 ### Sizes
 

--- a/packages/components/src/icon-button/IconButton.stories.tsx
+++ b/packages/components/src/icon-button/IconButton.stories.tsx
@@ -31,7 +31,6 @@ const intents: IconButtonProps['intent'][] = [
   'surface',
 ]
 const designs: IconButtonProps['design'][] = ['filled', 'outlined', 'tinted', 'contrast', 'ghost']
-const shapes: IconButtonProps['shape'][] = ['rounded', 'square', 'pill']
 
 const icon = (
   <Icon>
@@ -50,21 +49,6 @@ export const Sizes: StoryFn = _args => (
         <div key={size} className="text-center">
           <Tag className="mb-md mx-auto flex">{size}</Tag>
           <IconButton size={size} aria-label={`${size} button`}>
-            {icon}
-          </IconButton>
-        </div>
-      )
-    })}
-  </div>
-)
-
-export const Shapes: StoryFn = _args => (
-  <div className="gap-lg flex">
-    {shapes.map(shape => {
-      return (
-        <div key={shape} className="text-center">
-          <Tag className="mb-md mx-auto flex">{shape}</Tag>
-          <IconButton shape={shape} aria-label={`${shape} button`}>
             {icon}
           </IconButton>
         </div>

--- a/packages/components/src/icon-button/IconButton.tsx
+++ b/packages/components/src/icon-button/IconButton.tsx
@@ -15,7 +15,7 @@ export const IconButton = ({
   design = 'filled',
   disabled = false,
   intent = 'main',
-  shape = 'rounded',
+  shape = 'pill',
   size = 'md',
   className,
   ref,

--- a/packages/components/src/input/InputLeadingAddon.tsx
+++ b/packages/components/src/input/InputLeadingAddon.tsx
@@ -16,10 +16,10 @@ const Root = ({ className, ref, ...others }: InputLeadingAddonProps) => {
   const isInactive = disabled || readOnly
 
   return (
-    <div className={cx('rounded-l-lg', isInactive ? 'bg-on-surface/dim-5' : null)}>
+    <div className={cx('rounded-l-full', isInactive ? 'bg-on-surface/dim-5' : null)}>
       <InputAddon
         ref={ref}
-        className={cx(className, 'rounded-r-0! mr-[-1px] rounded-l-lg')}
+        className={cx(className, 'rounded-r-0! -mr-px rounded-l-full')}
         {...others}
       />
     </div>

--- a/packages/components/src/input/InputTrailingAddon.tsx
+++ b/packages/components/src/input/InputTrailingAddon.tsx
@@ -14,10 +14,10 @@ const Root = ({ className, ref, ...others }: InputTrailingAddonProps) => {
   const isInactive = disabled || readOnly
 
   return (
-    <div className={cx('rounded-r-lg', isInactive ? 'bg-on-surface/dim-5' : null)}>
+    <div className={cx('rounded-r-full', isInactive ? 'bg-on-surface/dim-5' : null)}>
       <InputAddon
         ref={ref}
-        className={cx(className, 'rounded-l-0! ml-[-1px] rounded-r-lg')}
+        className={cx(className, 'rounded-l-0! -ml-px rounded-r-full')}
         {...others}
       />
     </div>

--- a/packages/components/src/tag/Tag.doc.mdx
+++ b/packages/components/src/tag/Tag.doc.mdx
@@ -58,12 +58,6 @@ Use `size` prop to set the different sizes of a tag. Default: `md`.
 
 <Canvas of={TagStories.Sizes} />
 
-### Shapes
-
-Use `shape` prop to set the different border radius styles of a tag. Default: `pill`.
-
-<Canvas of={TagStories.Shapes} />
-
 ### All Combinations
 
 Explore all possible combinations of design, intent, shape, and size props.

--- a/packages/components/src/tag/Tag.stories.tsx
+++ b/packages/components/src/tag/Tag.stories.tsx
@@ -88,17 +88,6 @@ export const Sizes: StoryFn = _args => (
   </div>
 )
 
-export const Shapes: StoryFn = _args => (
-  <div className="gap-md flex flex-row items-center">
-    <Tag shape="square">Square tag</Tag>
-    <Tag shape="rounded">Rounded tag</Tag>
-    <Tag shape="pill">Pill tag</Tag>
-    <Tag shape="rounded" className="rounded-bl-none">
-      Custom shape
-    </Tag>
-  </div>
-)
-
 export const AllCombinations: StoryFn = _args => {
   const designs: TagProps['design'][] = ['filled', 'outlined', 'tinted']
   const intents: TagProps['intent'][] = [
@@ -112,7 +101,7 @@ export const AllCombinations: StoryFn = _args => {
     'neutral',
     'surface',
   ]
-  const shapes: TagProps['shape'][] = ['square', 'rounded', 'pill']
+  const shapes: TagProps['shape'][] = ['rounded']
 
   return (
     <div className="overflow-x-auto">
@@ -159,7 +148,6 @@ export const AllCombinations: StoryFn = _args => {
                         key="custom"
                         design={design}
                         intent={intent as any}
-                        shape="rounded"
                         className="rounded-bl-none"
                       >
                         custom

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -28,7 +28,11 @@ export const tagStyles = cva(
       }),
       shape: makeVariants<'shape', ['square', 'rounded', 'pill']>({
         square: [],
+<<<<<<< HEAD
         rounded: ['rounded-tag'],
+=======
+        rounded: ['rounded-sm'],
+>>>>>>> 165d36d86 (style(components): make buttons pill shaped and tags rounded)
         pill: ['rounded-full'],
       }),
       /**

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -28,11 +28,7 @@ export const tagStyles = cva(
       }),
       shape: makeVariants<'shape', ['square', 'rounded', 'pill']>({
         square: [],
-<<<<<<< HEAD
         rounded: ['rounded-tag'],
-=======
-        rounded: ['rounded-sm'],
->>>>>>> 165d36d86 (style(components): make buttons pill shaped and tags rounded)
         pill: ['rounded-full'],
       }),
       /**

--- a/packages/components/src/tag/Tag.tsx
+++ b/packages/components/src/tag/Tag.tsx
@@ -34,7 +34,7 @@ export const Tag = ({
   design = 'filled',
   intent = 'support',
   size = 'md',
-  shape = 'pill',
+  shape = 'rounded',
   asChild,
   className,
   ref,

--- a/packages/components/src/textarea/Textarea.tsx
+++ b/packages/components/src/textarea/Textarea.tsx
@@ -21,11 +21,7 @@ const Root = ({
 }: PropsWithChildren<TextareaProps>) => {
   return (
     <Input
-      className={cx(
-        className,
-        'py-[var(--spacing-sz-10)]',
-        isResizable ? 'resize-y' : 'resize-none'
-      )}
+      className={cx(className, 'py-sz-10 rounded-xl!', isResizable ? 'resize-y' : 'resize-none')}
       data-spark-component="textarea"
       disabled={disabled}
       asChild

--- a/packages/utils/theme/src/base.css
+++ b/packages/utils/theme/src/base.css
@@ -138,10 +138,10 @@
   --radius-full: 9999px;
 
   /* Component tokens */
-  --radius-button: var(--radius-lg);
-  --radius-chip: var(--radius-md);
-  --radius-input: var(--radius-lg);
-  --radius-tag: var(--radius-md);
+  --radius-button: var(--radius-full);
+  --radius-chip: var(--radius-xl);
+  --radius-input: var(--radius-xl);
+  --radius-tag: var(--radius-sm);
 
   --shadow-xs: 0 1px 2px 0 var(--color-shadow);
   --shadow-sm: 0 4px 8px 0 var(--color-shadow);


### PR DESCRIPTION
### Description, Motivation and Context

- Button/IconButton is now `pill` shaped by default (vs `rounded` before)
- Tag is now `rounded` shaped by default (vs `pill` before) and radius went from `md` (8px) to `sm` (4px)
- Shape prop is still there but not feature in stories, as we want to encourage to use the default shapes.

### Types of changes

- [x] 💄 Styles


### Screenshots - Animations

<img width="952" height="417" alt="Capture d’écran 2026-02-10 à 17 39 09" src="https://github.com/user-attachments/assets/15fba492-90fa-416c-9cb0-ee11c357a199" />
<img width="484" height="672" alt="Capture d’écran 2026-02-10 à 17 39 20" src="https://github.com/user-attachments/assets/904dba63-036e-4a6c-b8dd-1e78ddb53556" />
<img width="634" height="645" alt="Capture d’écran 2026-02-10 à 17 39 30" src="https://github.com/user-attachments/assets/40b50ed7-426c-4e69-bbb2-98a0ab1a3a9c" />
