### PR TITLE
Accordion header content

### DIFF
--- a/packages/components/src/accordion/Accordion.doc.mdx
+++ b/packages/components/src/accordion/Accordion.doc.mdx
@@ -98,6 +98,12 @@ Use `design` to pick the overall look of the component (`filled` or `outlined`).
 
 <Canvas of={stories.Design} />
 
+### Intent
+
+Use `intent` to change the color scheme of the accordion (`surface` or `support`).
+
+<Canvas of={stories.Intent} />
+
 ### Disabled
 
 Use `disabled` to disabled the full `Accordion`.

--- a/packages/components/src/accordion/Accordion.doc.mdx
+++ b/packages/components/src/accordion/Accordion.doc.mdx
@@ -32,21 +32,19 @@ npm install @spark-ui/components
 ## Anatomy
 
 ```tsx
-import { Accordion } from "@spark-ui/components/accordion"
+import { Accordion } from '@spark-ui/components/accordion'
 
 export default () => (
   <Accordion>
-    <Accordion.Item> 
+    <Accordion.Item>
       <Accordion.ItemHeader>
         <Accordion.ItemTrigger />
       </Accordion.ItemHeader>
       <Accordion.ItemContent />
     </Accordion.Item>
   </Accordion>
-);
+)
 ```
-
-
 
 ## API Reference
 
@@ -56,35 +54,31 @@ Contains all the parts of an accordion.
 
 <ArgTypes of={Accordion} />
 
-### _.Item
+### \_.Item
 
 Contains all the parts of a collapsible section.
 
 <ArgTypes of={Accordion.Item} />
 
-### _.ItemHeader
+### \_.ItemHeader
 
 Set the heading level for your accordion trigger elements. By default, renders an `h3`.
 
 <ArgTypes of={Accordion.ItemHeader} />
 
-### _.ItemTrigger
+### \_.ItemTrigger
 
 Toggles the collapsed state of its associated item.
 
 <ArgTypes of={Accordion.ItemTrigger} />
 
-
-### _.ItemContent
+### \_.ItemContent
 
 Contains the collapsible content for an item.
 
 <ArgTypes of={Accordion.ItemContent} />
 
-
-
 ## Examples
-
 
 ### Controlled
 
@@ -123,6 +117,15 @@ Use `multiple` to allow multiple panels to be opened at the same time.
 Use `defaultValue` to pass an array of panels values to open by default.
 
 <Canvas of={stories.Multiple} />
+
+## Advanced Usage
+
+### Custom header content
+
+`Accordion.ItemTrigger` accepts dynamic children, allowing you for more than just a string of text.
+Note that the full textual content of the children will become the accessible name for the trigger.
+
+<Canvas of={stories.CustomHeaders} />
 
 ## Accessibility
 
@@ -177,11 +180,14 @@ Adheres to the [Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/acco
 
 ### Roles
 
-<AriaRoles of={Accordion} role="none" subcomponents={{
-  'Accordion.Item': {
-    of: Accordion.Item,
-    role: 'none',
-  },
+<AriaRoles
+  of={Accordion}
+  role="none"
+  subcomponents={{
+    'Accordion.Item': {
+      of: Accordion.Item,
+      role: 'none',
+    },
     'Accordion.ItemHeader': {
       of: Accordion.ItemHeader,
       role: 'heading',
@@ -194,4 +200,5 @@ Adheres to the [Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/acco
       of: Accordion.ItemContent,
       role: 'region',
     },
-}} />
+  }}
+/>

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -169,6 +169,64 @@ export const Design: StoryFn = _args => {
   )
 }
 
+export const Intent: StoryFn = _args => {
+  const intents = ['surface', 'support'] as const
+
+  return (
+    <div className="gap-xl p-xl grid grid-cols-2">
+      {intents.map(intent => {
+        return (
+          <div key={intent}>
+            <Tag className="mb-sm">{intent === 'surface' ? 'surface (default)' : intent}</Tag>
+            <Accordion
+              multiple
+              intent={intent}
+              defaultValue={['watercraft']}
+              aria-label={`Accordion with ${intent} intent`}
+            >
+              <Accordion.Item value="watercraft">
+                <Accordion.ItemTrigger>
+                  Watercraft <span className="sr-only">{intent}</span>
+                </Accordion.ItemTrigger>
+                <Accordion.ItemContent>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua.
+                  </p>
+                </Accordion.ItemContent>
+              </Accordion.Item>
+
+              <Accordion.Item value="automobiles">
+                <Accordion.ItemTrigger>
+                  Automobiles <span className="sr-only">{intent}</span>
+                </Accordion.ItemTrigger>
+                <Accordion.ItemContent>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua.
+                  </p>
+                </Accordion.ItemContent>
+              </Accordion.Item>
+
+              <Accordion.Item value="aircrafts">
+                <Accordion.ItemTrigger>
+                  Aircrafts <span className="sr-only">{intent}</span>
+                </Accordion.ItemTrigger>
+                <Accordion.ItemContent>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua.
+                  </p>
+                </Accordion.ItemContent>
+              </Accordion.Item>
+            </Accordion>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 export const DisabledItem: StoryFn = () => {
   return (
     <Accordion defaultValue={['watercraft']}>

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -2,6 +2,8 @@ import { Meta, StoryFn } from '@storybook/react-vite'
 import { useState } from 'react'
 
 import { Accordion } from '.'
+import { Button } from '../button'
+import { Card } from '../card'
 import { Checkbox, CheckboxGroup } from '../checkbox'
 import { Tag } from '../tag'
 import { Item as AccordionItem } from './AccordionItem'
@@ -347,5 +349,92 @@ export const Controlled: StoryFn = () => {
         </Accordion.Item>
       </Accordion>
     </div>
+  )
+}
+
+export const CustomHeaders: StoryFn = () => {
+  const programs = [
+    {
+      id: 'wonder-flats',
+      name: 'Apartment - 2 rooms - WONDER FLATS',
+      minPrice: '200,000 €',
+      unitsAvailable: 2,
+      units: [
+        { rooms: 2, price: 200000, sqm: 45, floor: 2 },
+        { rooms: 2, price: 215000, sqm: 48, floor: 4 },
+      ],
+    },
+    {
+      id: 'green-residence',
+      name: 'Apartment - 3 rooms - GREEN RESIDENCE',
+      minPrice: '320,000 €',
+      unitsAvailable: 3,
+      units: [
+        { rooms: 3, price: 320000, sqm: 65, floor: 1 },
+        { rooms: 3, price: 335000, sqm: 68, floor: 3 },
+        { rooms: 3, price: 350000, sqm: 70, floor: 5 },
+      ],
+    },
+    {
+      id: 'sunset-towers',
+      name: 'Apartment - 4 rooms - SUNSET TOWERS',
+      minPrice: '480,000 €',
+      unitsAvailable: 1,
+      units: [{ rooms: 4, price: 480000, sqm: 95, floor: 8 }],
+    },
+  ]
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(price)
+  }
+
+  const calculatePricePerSqm = (price: number, sqm: number) => {
+    return Math.round(price / sqm)
+  }
+
+  return (
+    <Accordion intent="support" defaultValue={['wonder-flats']}>
+      {programs.map(program => (
+        <Accordion.Item key={program.id} value={program.id}>
+          <Accordion.ItemTrigger>
+            <div className="flex grow items-center justify-between">
+              <div className="flex flex-col">
+                <span className="text-headline-2">{program.name}</span>
+                <span className="text-caption font-regular">as low as {program.minPrice}</span>
+              </div>
+              <span className="text-body-2 font-regular ml-lg shrink-0">
+                {program.unitsAvailable} {program.unitsAvailable === 1 ? 'unit' : 'units'} available
+              </span>
+            </div>
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent>
+            <div className="gap-md flex flex-col">
+              {program.units.map((unit, index) => {
+                const pricePerSqm = calculatePricePerSqm(unit.price, unit.sqm)
+                return (
+                  <Card design="tinted" intent="neutral" key={index}>
+                    <Card.Content className="gap-md flex items-center">
+                      <div className="gap-sm flex grow flex-col">
+                        <span className="text-body-1">
+                          {unit.rooms} {unit.rooms === 1 ? 'room' : 'rooms'} •{' '}
+                          <span className="text-main font-bold">{formatPrice(unit.price)}</span> (
+                          {formatPrice(pricePerSqm)}/m²)
+                        </span>
+                        <span className="text-caption text-neutral">
+                          {unit.sqm} m² • Floor {unit.floor}
+                        </span>
+                      </div>
+                      <Button design="filled" intent="support">
+                        Request map
+                      </Button>
+                    </Card.Content>
+                  </Card>
+                )
+              })}
+            </div>
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      ))}
+    </Accordion>
   )
 }

--- a/packages/components/src/accordion/Accordion.tsx
+++ b/packages/components/src/accordion/Accordion.tsx
@@ -25,6 +25,11 @@ export interface AccordionProps extends ExtentedBaseUIInterface {
    */
   multiple?: boolean
   design?: 'filled' | 'outlined'
+  /**
+   * Change the color scheme of the accordion
+   * @default surface
+   */
+  intent?: 'surface' | 'support'
   ref?: Ref<HTMLDivElement>
   /**
    * The controlled value (always an array of strings)
@@ -42,12 +47,14 @@ export interface AccordionProps extends ExtentedBaseUIInterface {
 
 const AccordionContext = createContext<{
   design: 'filled' | 'outlined'
+  intent: 'surface' | 'support'
 } | null>(null)
 
 export function Accordion({
   asChild = false,
   children,
   design = 'outlined',
+  intent = 'surface',
   hiddenUntilFound = true,
   multiple = false,
   className,
@@ -70,7 +77,7 @@ export function Accordion({
     : undefined
 
   return (
-    <AccordionContext value={{ design }}>
+    <AccordionContext value={{ design, intent }}>
       <BaseAccordion.Root
         data-spark-component="accordion"
         ref={ref}

--- a/packages/components/src/accordion/AccordionItemTrigger.tsx
+++ b/packages/components/src/accordion/AccordionItemTrigger.tsx
@@ -33,9 +33,8 @@ export const ItemTrigger = ({
         'group',
         'gap-lg min-h-sz-48 relative flex items-center justify-between',
         'px-lg py-md text-headline-2 data-panel-open:rounded-b-0 w-full rounded-[inherit] text-left',
-
         'focus-visible:u-outline focus-visible:z-raised focus-visible:outline-hidden',
-        'disabled:opacity-dim-3 cursor-pointer disabled:cursor-not-allowed',
+        'data-disabled:opacity-dim-3 cursor-pointer data-disabled:cursor-not-allowed',
         intent === 'surface' &&
           'bg-surface text-on-surface hover:enabled:bg-surface-hovered focus:bg-surface-hovered',
         intent === 'support' &&

--- a/packages/components/src/accordion/AccordionItemTrigger.tsx
+++ b/packages/components/src/accordion/AccordionItemTrigger.tsx
@@ -4,6 +4,7 @@ import { cx } from 'class-variance-authority'
 import { type ComponentProps, Ref } from 'react'
 
 import { Icon } from '../icon'
+import { useAccordionContext } from './Accordion'
 import { useRenderSlot } from './useRenderSlot'
 
 type ExtentedZagInterface = Omit<ComponentProps<typeof BaseAccordion.Trigger>, 'render'>
@@ -21,6 +22,7 @@ export const ItemTrigger = ({
   ...props
 }: AccordionItemTriggerProps) => {
   const renderSlot = useRenderSlot(asChild, 'button')
+  const { intent } = useAccordionContext()
 
   return (
     <BaseAccordion.Trigger
@@ -30,10 +32,14 @@ export const ItemTrigger = ({
       className={cx(
         'group',
         'gap-lg min-h-sz-48 relative flex items-center justify-between',
-        'px-lg py-md text-headline-2 text-on-surface data-[panel-open]:rounded-b-0 w-full rounded-[inherit] text-left',
-        'hover:enabled:bg-surface-hovered focus:bg-surface-hovered',
+        'px-lg py-md text-headline-2 data-panel-open:rounded-b-0 w-full rounded-[inherit] text-left',
+
         'focus-visible:u-outline focus-visible:z-raised focus-visible:outline-hidden',
         'disabled:opacity-dim-3 cursor-pointer disabled:cursor-not-allowed',
+        intent === 'surface' &&
+          'bg-surface text-on-surface hover:enabled:bg-surface-hovered focus:bg-surface-hovered',
+        intent === 'support' &&
+          'bg-support-container text-on-support-container hover:enabled:bg-support-container-hovered focus:bg-support-container-hovered',
         className
       )}
       {...props}
@@ -43,7 +49,7 @@ export const ItemTrigger = ({
         intent="neutral"
         className={cx(
           'shrink-0 rotate-0 duration-100 ease-in motion-reduce:transition-none',
-          'group-data-[panel-open]:rotate-180'
+          'group-data-panel-open:rotate-180'
         )}
         size="sm"
       >


### PR DESCRIPTION
### Description, Motivation and Context

- Added `intent` prop to `Accordion`: `surface` (default) or `support` for now. Applies colors to the Items triggers.
- Added as story to showcase composability for custom content in header/content.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

<img width="587" height="563" alt="Capture d’écran 2026-06-18 à 17 52 58" src="https://github.com/user-attachments/assets/bc2add2c-1510-48bf-8b2d-a5551bbbf394" />
<img width="586" height="656" alt="Capture d’écran 2026-06-18 à 17 53 12" src="https://github.com/user-attachments/assets/41d5f547-611d-406a-a508-982e7c09b7d4" />
