### PR TITLE
refactor(components): portal no longer uses Radix UI

### DIFF
--- a/documentation/componentsPrinciples/ThirdPartyLibraries.mdx
+++ b/documentation/componentsPrinciples/ThirdPartyLibraries.mdx
@@ -19,13 +19,13 @@ The mid-term goal is to migrate all component to `Base UI` if possible, as its c
 | Section                      | Components                                                                                                                                                                                                                                                         |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Homemade components**      | `Badge`, `Breadcrumb`, `Button`, `Carousel`, `Chip`, `FormField`, `Icon`, `IconButton`, `Input`, `Kbd`, `LinkBox`, `ProgressTracker`, `Rating`, `RatingDisplay`, `ScrollingList`, `Select`, `Skeleton`, `Spinner`, `Tag`, `TextLink`, `Textarea`, `VisuallyHidden` |
-| **Using Base UI**            | `Accordion`, `AlertDialog`, `Dialog`, `Divider`,`Drawer` (indirectly using Dialog), `CircularMeter`, `Meter`, `Collapsible`, `Progress`, `Slider`, `Stepper`, `Switch`,`Tabs`, `Toast`                                                                             |
+| **Using Base UI**            | `Accordion`, `AlertDialog`, `Dialog`, `Divider`,`Drawer` (indirectly using Dialog), `CircularMeter`, `Menu`, `Meter`, `Collapsible`, `Portal`, `Progress`, `Slider`, `Stepper`, `Switch`,`Tabs`, `Toast`                                                           |
 | **Using React aria/stately** | `Table`                                                                                                                                                                                                                                                            |
 
 ## To migrate
 
-| Section                       | Components                                                                                                                                                                  |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TODO**                      | `Dropdown`, `Avatar`, `Combobox`, `Checkbox`, `Popover`, `RadioGroup`, `Slot`, `Pagination`, `Label`, `Portal`                                                              |
-| **Base UI**                   | `AutoComplete`, `ContextMenu`, `Field`, `Fieldset`, `Form`, `Menu`, `Menubar`, `NavigationMenu`, `PreviewCard`, `ScrollArea`, `Toggle`, `ToggleGroup`, `Toolbar`, `Tooltip` |
-| **Base UI - incoming (2026)** | `Calendar`, `Date/Time Picker`, `Drawer`, `Tree`, `Listbox`, `Charts`, `Table`, `Window`, `Carousel`, `Color Picker`, `Window Splitter`                                     |
+| Section                       | Components                                                                                                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TODO**                      | `Dropdown`, `Avatar`, `Combobox`, `Checkbox`, `Popover`, `RadioGroup`, `Slot`, `Pagination`, `Label`                                                                |
+| **Base UI**                   | `AutoComplete`, `ContextMenu`, `Field`, `Fieldset`, `Form`, `Menubar`, `NavigationMenu`, `PreviewCard`, `ScrollArea`, `Toggle`, `ToggleGroup`, `Toolbar`, `Tooltip` |
+| **Base UI - incoming (2026)** | `Calendar`, `Date/Time Picker`, `Drawer`, `Tree`, `Listbox`, `Charts`, `Table`, `Window`, `Carousel`, `Color Picker`, `Window Splitter`                             |

--- a/packages/components/src/portal/Portal.tsx
+++ b/packages/components/src/portal/Portal.tsx
@@ -1,5 +1,5 @@
-import { Portal as RadixPortal } from 'radix-ui'
-import { type PropsWithChildren, Ref } from 'react'
+import { type PropsWithChildren, Ref, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 interface PortalProps {
   /**
@@ -12,6 +12,19 @@ interface PortalProps {
 /**
  * A utility component that renders content into a different part of the DOM tree, typically outside the main hierarchy.
  */
-export const Portal = (props: PropsWithChildren<PortalProps>) => {
-  return <RadixPortal.Portal {...props} />
+export const Portal = ({ children, container }: PropsWithChildren<PortalProps>) => {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    return () => setMounted(false)
+  }, [])
+
+  if (!mounted) return null
+
+  const targetContainer = container ?? (typeof document !== 'undefined' ? document.body : null)
+
+  if (!targetContainer) return null
+
+  return createPortal(children, targetContainer)
 }


### PR DESCRIPTION
### Description, Motivation and Context

- Removing Radix UI from Portal component.

The end goal is to get rid of Radix UI on every component (using either Base UI or homemade components to reduce dependencies)

### Types of changes
- [x] 🧠 Refactor
