### PR TITLE
fix(components): rating star appearing above other components

### DIFF
--- a/packages/components/src/rating-display/RatingDisplayStar.tsx
+++ b/packages/components/src/rating-display/RatingDisplayStar.tsx
@@ -51,7 +51,7 @@ export const RatingDisplayStar = ({ value, size }: RatingDisplayStarProps) => {
         gap: size === 'lg' ? 'md' : 'sm',
       })}
     >
-      <div className={cx('z-raised absolute overflow-hidden')} style={{ width: value * 100 + '%' }}>
+      <div className={cx('absolute overflow-hidden')} style={{ width: value * 100 + '%' }}>
         <Icon
           className={ratingDisplayStarIconStyles({
             size,


### PR DESCRIPTION
## fix(components): Fixes star overlapping scrolling list navigation buttons

<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: #3051 

### Description, Motivation and Context
When using the ScrollingList together with the RatingDisplay.Stars, the star can appear on top of the scrolling list navigation buttons.

Fixes #3051 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:  -->
<!---
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
 -->

### Screenshots - Animations
<img width="71" height="66" alt="Screenshot 2026-05-21 at 13 53 12" src="https://github.com/user-attachments/assets/94f67e23-c990-4abd-a6f7-18ea84ab76d0" />

https://github.com/user-attachments/assets/520ab8fc-7755-4eee-be1a-9795e86e42e3

