### PR TITLE
fix(theme-utils): caption highlight font token

### DIFF
--- a/documentation/styling/DesignTokens.mdx
+++ b/documentation/styling/DesignTokens.mdx
@@ -1057,6 +1057,7 @@ Spark typography are composite tokens (Tailwindcss utilities) that combines font
           { name: 'body-2', className: 'text-body-2' },
           { name: 'body-2-highlight', className: 'text-body-2-highlight' },
           { name: 'caption', className: 'text-caption' },
+          { name: 'caption-highlight', className: 'text-caption-highlight' },
           { name: 'small', className: 'text-small' },
           { name: 'small-highlight', className: 'text-small-highlight' },
           { name: 'callout', className: 'text-callout' },

--- a/packages/utils/theme/src/utilities.css
+++ b/packages/utils/theme/src/utilities.css
@@ -61,7 +61,7 @@
   line-height: 1.333;
 }
 
-@utility text-caption {
+@utility text-caption-highlight {
   font-size: calc(0.75rem * var(--spacing-factor));
   line-height: 1.333;
   font-weight: 700;


### PR DESCRIPTION
### Description, Motivation and Context

Fixed typo on dual `text-caption` tailwind utility.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
