### PR TITLE
feat(components): added description to formfield compound

### DIFF
--- a/e2e/a11y/pages/FormField.tsx
+++ b/e2e/a11y/pages/FormField.tsx
@@ -6,6 +6,7 @@ export const A11yFormField = () => (
     <div>
       <FormField name="email">
         <FormField.Label>Email</FormField.Label>
+        <FormField.Description>Enter your email address</FormField.Description>
 
         <FormField.Control>
           {({ id, name, description }) => (
@@ -26,6 +27,7 @@ export const A11yFormField = () => (
     <div>
       <FormField name="password" isRequired>
         <FormField.Label>Password</FormField.Label>
+        <FormField.Description>Choose a strong password</FormField.Description>
 
         <FormField.Control>
           {({ id, name, description, isRequired }) => (

--- a/packages/components/src/form-field/FormField.doc.mdx
+++ b/packages/components/src/form-field/FormField.doc.mdx
@@ -3,6 +3,8 @@ import { A11yReport } from '@docs/helpers/A11yReport'
 import { Callout } from '@docs/helpers/Callout'
 
 import { FormField } from '.'
+import { Card } from '../card'
+import { Button } from '../button'
 
 import * as stories from './FormField.stories'
 
@@ -13,6 +15,57 @@ import * as stories from './FormField.stories'
 Provide context to your form elements easily.
 
 By default, all Spark input components use `FormField.Control` behind the scenes. However, if you want to use a custom input component, or if you need more fine-grained control over the state of a form control, it can be used.
+
+<Card intent="accent" className="sb-unstyled my-lg">
+  <Card.Type>Compatible Components</Card.Type>
+  <Card.Content className="gap-md flex flex-col">
+    <p className="text-body-2">
+      FormField works seamlessly with all Spark form components to provide consistent labeling,
+      descriptions, validation states, and accessibility features:
+    </p>
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-sm">
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-input--docs">Input</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-textarea--docs">Textarea</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-select--docs">Select</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-combobox--docs">Combobox</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-checkbox--docs">Checkbox</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-radiogroup--docs">RadioGroup</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-switch--docs">Switch</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-slider--docs">Slider</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-stepper--docs">Stepper</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-rating--docs">Rating</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-fileupload--docs">FileUpload</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-inputotp--docs">InputOTP</a>
+      </Button>
+      <Button design="ghost" underline intent="support" asChild>
+        <a href="/?path=/docs/components-segmentedcontrol--docs">SegmentedControl</a>
+      </Button>
+    </div>
+  </Card.Content>
+</Card>
 
 <Canvas of={stories.Default} />
 
@@ -30,13 +83,13 @@ import { FormField } from '@spark-ui/components/form-field'
 export default () => (
   <FormField>
     <FormField.Label />
-    /**
+    <FormField.Description />
+    {/**
      * FormField.Control can be replaced by any Spark component that is an input:
      * - Checkbox, Combobox, Dropdown, TextInput, RadioGroup, Select, Stepper, Switch, etc
-     */
-    <FormField.Control /> 
-
-    <FormField.HelperMessage>We will never share your email</FormField.HelperMessage>
+     */}
+    <FormField.Control />
+    <FormField.HelperMessage />
   </FormField>
 )
 ```
@@ -49,59 +102,59 @@ Wrap any type of input (Input, Checkbox, RadioGroup, etc.) to add contextual inf
 
 <ArgTypes of={FormField} />
 
-
-
-### _.Label
+### \_.Label
 
 Label to attach to the associated input to describe it and give it an accessible name.
 
 <ArgTypes of={FormField.Label} />
 
+### \_.Description
 
-### _.HelperMessage
+Provides an accessible description for the input field. The description is automatically linked to the input via `aria-describedby` and can be combined with helper messages and error messages.
+
+<ArgTypes of={FormField.Description} />
+
+### \_.HelperMessage
 
 Help users by showing an helper message below an input.
 
 <ArgTypes of={FormField.HelperMessage} />
 
-
-### _.SuccessMessage
+### \_.SuccessMessage
 
 Help users by showing an success message below an input. Indicates the input has been successfully filled in by the user.
 
 <ArgTypes of={FormField.SuccessMessage} />
 
-### _.AlertMessage
+### \_.AlertMessage
 
 Help users by showing an alert message (warning) below an input. For example: a password input with an insecure password.
 
 <ArgTypes of={FormField.AlertMessage} />
 
-### _.ErrorMessage
+### \_.ErrorMessage
 
 Help users by showing an error message below an input. Indicated the input has not been successfully filled in by the user.
 
 <ArgTypes of={FormField.ErrorMessage} />
 
-### _.Control
+### \_.Control
 
 This higher order component gives you access to the internal state of the field. Wrap an input with it to get access to the state. It can be used to build complex custom inputs.
 
 <ArgTypes of={FormField.Control} />
 
-### _.RequiredIndicator
+### \_.RequiredIndicator
 
 Render it inside the FormField.Label to mark the field as mandatory (required)
 
 <ArgTypes of={FormField.RequiredIndicator} />
 
-### _.CharactersCount
+### \_.CharactersCount
 
 Displays characters count for text inputs and textareas, and the max length allowed in these components.
 
 <ArgTypes of={FormField.CharactersCount} />
-
-
 
 ## Examples
 
@@ -110,10 +163,11 @@ Displays characters count for text inputs and textareas, and the max length allo
 Use `FormField.CharactersCount` to show users how many characters they have left. Can be used in combination with all types of text inputs.
 
 <Callout kind="warning" className="sb-unstyled">
-  Don't forget to pass both `description` and `liveAnnouncement` props to the `FormField.CharactersCount` component to make it compatible with screen readers:
+  Don't forget to pass both `description` and `liveAnnouncement` props to the
+  `FormField.CharactersCount` component to make it compatible with screen readers:
   <ul className="pl-3xl">
-    <li className='list-disc'>`description` is read when the focus is on the input.</li>
-    <li className='list-disc'>`liveAnnouncement` is read when the user types (after a delay).</li>
+    <li className="list-disc">`description` is read when the focus is on the input.</li>
+    <li className="list-disc">`liveAnnouncement` is read when the user types (after a delay).</li>
   </ul>
 </Callout>
 
@@ -124,7 +178,8 @@ Use `FormField.CharactersCount` to show users how many characters they have left
 Set `isRequired` prop to `true` to mark the input as required and display a required indicator. The default indicator is an asterisk `*`.
 
 <Callout kind="warning">
-  If your form has mandatory fields, you must include an explicit note at the top of the form, outside of the input fields, to inform users that certain fields are required.
+  If your form has mandatory fields, you must include an explicit note at the top of the form,
+  outside of the input fields, to inform users that certain fields are required.
 </Callout>
 
 <Canvas of={stories.Required} />

--- a/packages/components/src/form-field/FormField.stories.tsx
+++ b/packages/components/src/form-field/FormField.stories.tsx
@@ -22,6 +22,7 @@ export default meta
 export const Default: StoryFn = () => (
   <FormField name="email">
     <FormField.Label>Email</FormField.Label>
+    <FormField.Description>Enter your email address</FormField.Description>
 
     <FormField.Control>
       {({ id, name, description }) => (
@@ -35,7 +36,7 @@ export const Default: StoryFn = () => (
       )}
     </FormField.Control>
 
-    <FormField.HelperMessage>We will never share your email</FormField.HelperMessage>
+    <FormField.HelperMessage>Use your work email for business accounts</FormField.HelperMessage>
   </FormField>
 )
 
@@ -44,6 +45,7 @@ export const Required: StoryFn = () => (
     <p className="mb-xl">* Required fields</p>
     <FormField name="password" isRequired>
       <FormField.Label>Password</FormField.Label>
+      <FormField.Description>Choose a strong password</FormField.Description>
 
       <FormField.Control>
         {({ id, name, description, isRequired }) => (
@@ -75,6 +77,7 @@ export const CustomRequired: StoryFn = () => (
     >
       Password
     </FormField.Label>
+    <FormField.Description>Must be at least 8 characters</FormField.Description>
 
     <FormField.Control>
       {({ id, name, description, isRequired }) => (
@@ -98,6 +101,7 @@ export const State: StoryFn = () => (
   <div className="gap-lg flex flex-col">
     <FormField name="email" state="error">
       <FormField.Label>Name</FormField.Label>
+      <FormField.Description>Enter your full name</FormField.Description>
 
       <FormField.Control>
         {({ id, name, description, state }) => (
@@ -118,6 +122,7 @@ export const State: StoryFn = () => (
 
     <FormField name="email" state="success">
       <FormField.Label>Email</FormField.Label>
+      <FormField.Description>We'll send a confirmation to this address</FormField.Description>
 
       <FormField.Control>
         {({ id, name, description, state }) => (
@@ -139,6 +144,7 @@ export const State: StoryFn = () => (
 
     <FormField name="email" state="alert">
       <FormField.Label>Password</FormField.Label>
+      <FormField.Description>Create a secure password for your account</FormField.Description>
 
       <FormField.Control>
         {({ id, name, description, state }) => (
@@ -171,6 +177,7 @@ export const CharactersCount: StoryFn = () => {
   return (
     <FormField name="input-with-a-characters-count">
       <FormField.Label>Email</FormField.Label>
+      <FormField.Description>Your primary contact email</FormField.Description>
 
       <FormField.Control>
         {({ id, name, description }) => (

--- a/packages/components/src/form-field/FormField.test.tsx
+++ b/packages/components/src/form-field/FormField.test.tsx
@@ -94,6 +94,55 @@ describe('FormField', () => {
     expect(inputEl.getAttribute('aria-describedby')).toEqual(helperTextEl.getAttribute('id'))
   })
 
+  it('should render description', () => {
+    render(
+      <FormField name="email">
+        <FormField.Label>Email</FormField.Label>
+        <FormField.Description>Enter your email address</FormField.Description>
+
+        <FormField.Control>
+          {({ id, name, description }) => (
+            <input type="email" id={id} name={name} aria-describedby={description} />
+          )}
+        </FormField.Control>
+      </FormField>
+    )
+
+    const inputEl = screen.getByLabelText('Email')
+    const descriptionEl = screen.getByText('Enter your email address')
+
+    expect(inputEl.getAttribute('aria-describedby')).toEqual(descriptionEl.getAttribute('id'))
+  })
+
+  it('should combine description and helper message in aria-describedby', () => {
+    render(
+      <FormField name="email">
+        <FormField.Label>Email</FormField.Label>
+        <FormField.Description>Enter your email address</FormField.Description>
+
+        <FormField.Control>
+          {({ id, name, description }) => (
+            <input type="email" id={id} name={name} aria-describedby={description} />
+          )}
+        </FormField.Control>
+
+        <FormField.HelperMessage>We will never share your email</FormField.HelperMessage>
+      </FormField>
+    )
+
+    const inputEl = screen.getByLabelText('Email')
+    const descriptionEl = screen.getByText('Enter your email address')
+    const helperTextEl = screen.getByText('We will never share your email')
+
+    expect(inputEl).toHaveAttribute('aria-describedby')
+
+    const ids = (inputEl.getAttribute('aria-describedby') as string).split(' ')
+
+    expect(ids).toContain(descriptionEl.getAttribute('id'))
+    expect(ids).toContain(helperTextEl.getAttribute('id'))
+    expect(ids).toHaveLength(2)
+  })
+
   it('should render using custom label', () => {
     render(
       <FormField name="category">

--- a/packages/components/src/form-field/FormFieldDescription.tsx
+++ b/packages/components/src/form-field/FormFieldDescription.tsx
@@ -1,0 +1,21 @@
+import { cx } from 'class-variance-authority'
+import { Ref } from 'react'
+
+import { FormFieldMessage, FormFieldMessageProps } from './FormFieldMessage'
+
+export type FormFieldDescriptionProps = FormFieldMessageProps & {
+  ref?: Ref<HTMLSpanElement>
+}
+
+export const FormFieldDescription = ({ className, ref, ...others }: FormFieldDescriptionProps) => {
+  return (
+    <FormFieldMessage
+      ref={ref}
+      data-spark-component="form-field-description"
+      className={cx('text-on-surface/dim-1 text-body-2', className)}
+      {...others}
+    />
+  )
+}
+
+FormFieldDescription.displayName = 'FormField.Description'

--- a/packages/components/src/form-field/FormFieldLabel.tsx
+++ b/packages/components/src/form-field/FormFieldLabel.tsx
@@ -34,7 +34,11 @@ export const FormFieldLabel = ({
       id={labelId}
       data-spark-component="form-field-label"
       htmlFor={htmlFor}
-      className={cx(className, disabled ? 'text-on-surface/dim-3  pointer-events-none' : undefined)}
+      className={cx(
+        'default:font-bold',
+        className,
+        disabled ? 'text-on-surface/dim-3  pointer-events-none' : undefined
+      )}
       asChild={asChild}
       {...others}
     >

--- a/packages/components/src/form-field/FormFieldLabel.tsx
+++ b/packages/components/src/form-field/FormFieldLabel.tsx
@@ -34,7 +34,7 @@ export const FormFieldLabel = ({
       id={labelId}
       data-spark-component="form-field-label"
       htmlFor={htmlFor}
-      className={cx(className, disabled ? 'text-on-surface/dim-3 pointer-events-none' : undefined)}
+      className={cx(className, disabled ? 'text-on-surface/dim-3  pointer-events-none' : undefined)}
       asChild={asChild}
       {...others}
     >

--- a/packages/components/src/form-field/FormFieldMessage.tsx
+++ b/packages/components/src/form-field/FormFieldMessage.tsx
@@ -30,7 +30,7 @@ export const FormFieldMessage = ({
       ref={ref}
       id={id}
       data-spark-component="form-field-message"
-      className={cx(className, 'text-caption')}
+      className={cx(className, 'default:text-caption')}
       {...others}
     />
   )

--- a/packages/components/src/form-field/index.ts
+++ b/packages/components/src/form-field/index.ts
@@ -2,6 +2,7 @@ import { FormField as Root } from './FormField'
 import { FormFieldAlertMessage } from './FormFieldAlertMessage'
 import { FormFieldCharactersCount } from './FormFieldCharactersCount'
 import { FormFieldControl } from './FormFieldControl'
+import { FormFieldDescription } from './FormFieldDescription'
 import { FormFieldErrorMessage } from './FormFieldErrorMessage'
 import { FormFieldHelperMessage } from './FormFieldHelperMessage'
 import { FormFieldLabel } from './FormFieldLabel'
@@ -14,6 +15,7 @@ import { FormFieldSuccessMessage } from './FormFieldSuccessMessage'
  */
 export const FormField: typeof Root & {
   Label: typeof FormFieldLabel
+  Description: typeof FormFieldDescription
   Control: typeof FormFieldControl
   StateMessage: typeof FormFieldStateMessage
   SuccessMessage: typeof FormFieldSuccessMessage
@@ -24,6 +26,7 @@ export const FormField: typeof Root & {
   CharactersCount: typeof FormFieldCharactersCount
 } = Object.assign(Root, {
   Label: FormFieldLabel,
+  Description: FormFieldDescription,
   Control: FormFieldControl,
   StateMessage: FormFieldStateMessage,
   SuccessMessage: FormFieldSuccessMessage,
@@ -36,6 +39,7 @@ export const FormField: typeof Root & {
 
 FormField.displayName = 'FormField'
 FormFieldLabel.displayName = 'FormField.Label'
+FormFieldDescription.displayName = 'FormField.Description'
 FormFieldControl.displayName = 'FormField.Control'
 FormFieldStateMessage.displayName = 'FormField.StateMessage'
 FormFieldSuccessMessage.displayName = 'FormField.SuccessMessage'
@@ -48,6 +52,7 @@ FormFieldCharactersCount.displayName = 'FormField.CharactersCount'
 export { type FormFieldProps } from './FormField'
 export { type FormFieldStateMessageProps } from './FormFieldStateMessage'
 export { type FormFieldControl, useFormFieldControl } from './FormFieldControl'
+export { type FormFieldDescriptionProps } from './FormFieldDescription'
 export { type FormFieldHelperMessageProps } from './FormFieldHelperMessage'
 export { type FormFieldSuccessMessageProps } from './FormFieldSuccessMessage'
 export { type FormFieldAlertMessageProps } from './FormFieldAlertMessage'

--- a/packages/components/src/label/Label.tsx
+++ b/packages/components/src/label/Label.tsx
@@ -11,7 +11,7 @@ export const Label = ({ className, ref, ...others }: LabelProps) => {
     <RadixLabel.Label
       ref={ref}
       data-spark-component="label"
-      className={cx('text-body-1 font-bold', className)}
+      className={cx('text-body-1', className)}
       {...others}
     />
   )

--- a/packages/components/src/label/Label.tsx
+++ b/packages/components/src/label/Label.tsx
@@ -11,7 +11,7 @@ export const Label = ({ className, ref, ...others }: LabelProps) => {
     <RadixLabel.Label
       ref={ref}
       data-spark-component="label"
-      className={cx('text-body-1', className)}
+      className={cx('text-body-1 font-bold', className)}
       {...others}
     />
   )


### PR DESCRIPTION
### Description, Motivation and Context

- FormField label is now bold
- FormField.Description: new subcomponent
- adapted unit tests and e2e tests (a11y)

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations
<img width="1021" height="260" alt="Capture d’écran 2026-04-29 à 17 16 16" src="https://github.com/user-attachments/assets/81e1bd39-1eab-4841-873a-df7c80299b67" />

