### PR TITLE
fix: update package exports to match TypeScript 7 output structure

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,12 +10,12 @@
       "require": "./dist/index.js"
     },
     "./form-field": {
-      "types": "./dist/src/form-field/index.d.ts",
+      "types": "./dist/form-field/index.d.ts",
       "import": "./dist/form-field/index.mjs",
       "require": "./dist/form-field/index.js"
     },
     "./*": {
-      "types": "./dist/src/*/index.d.ts",
+      "types": "./dist/*/index.d.ts",
       "import": "./dist/*/index.mjs",
       "require": "./dist/*/index.js"
     }
@@ -23,7 +23,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/src/*/index.d.ts"
+        "./dist/*/index.d.ts"
       ]
     }
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -7,17 +7,17 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./*": {
-      "types": "./dist/src/icons/*.d.ts",
+      "types": "./dist/icons/*.d.ts",
       "import": "./dist/icons/*.mjs",
       "require": "./dist/icons/*.js"
     }
   },
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "generate": "node ./scripts/build.mjs",
     "build": "vite build"

--- a/packages/utils/internal-utils/package.json
+++ b/packages/utils/internal-utils/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "vite build"
   },


### PR DESCRIPTION
### Description, Motivation and Context

TypeScript 7 now colocates type definitions with source code in dist/, removing the intermediate dist/src/ directory. This updates the exports in package.json files to point to the correct type definition paths:
- dist/src/*/index.d.ts → dist/*/index.d.ts

This fixes imports like "import { Button } from '@spark-ui/components/button'" which were broken after the TypeScript 7 migration in #3027.

### Types of changes
- [x] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
