### PR TITLE
fix(components): fixed invalid direct access to ref

### DIFF
--- a/packages/components/src/input/InputGroup.tsx
+++ b/packages/components/src/input/InputGroup.tsx
@@ -62,7 +62,7 @@ export const InputGroup = ({
 
   const inputRef = useRef<HTMLInputElement>(null!)
   const onClearRef = useRef(onClear)
-  const ref = useMergeRefs<HTMLInputElement>(input?.ref, inputRef)
+  const ref = useMergeRefs<HTMLInputElement>(input?.props.ref, inputRef)
   const [value, onChange] = useCombinedState(
     props.value as string,
     props.defaultValue as string,


### PR DESCRIPTION
### Description, Motivation and Context

Removed direct access to ref from `InputGroup` (since React 19, refs are props)

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
