### PR TITLE
fix(components): stabilize useToastManager return reference across renders

### DIFF
--- a/packages/components/src/toast/Toast.test.tsx
+++ b/packages/components/src/toast/Toast.test.tsx
@@ -187,5 +187,29 @@ describe('Toast', () => {
         expect(screen.getByText('View it here')).toBeInTheDocument()
       })
     })
+
+    it('should return a stable reference across re-renders', () => {
+      const refs: ReturnType<typeof useToastManager>[] = []
+
+      const Implementation = () => {
+        const toastManager = useToastManager()
+        refs.push(toastManager)
+        return null
+      }
+
+      const { rerender } = render(
+        <ToastProvider>
+          <Implementation />
+        </ToastProvider>
+      )
+
+      rerender(
+        <ToastProvider>
+          <Implementation />
+        </ToastProvider>
+      )
+
+      expect(refs[0]).toBe(refs[1])
+    })
   })
 })

--- a/packages/components/src/toast/useToastManager.ts
+++ b/packages/components/src/toast/useToastManager.ts
@@ -10,8 +10,10 @@ export function useToastManager(): UseToastManagerReturnValue {
     baseToastManager.toasts.forEach(({ id }) => baseToastManager.close(id))
   }, [baseToastManager])
 
-  return {
-    ...baseToastManager,
-    closeAll,
-  } as UseToastManagerReturnValue
+  // Memoize the returned object so its reference is stable across renders,
+  // preventing infinite loops when used as a useEffect dependency.
+  return React.useMemo(
+    () => ({ ...baseToastManager, closeAll }) as UseToastManagerReturnValue,
+    [baseToastManager, closeAll]
+  )
 }


### PR DESCRIPTION
### Description, Motivation and Context
`useToastManager` returned a new object reference on every render due to the object spread in the return statement.
This caused infinite loops when the hook's return value was used as a `useEffect` dependency.

The fix wraps the return value in `useMemo` so the reference stays stable across renders as long as the underlying `baseToastManager` hasn't changed.

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
