### PR TITLE
fix(components): prevent native form submission on loading buttons

### DIFF
--- a/packages/components/src/button/Button.test.tsx
+++ b/packages/components/src/button/Button.test.tsx
@@ -124,5 +124,40 @@ describe('Button', () => {
 
       expect(element).toHaveAttribute('aria-busy', 'true')
     })
+
+    it('should not submit form when loading', async () => {
+      const user = userEvent.setup()
+      const submitSpy = vi.fn()
+
+      render(
+        <form onSubmit={submitSpy}>
+          <Button type="submit" isLoading loadingLabel="Loading...">
+            Submit
+          </Button>
+        </form>
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Loading...' }))
+
+      expect(submitSpy).not.toHaveBeenCalled()
+    })
+
+    it('should allow focus to move away with Tab when loading', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <>
+          <Button isLoading loadingLabel="Loading...">
+            Submit
+          </Button>
+          <button>Next</button>
+        </>
+      )
+
+      screen.getByRole('button', { name: 'Loading...' }).focus()
+      await user.keyboard('{Tab}')
+
+      expect(screen.getByRole('button', { name: 'Next' })).toHaveFocus()
+    })
   })
 })

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -78,10 +78,20 @@ export const Button = ({
   const useNativeDisabled = !!disabled && !ariaDisabled
 
   const disabledEventHandlers = useMemo(() => {
-    const result: Partial<Record<DOMAttributesEventHandler, () => void>> = {}
+    const result: Partial<Record<DOMAttributesEventHandler, (e: React.SyntheticEvent) => void>> = {}
 
     if (shouldNotInteract) {
-      blockedEventHandlers.forEach(eventHandler => (result[eventHandler] = undefined))
+      blockedEventHandlers.forEach(key => {
+        result[key] = (e: React.SyntheticEvent) => {
+          // Allow Tab to move focus away from the button
+          if (e.type === 'keydown' && (e as React.KeyboardEvent).key === 'Tab') return
+          /*
+            Setting handlers to `undefined` (e.g. `result[eventHandler] = undefined`) only blocks JS-level handlers, it does not prevent native browser behavior.
+            Calling preventDefault() here also blocks native form submission when type="submit", since the browser triggers it from the click chain.
+          */
+          e.preventDefault()
+        }
+      })
     }
 
     return result


### PR DESCRIPTION
### Description, Motivation and Context
When a `Button` with `type="submit"` was in a loading state, clicking it would still trigger native form submission. This happened because setting event handlers to `undefined` only blocks JS-level handlers, it does not prevent native browser behavior.

The fix replaces the `undefined` assignments with `e.preventDefault()` calls, which correctly blocks native form submission. Tab key navigation is explicitly allowed through so users can still move focus away from a loading button.

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
