### PR TITLE
style(theme-utils): added first component level design tokens

### DIFF
--- a/packages/components/src/button/Button.styles.tsx
+++ b/packages/components/src/button/Button.styles.tsx
@@ -84,7 +84,7 @@ export const buttonStyles = cva(
        * Shape of the button.
        */
       shape: makeVariants<'shape', ['rounded', 'square', 'pill']>({
-        rounded: ['rounded-lg'],
+        rounded: ['rounded-button'],
         square: ['rounded-0'],
         pill: ['rounded-full'],
       }),

--- a/packages/components/src/chip/Chip.styles.tsx
+++ b/packages/components/src/chip/Chip.styles.tsx
@@ -5,7 +5,7 @@ import { dashedVariants, outlinedVariants, tintedVariants } from './variants'
 
 export const chipStyles = cva(
   [
-    'box-border inline-flex h-sz-32 flex-nowrap items-center justify-center rounded-md text-body-1 font-regular',
+    'box-border inline-flex h-sz-32 flex-nowrap items-center justify-center rounded-button text-body-1 font-regular',
     'focus-visible:u-outline',
     'ease-out duration-150',
   ],

--- a/packages/components/src/combobox/ComboboxTrigger.styles.tsx
+++ b/packages/components/src/combobox/ComboboxTrigger.styles.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority'
 export const styles = cva(
   [
     'flex items-start gap-md min-h-sz-44 text-body-1',
-    'h-fit rounded-lg px-lg',
+    'h-fit rounded-input px-lg',
     // outline styles
     'ring-1 outline-hidden ring-inset focus-within:ring-2 focus-within:ring-focus',
   ],

--- a/packages/components/src/dropdown/DropdownTrigger.styles.tsx
+++ b/packages/components/src/dropdown/DropdownTrigger.styles.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority'
 export const styles = cva(
   [
     'flex w-full items-center justify-between',
-    'min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg',
+    'min-h-sz-44 rounded-input bg-surface text-on-surface px-lg',
     'text-body-1',
     // outline styles
     'ring-1 outline-hidden ring-inset focus:ring-2 focus:ring-focus',

--- a/packages/components/src/input/Input.styles.ts
+++ b/packages/components/src/input/Input.styles.ts
@@ -39,14 +39,14 @@ export const inputStyles = cva(
        */
       hasLeadingAddon: {
         true: ['rounded-l-0'],
-        false: ['rounded-l-lg'],
+        false: ['rounded-l-input'],
       },
       /**
        * Sets if there is an addon after the input text.
        */
       hasTrailingAddon: {
         true: ['rounded-r-0'],
-        false: ['rounded-r-lg'],
+        false: ['rounded-r-input'],
       },
       /**
        * Sets if there is an icon before the input text.

--- a/packages/components/src/select/SelectTrigger.styles.tsx
+++ b/packages/components/src/select/SelectTrigger.styles.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority'
 export const styles = cva(
   [
     'relative flex w-full items-center justify-between',
-    'min-h-sz-44 rounded-lg px-lg',
+    'min-h-sz-44 rounded-input px-lg',
     'text-body-1',
     // outline styles
     'ring-1 outline-hidden ring-inset focus-within:ring-focus',

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -28,7 +28,7 @@ export const tagStyles = cva(
       }),
       shape: makeVariants<'shape', ['square', 'rounded', 'pill']>({
         square: [],
-        rounded: ['rounded-md'],
+        rounded: ['rounded-tag'],
         pill: ['rounded-full'],
       }),
       /**

--- a/packages/utils/theme/src/base.css
+++ b/packages/utils/theme/src/base.css
@@ -138,6 +138,11 @@
   --radius-xl: calc(1.5rem * var(--spacing-factor));
   --radius-full: 9999px;
 
+  /* Component tokens */
+  --radius-button: var(--radius-lg);
+  --radius-input: var(--radius-lg);
+  --radius-tag: var(--radius-md);
+
   --shadow-xs: 0 1px 2px 0 var(--color-shadow);
   --shadow-sm: 0 4px 8px 0 var(--color-shadow);
   --shadow-md: 0 6px 12px 0 var(--color-shadow);


### PR DESCRIPTION
### Description, Motivation and Context

Added first "token level" design tokens for proper remapping.

The goal is to encourage using this layer when possible in case of future rebranding events.

For example, it would be easier to update all custom buttons on the consumer side if they were using the new `rounded-button` class.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

