### PR TITLE
fix: chromatic needs access to gh history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install
         uses: ./.github/composite-actions/install
       - name: Publish to Chromatic


### PR DESCRIPTION
### Description, Motivation and Context

Chromatic needs full access to the commit history to process code comparison and deploy to production.

### Types of changes
- [x] 🛠️ Tool
