### PR TITLE
feat(components): togglegroup component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1891,6 +1891,66 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
+      "integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.9",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@base2/pretty-print-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.2.tgz",
@@ -20911,9 +20971,9 @@
       }
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
@@ -21801,12 +21861,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tagged-tag": {
@@ -23604,7 +23658,7 @@
       "version": "17.11.3",
       "license": "MIT",
       "dependencies": {
-        "@base-ui/react": "1.0.0",
+        "@base-ui/react": "^1.5.0",
         "@spark-ui/hooks": "17.11.3",
         "@spark-ui/icons": "17.11.3",
         "@spark-ui/internal-utils": "17.11.3",
@@ -23626,60 +23680,6 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "tailwindcss": "4.1.18"
-      }
-    },
-    "packages/components/node_modules/@base-ui/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "0.2.3",
-        "@floating-ui/react-dom": "^2.1.6",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
-        "tabbable": "^6.3.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/components/node_modules/@base-ui/utils": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.3.tgz",
-      "integrity": "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "packages/components/node_modules/@react-aria/autocomplete": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
     "build": "NODE_OPTIONS='--max-old-space-size=8192' vite build"
   },
   "dependencies": {
-    "@base-ui/react": "1.0.0",
+    "@base-ui/react": "^1.5.0",
     "@spark-ui/hooks": "17.11.3",
     "@spark-ui/icons": "17.11.3",
     "@spark-ui/internal-utils": "17.11.3",

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -242,7 +242,7 @@ export const Multiple: StoryFn = () => {
 }
 
 export const Controlled: StoryFn = () => {
-  const [value, setValue] = useState(['watercraft'])
+  const [value, setValue] = useState<string[]>(['watercraft'])
 
   return (
     <div>
@@ -257,7 +257,7 @@ export const Controlled: StoryFn = () => {
         <Checkbox value="aircrafts">Aircrafts</Checkbox>
       </CheckboxGroup>
 
-      <Accordion multiple value={value} onValueChange={setValue}>
+      <Accordion multiple value={value} onValueChange={newValue => setValue(newValue as string[])}>
         <Accordion.Item value="watercraft">
           <Accordion.ItemTrigger>Watercraft</Accordion.ItemTrigger>
           <Accordion.ItemContent>

--- a/packages/components/src/toggle-group/ToggleGroup.doc.mdx
+++ b/packages/components/src/toggle-group/ToggleGroup.doc.mdx
@@ -1,0 +1,104 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks'
+import { A11yReport } from '@docs/helpers/A11yReport'
+import { AriaRoles } from '@docs/helpers/AriaRoles'
+import { ToggleGroup } from '.'
+import { Kbd } from '@spark-ui/components/kbd'
+
+import * as stories from './ToggleGroup.stories'
+
+<Meta of={stories} />
+
+# ToggleGroup
+
+A set of two-state buttons that can be toggled on or off within a group context.
+
+<Canvas of={stories.Default} />
+
+## Install
+
+```
+npm install @spark-ui/components
+```
+
+## Anatomy
+
+```tsx
+import { ToggleGroup } from '@spark-ui/components/toggle-group'
+
+export default () => (
+  <ToggleGroup>
+    <ToggleGroup.Toggle value="option-1" />
+    <ToggleGroup.Toggle value="option-2" />
+  </ToggleGroup>
+)
+```
+
+## API Reference
+
+### ToggleGroup
+
+Contains all the toggle group component parts.
+
+<ArgTypes of={ToggleGroup} />
+
+### \_.Toggle
+
+A toggle button within the group.
+
+<ArgTypes of={ToggleGroup.Toggle} />
+
+## Examples
+
+### Multiple
+
+Use the `multiple` prop to allow multiple toggles to be pressed simultaneously. 
+
+**Important:** Both `value` and `defaultValue` must always be arrays, even for single selection mode.
+
+<Canvas of={stories.Multiple} />
+
+### With Existing Spark Components
+
+Use the `asChild` prop on `ToggleGroup.Toggle` to compose with existing Spark components like Button or Chip.
+
+<Canvas of={stories.WithExistingSparkComponents} />
+
+### Controlled
+
+Control the toggle group state using the `value` and `onValueChange` props.
+
+<Canvas of={stories.Controlled} />
+
+### Disabled
+
+Use the `disabled` prop on individual toggles to prevent user interaction.
+
+<Canvas of={stories.Disabled} />
+
+### With FormField
+
+Integrate ToggleGroup with FormField for form contexts using `FormField.Control`.
+
+<Canvas of={stories.WithFormField} />
+
+## Implementation
+
+This component provides a custom implementation of a toggle group pattern, allowing for single or multiple selection of toggle buttons.
+
+## Accessibility
+
+<A11yReport of="toggle-group" />
+
+Adheres to the [Toggle Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/).
+
+### Tips
+
+- Always provide an `aria-label` prop on the `ToggleGroup` to describe the group's purpose.
+- Each `ToggleGroup.Toggle` should have an `aria-label` that describes its specific action.
+- Use the `value` prop to uniquely identify each toggle within the group.
+
+### Keyboard Interactions
+
+- <Kbd>Tab</Kbd>: Moves focus to the next toggle in the group.
+- <Kbd>Space</Kbd>: Toggles the pressed state of the focused toggle.
+- <Kbd>Enter</Kbd>: Toggles the pressed state of the focused toggle.

--- a/packages/components/src/toggle-group/ToggleGroup.stories.tsx
+++ b/packages/components/src/toggle-group/ToggleGroup.stories.tsx
@@ -1,0 +1,231 @@
+import { BookmarkFill } from '@spark-ui/icons/BookmarkFill'
+import { EyeFill } from '@spark-ui/icons/EyeFill'
+import { HomeFill } from '@spark-ui/icons/HomeFill'
+import { LikeFill } from '@spark-ui/icons/LikeFill'
+import { MailFill } from '@spark-ui/icons/MailFill'
+import { StarFill } from '@spark-ui/icons/StarFill'
+import type { Meta, StoryFn } from '@storybook/react-vite'
+import { useState } from 'react'
+
+import { ToggleGroup } from '.'
+import { Button } from '../button'
+import { FormField } from '../form-field'
+import { Icon } from '../icon'
+import { ToggleGroupToggle } from './ToggleGroupToggle'
+
+const meta: Meta<typeof ToggleGroup> = {
+  title: 'Components/ToggleGroup',
+  component: ToggleGroup,
+  subcomponents: {
+    'ToggleGroup.Toggle': ToggleGroupToggle,
+  },
+  tags: ['data-entry'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/0QchRdipAVuvVoDfTjLrgQ/Component-Specs-of-Spark',
+      allowFullscreen: true,
+    },
+  },
+}
+
+export default meta
+
+export const Default: StoryFn = () => {
+  const toggleStyles =
+    'bg-neutral-container px-lg py-md data-[pressed]:bg-main data-[pressed]:text-on-main first:rounded-l-md last:rounded-r-md'
+
+  return (
+    <ToggleGroup className="gap-px" defaultValue={['star']} aria-label="Favorite options">
+      <ToggleGroup.Toggle value="star" aria-label="Star" className={toggleStyles}>
+        <Icon size="sm">
+          <StarFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="like" aria-label="Like" className={toggleStyles}>
+        <Icon size="sm">
+          <LikeFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="bookmark" aria-label="Bookmark" className={toggleStyles}>
+        <Icon size="sm">
+          <BookmarkFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+    </ToggleGroup>
+  )
+}
+
+export const Multiple: StoryFn = () => {
+  const toggleStyles =
+    'bg-neutral-container px-lg py-md data-[pressed]:bg-main data-[pressed]:text-on-main first:rounded-l-md last:rounded-r-md'
+
+  return (
+    <ToggleGroup
+      className="gap-px"
+      multiple
+      defaultValue={['star', 'like']}
+      aria-label="Favorite options"
+    >
+      <ToggleGroup.Toggle value="star" aria-label="Star" className={toggleStyles}>
+        <Icon size="sm">
+          <StarFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="like" aria-label="Like" className={toggleStyles}>
+        <Icon size="sm">
+          <LikeFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="bookmark" aria-label="Bookmark" className={toggleStyles}>
+        <Icon size="sm">
+          <BookmarkFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+    </ToggleGroup>
+  )
+}
+
+export const WithExistingSparkComponents: StoryFn = () => {
+  const [buttonValues, setButtonValues] = useState<string[]>(['star'])
+
+  return (
+    <ToggleGroup
+      value={buttonValues}
+      onValueChange={v => setButtonValues(v as string[])}
+      aria-label="Favorite options"
+      className="gap-md flex"
+    >
+      <ToggleGroup.Toggle value="star" aria-label="Star" asChild>
+        <Button
+          design={buttonValues.includes('star') ? 'filled' : 'outlined'}
+          intent="support"
+          size="md"
+        >
+          <Icon size="sm">
+            <StarFill />
+          </Icon>
+          Favorite
+        </Button>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="like" aria-label="Like" asChild>
+        <Button
+          design={buttonValues.includes('like') ? 'filled' : 'outlined'}
+          intent="support"
+          size="md"
+        >
+          <Icon size="sm">
+            <LikeFill />
+          </Icon>
+          Like
+        </Button>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="bookmark" aria-label="Bookmark" asChild>
+        <Button
+          design={buttonValues.includes('bookmark') ? 'filled' : 'outlined'}
+          intent="support"
+          size="md"
+        >
+          <Icon size="sm">
+            <BookmarkFill />
+          </Icon>
+          Bookmark
+        </Button>
+      </ToggleGroup.Toggle>
+    </ToggleGroup>
+  )
+}
+
+export const Controlled: StoryFn = () => {
+  const [value, setValue] = useState<any>(['home'])
+
+  const toggleStyles =
+    'bg-neutral-container px-lg py-md data-[pressed]:bg-main data-[pressed]:text-on-main first:rounded-l-md last:rounded-r-md'
+
+  return (
+    <ToggleGroup value={value} onValueChange={v => setValue(v)} aria-label="Navigation">
+      <ToggleGroup.Toggle value="home" aria-label="Home" className={toggleStyles}>
+        <Icon size="sm">
+          <HomeFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="mail" aria-label="Mail" className={toggleStyles}>
+        <Icon size="sm">
+          <MailFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="eye" aria-label="View" className={toggleStyles}>
+        <Icon size="sm">
+          <EyeFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+    </ToggleGroup>
+  )
+}
+
+export const Disabled: StoryFn = () => {
+  const toggleStyles =
+    'bg-neutral-container px-lg py-md data-[pressed]:bg-main data-[pressed]:text-on-main first:rounded-l-md last:rounded-r-md'
+
+  return (
+    <ToggleGroup defaultValue={['star']} aria-label="Favorite options">
+      <ToggleGroup.Toggle value="star" aria-label="Star" className={toggleStyles}>
+        <Icon size="sm">
+          <StarFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="like" aria-label="Like" disabled className={toggleStyles}>
+        <Icon size="sm">
+          <LikeFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+      <ToggleGroup.Toggle value="bookmark" aria-label="Bookmark" className={toggleStyles}>
+        <Icon size="sm">
+          <BookmarkFill />
+        </Icon>
+      </ToggleGroup.Toggle>
+    </ToggleGroup>
+  )
+}
+
+export const WithFormField: StoryFn = () => {
+  const [view, setView] = useState<any>(['home'])
+
+  const toggleStyles =
+    'bg-neutral-container px-lg py-md data-[pressed]:bg-main data-[pressed]:text-on-main first:rounded-l-md last:rounded-r-md'
+
+  return (
+    <FormField name="navigation-view">
+      <FormField.Label>Navigation View</FormField.Label>
+      <FormField.Control>
+        {({ labelId, description }) => {
+          return (
+            <ToggleGroup
+              value={view}
+              onValueChange={v => setView(v)}
+              aria-labelledby={labelId}
+              aria-describedby={description}
+            >
+              <ToggleGroup.Toggle value="home" aria-label="Home" className={toggleStyles}>
+                <Icon size="sm">
+                  <HomeFill />
+                </Icon>
+              </ToggleGroup.Toggle>
+              <ToggleGroup.Toggle value="mail" aria-label="Mail" className={toggleStyles}>
+                <Icon size="sm">
+                  <MailFill />
+                </Icon>
+              </ToggleGroup.Toggle>
+              <ToggleGroup.Toggle value="eye" aria-label="View" className={toggleStyles}>
+                <Icon size="sm">
+                  <EyeFill />
+                </Icon>
+              </ToggleGroup.Toggle>
+            </ToggleGroup>
+          )
+        }}
+      </FormField.Control>
+      <FormField.HelperMessage>Choose your preferred navigation view</FormField.HelperMessage>
+    </FormField>
+  )
+}

--- a/packages/components/src/toggle-group/ToggleGroup.styles.ts
+++ b/packages/components/src/toggle-group/ToggleGroup.styles.ts
@@ -1,0 +1,5 @@
+import { cx } from 'class-variance-authority'
+
+export const rootStyles = ({ className }: { className?: string }) => {
+  return cx('gap-none inline-flex', className)
+}

--- a/packages/components/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/components/src/toggle-group/ToggleGroup.test.tsx
@@ -1,0 +1,291 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ToggleGroup } from '.'
+
+describe('ToggleGroup', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('should render', () => {
+    render(
+      <ToggleGroup aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    expect(screen.getByRole('group', { name: 'Test group' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Option 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Option 2' })).toBeInTheDocument()
+    expect(document.querySelector('[data-spark-component="toggle-group"]')).toBeInTheDocument()
+  })
+
+  it('should handle single selection', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    render(
+      <ToggleGroup onValueChange={onValueChange} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option1 = screen.getByRole('button', { name: 'Option 1' })
+    const option2 = screen.getByRole('button', { name: 'Option 2' })
+
+    await user.click(option1)
+    expect(onValueChange).toHaveBeenCalled()
+    expect(option1).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(option2)
+    expect(onValueChange).toHaveBeenCalled()
+    expect(option2).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('should handle multiple selection', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    render(
+      <ToggleGroup multiple onValueChange={onValueChange} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option1 = screen.getByRole('button', { name: 'Option 1' })
+    const option2 = screen.getByRole('button', { name: 'Option 2' })
+
+    await user.click(option1)
+    expect(onValueChange).toHaveBeenCalled()
+
+    await user.click(option2)
+    expect(onValueChange).toHaveBeenCalled()
+
+    await user.click(option1)
+    expect(onValueChange).toHaveBeenCalled()
+  })
+
+  it('should handle defaultValue', () => {
+    render(
+      <ToggleGroup defaultValue={['option2']} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option2 = screen.getByRole('button', { name: 'Option 2' })
+    expect(option2).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('should handle controlled value', () => {
+    const { rerender } = render(
+      <ToggleGroup value={['option1']} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option1 = screen.getByRole('button', { name: 'Option 1' })
+    expect(option1).toHaveAttribute('aria-pressed', 'true')
+
+    rerender(
+      <ToggleGroup value={['option2']} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option2 = screen.getByRole('button', { name: 'Option 2' })
+    expect(option2).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('should handle disabled toggle', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    render(
+      <ToggleGroup onValueChange={onValueChange} aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1" disabled>
+          Option 1
+        </ToggleGroup.Toggle>
+        <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+          Option 2
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const option1 = screen.getByRole('button', { name: 'Option 1' })
+    await user.click(option1)
+
+    expect(onValueChange).not.toHaveBeenCalled()
+    expect(option1).toBeDisabled()
+  })
+
+  it('should render with asChild', () => {
+    render(
+      <ToggleGroup aria-label="Test group">
+        <ToggleGroup.Toggle value="option1" aria-label="Option 1" asChild>
+          <a href="#" data-testid="custom-link">
+            Custom Element
+          </a>
+        </ToggleGroup.Toggle>
+      </ToggleGroup>
+    )
+
+    const link = screen.getByTestId('custom-link')
+    expect(link).toHaveAttribute('href', '#')
+    expect(link).toHaveAttribute('aria-pressed', 'false')
+    expect(link).toHaveAttribute('data-spark-component', 'toggle-group-toggle')
+  })
+
+  describe('Keyboard navigation', () => {
+    it('should maintain focus after click', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <ToggleGroup aria-label="Test group">
+          <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+            Option 1
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+            Option 2
+          </ToggleGroup.Toggle>
+        </ToggleGroup>
+      )
+
+      const option1 = screen.getByRole('button', { name: 'Option 1' })
+
+      // Click should focus the element
+      await user.click(option1)
+      expect(document.activeElement).toBe(option1)
+    })
+
+    it('should navigate with arrow keys', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <ToggleGroup aria-label="Test group">
+          <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+            Option 1
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+            Option 2
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option3" aria-label="Option 3">
+            Option 3
+          </ToggleGroup.Toggle>
+        </ToggleGroup>
+      )
+
+      const option1 = screen.getByRole('button', { name: 'Option 1' })
+      const option2 = screen.getByRole('button', { name: 'Option 2' })
+      const option3 = screen.getByRole('button', { name: 'Option 3' })
+
+      // Focus first option
+      option1.focus()
+      expect(document.activeElement).toBe(option1)
+
+      // Arrow right should move to option2
+      await user.keyboard('{ArrowRight}')
+      expect(document.activeElement).toBe(option2)
+
+      // Arrow right should move to option3
+      await user.keyboard('{ArrowRight}')
+      expect(document.activeElement).toBe(option3)
+
+      // Arrow left should move back to option2
+      await user.keyboard('{ArrowLeft}')
+      expect(document.activeElement).toBe(option2)
+    })
+
+    it('should navigate with Home and End keys', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <ToggleGroup aria-label="Test group">
+          <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+            Option 1
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option2" aria-label="Option 2">
+            Option 2
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option3" aria-label="Option 3">
+            Option 3
+          </ToggleGroup.Toggle>
+        </ToggleGroup>
+      )
+
+      const option1 = screen.getByRole('button', { name: 'Option 1' })
+      const option2 = screen.getByRole('button', { name: 'Option 2' })
+      const option3 = screen.getByRole('button', { name: 'Option 3' })
+
+      // Focus middle option
+      option2.focus()
+      expect(document.activeElement).toBe(option2)
+
+      // End key should move to last option
+      await user.keyboard('{End}')
+      expect(document.activeElement).toBe(option3)
+
+      // Home key should move to first option
+      await user.keyboard('{Home}')
+      expect(document.activeElement).toBe(option1)
+    })
+
+    it('should skip disabled toggles during navigation', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <ToggleGroup aria-label="Test group">
+          <ToggleGroup.Toggle value="option1" aria-label="Option 1">
+            Option 1
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option2" aria-label="Option 2" disabled>
+            Option 2
+          </ToggleGroup.Toggle>
+          <ToggleGroup.Toggle value="option3" aria-label="Option 3">
+            Option 3
+          </ToggleGroup.Toggle>
+        </ToggleGroup>
+      )
+
+      const option1 = screen.getByRole('button', { name: 'Option 1' })
+      const option3 = screen.getByRole('button', { name: 'Option 3' })
+
+      // Focus first option
+      option1.focus()
+      expect(document.activeElement).toBe(option1)
+
+      // Arrow right should skip disabled option2 and move to option3
+      await user.keyboard('{ArrowRight}')
+      expect(document.activeElement).toBe(option3)
+    })
+  })
+})

--- a/packages/components/src/toggle-group/ToggleGroup.tsx
+++ b/packages/components/src/toggle-group/ToggleGroup.tsx
@@ -1,0 +1,66 @@
+import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group'
+import { cx } from 'class-variance-authority'
+import { type ComponentPropsWithoutRef, type PropsWithChildren, Ref } from 'react'
+
+import { useRenderSlot } from './useRenderSlot'
+
+export interface ToggleGroupProps extends PropsWithChildren, ComponentPropsWithoutRef<'div'> {
+  /**
+   * Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node.
+   * @default false
+   */
+  asChild?: boolean
+  /**
+   * Whether multiple toggles can be pressed at the same time.
+   * @default false
+   */
+  multiple?: boolean
+  /**
+   * The default value(s) of the toggle group when it is initially rendered.
+   * Use when you do not need to control its value(s).
+   * Must be an array even for single selection mode.
+   */
+  defaultValue?: readonly any[]
+  /**
+   * The controlled value(s) of the toggle group.
+   * Must be used in conjunction with `onValueChange`.
+   * Must be an array even for single selection mode.
+   */
+  value?: readonly any[]
+  /**
+   * Event handler called when the value changes.
+   * Always receives an array, even for single selection mode.
+   */
+  onValueChange?: (value: readonly any[]) => void
+  ref?: Ref<HTMLDivElement>
+}
+
+export const ToggleGroup = ({
+  /**
+   * Default Base UI Primitive values
+   * see https://base-ui.com/react/components/toggle-group
+   */
+  asChild = false,
+  multiple = false,
+  children,
+  className,
+  ref,
+  ...rest
+}: ToggleGroupProps) => {
+  const renderSlot = useRenderSlot(asChild)
+
+  return (
+    <BaseToggleGroup
+      {...rest}
+      ref={ref}
+      multiple={multiple}
+      className={cx('gap-none inline-flex', className)}
+      data-spark-component="toggle-group"
+      {...(asChild && { render: renderSlot })}
+    >
+      {children}
+    </BaseToggleGroup>
+  )
+}
+
+ToggleGroup.displayName = 'ToggleGroup'

--- a/packages/components/src/toggle-group/ToggleGroupToggle.tsx
+++ b/packages/components/src/toggle-group/ToggleGroupToggle.tsx
@@ -1,0 +1,60 @@
+import { Toggle } from '@base-ui/react/toggle'
+import { cx } from 'class-variance-authority'
+import { type ComponentPropsWithoutRef, Ref } from 'react'
+
+import { useRenderSlot } from './useRenderSlot'
+
+export interface ToggleGroupToggleProps extends ComponentPropsWithoutRef<'button'> {
+  /**
+   * A unique value that identifies the toggle within the group.
+   */
+  value: any
+  /**
+   * Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node.
+   * @default false
+   */
+  asChild?: boolean
+  /**
+   * When true, prevents the user from interacting with the toggle.
+   * @default false
+   */
+  disabled?: boolean
+  ref?: Ref<HTMLButtonElement>
+}
+
+/** A toggle button within a toggle group. Renders a <button> element. */
+export const ToggleGroupToggle = ({
+  /**
+   * Default Base UI Primitive values
+   * see https://base-ui.com/react/components/toggle
+   */
+  asChild = false,
+  value,
+  disabled = false,
+  children,
+  className,
+  ref,
+  ...rest
+}: ToggleGroupToggleProps) => {
+  const renderSlot = useRenderSlot(asChild)
+
+  return (
+    <Toggle
+      data-spark-component="toggle-group-toggle"
+      ref={ref}
+      className={cx(
+        'focus-visible:u-outline-inset',
+        'disabled:cursor-not-allowed disabled:opacity-dim-3',
+        className
+      )}
+      {...(asChild && { render: renderSlot })}
+      disabled={disabled}
+      value={value}
+      {...rest}
+    >
+      {children}
+    </Toggle>
+  )
+}
+
+ToggleGroupToggle.displayName = 'ToggleGroup.Toggle'

--- a/packages/components/src/toggle-group/index.ts
+++ b/packages/components/src/toggle-group/index.ts
@@ -1,0 +1,17 @@
+import { ToggleGroup as Root } from './ToggleGroup'
+import { ToggleGroupToggle as Toggle } from './ToggleGroupToggle'
+
+/**
+ * A set of two-state buttons that can be toggled on or off within a group context.
+ */
+export const ToggleGroup: typeof Root & {
+  Toggle: typeof Toggle
+} = Object.assign(Root, {
+  Toggle,
+})
+
+ToggleGroup.displayName = 'ToggleGroup'
+Toggle.displayName = 'ToggleGroup.Toggle'
+
+export { type ToggleGroupProps } from './ToggleGroup'
+export { type ToggleGroupToggleProps } from './ToggleGroupToggle'

--- a/packages/components/src/toggle-group/useRenderSlot.tsx
+++ b/packages/components/src/toggle-group/useRenderSlot.tsx
@@ -1,0 +1,5 @@
+import { Slot } from '../slot'
+
+export function useRenderSlot(asChild: boolean) {
+  return asChild ? ({ ...props }: object) => <Slot {...props} /> : undefined
+}


### PR DESCRIPTION
### Description, Motivation and Context

`ToggleGroup` components. Almost headless (no styles).

- single selection
- multiple selection
- polymorphic (possible to use custom components or reuse existing Spark components such as Button or Chip/Card)

Why just "almost" => it has default focus styles for a11y (keyboard navigation).

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations

<img width="1058" height="299" alt="Capture d’écran 2026-06-15 à 15 14 58" src="https://github.com/user-attachments/assets/0d1a6052-d309-4e65-bd6e-146fc84b4d0a" />
