### PR TITLE
docs(components): reduce animations when needed

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -66,8 +66,9 @@ const ExampleContainer = ({ children, ...props }: Props) => {
     setShouldDisplayDeprecatedBanner(primaryStoryTitle?.startsWith('Deprecated') || false)
   }, [props.context?.channel])
 
-
   useEffect(() => {
+    const mm = gsap.matchMedia()
+
     // Wait for canvas elements to be fully rendered and positioned
     const setupAnimations = () => {
       const canvasElements = document.querySelectorAll('.sbdocs-preview')
@@ -78,34 +79,38 @@ const ExampleContainer = ({ children, ...props }: Props) => {
         return
       }
 
-      // Create ScrollTrigger for each canvas
-      canvasElements.forEach(canvas => {
-        // Animation when entering from bottom with 3D tilt
-        gsap.fromTo(
-          canvas,
-          {
-            scale: 0.9,
-            opacity: 0,
-          },
-          {
-            scale: 1,
-            opacity: 1,
-            ease: 'none',
-            scrollTrigger: {
-              trigger: canvas,
-              start: 'top bottom',
-              end: 'top+=100px bottom',
-              scrub: 1,
-              invalidateOnRefresh: true,
+      // Only animate if user has not opted out of animation at the OS level
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        // Create ScrollTrigger for each canvas
+        canvasElements.forEach(canvas => {
+          // Animation when entering from bottom with 3D tilt
+          gsap.fromTo(
+            canvas,
+            {
+              scale: 0.9,
+              opacity: 0,
             },
-          }
-        )
-      })
+            {
+              scale: 1,
+              opacity: 1,
+              ease: 'none',
+              scrollTrigger: {
+                trigger: canvas,
+                start: 'top bottom',
+                end: 'top+=100px bottom',
+                scrub: 1,
+                invalidateOnRefresh: true,
+                once: true
+              },
+            }
+          )
+        })
 
-      // Refresh after a delay to recalculate positions
-      setTimeout(() => {
-        ScrollTrigger.refresh()
-      }, 500)
+        // Refresh after a delay to recalculate positions
+        setTimeout(() => {
+          ScrollTrigger.refresh()
+        }, 500)
+      })
 
       // Observe size changes to canvas elements (e.g., when "show source" is clicked)
       const resizeObserver = new ResizeObserver(() => {
@@ -125,9 +130,10 @@ const ExampleContainer = ({ children, ...props }: Props) => {
     // Start setup after DOM is ready
     const cleanupObserver = setupAnimations()
 
-    // Cleanup ScrollTrigger instances and observer on unmount
+    // Cleanup ScrollTrigger instances and matchMedia on unmount
     return () => {
       cleanupObserver?.()
+      mm.revert()
       ScrollTrigger.getAll().forEach(trigger => trigger.kill())
     }
   }, [children])

--- a/documentation/components/AnimatedHero.tsx
+++ b/documentation/components/AnimatedHero.tsx
@@ -11,33 +11,48 @@ export const AnimatedHero = () => {
 
       const words = containerRef.current.querySelectorAll('.gsap-word')
       const highlight = containerRef.current.querySelector('.gsap-highlight')
+      const mm = gsap.matchMedia()
 
-      // Set initial states
-      gsap.set(words, {
-        opacity: 0,
-        y: 50,
-        rotateX: -90,
+      // Only animate if user has not opted out of animation at the OS level
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        // Set initial states
+        gsap.set(words, {
+          opacity: 0,
+          y: 50,
+          rotateX: -90,
+        })
+
+        gsap.set(highlight, {
+          '--gradient-position': '0%',
+        })
+
+        // Create shared timeline
+        const timeline = gsap.timeline({
+          defaults: {
+            ease: 'power4.out',
+          },
+        })
+
+        // Animate words appearing one by one
+        timeline.to(words, {
+          opacity: 1,
+          y: 0,
+          rotateX: 0,
+          duration: 0.8,
+          stagger: 0.15,
+        })
       })
 
-      gsap.set(highlight, {
-        '--gradient-position': '0%',
+      // If reduced motion is preferred, ensure elements are visible
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        gsap.set(words, {
+          opacity: 1,
+          y: 0,
+          rotateX: 0,
+        })
       })
 
-      // Create shared timeline
-      const timeline = gsap.timeline({
-        defaults: {
-          ease: 'power4.out',
-        },
-      })
-
-      // Animate words appearing one by one
-      timeline.to(words, {
-        opacity: 1,
-        y: 0,
-        rotateX: 0,
-        duration: 0.8,
-        stagger: 0.15,
-      })
+      return () => mm.revert()
     },
     { scope: containerRef }
   )
@@ -76,34 +91,48 @@ interface AnimatedButtonsProps {
 export const AnimatedButtons = ({ children }: AnimatedButtonsProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Create shared timeline
-  const timeline = gsap.timeline({
-    defaults: {
-      ease: 'power4.out',
-    },
-  })
-
   useGSAP(
     () => {
       if (!containerRef.current) return
 
       const buttons = containerRef.current.querySelectorAll('.animated-button')
+      const mm = gsap.matchMedia()
 
-      // Set initial states
-      gsap.set(buttons, {
-        opacity: 0,
-        scale: 0.5,
+      // Only animate if user has not opted out of animation at the OS level
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        // Set initial states
+        gsap.set(buttons, {
+          opacity: 0,
+          scale: 0.5,
+        })
+
+        // Create shared timeline
+        const timeline = gsap.timeline({
+          defaults: {
+            ease: 'power4.out',
+          },
+        })
+
+        // Add button animation to the shared timeline
+        timeline.to(buttons, {
+          delay: 1,
+          opacity: 1,
+          scale: 1,
+          duration: 0.6,
+          stagger: 0.15,
+          ease: 'back.out(1.7)',
+        })
       })
 
-      // Add button animation to the shared timeline
-      timeline.to(buttons, {
-        delay: 1,
-        opacity: 1,
-        scale: 1,
-        duration: 0.6,
-        stagger: 0.15,
-        ease: 'back.out(1.7)',
+      // If reduced motion is preferred, ensure buttons are visible
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        gsap.set(buttons, {
+          opacity: 1,
+          scale: 1,
+        })
       })
+
+      return () => mm.revert()
     },
     { scope: containerRef }
   )


### PR DESCRIPTION
### Description, Motivation and Context

`GSAP` animations (hero section and stories canvases) no longer triggers if the user's preference is to disable animations (a11y)

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

