### PR TITLE
fix(components): prevent useToastManager from causing infinite loops part 2

### DIFF
--- a/packages/components/src/toast/Toast.test.tsx
+++ b/packages/components/src/toast/Toast.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ToastProvider, ToastTrigger, useToastManager } from '.'
@@ -189,27 +189,25 @@ describe('Toast', () => {
     })
 
     it('should return a stable reference across re-renders', () => {
-      const refs: ReturnType<typeof useToastManager>[] = []
+      const { result, rerender } = renderHook(() => useToastManager(), {
+        wrapper: ToastProvider,
+      })
 
-      const Implementation = () => {
-        const toastManager = useToastManager()
-        refs.push(toastManager)
-        return null
-      }
+      const first = result.current
+      rerender()
 
-      const { rerender } = render(
-        <ToastProvider>
-          <Implementation />
-        </ToastProvider>
-      )
+      expect(result.current).toBe(first)
+    })
 
-      rerender(
-        <ToastProvider>
-          <Implementation />
-        </ToastProvider>
-      )
+    it('should return a stable reference after adding a toast', () => {
+      const { result } = renderHook(() => useToastManager(), {
+        wrapper: ToastProvider,
+      })
 
-      expect(refs[0]).toBe(refs[1])
+      const first = result.current
+      act(() => result.current.add({ title: 'Hello' }))
+
+      expect(result.current).toBe(first)
     })
   })
 })

--- a/packages/components/src/toast/useToastManager.ts
+++ b/packages/components/src/toast/useToastManager.ts
@@ -4,16 +4,21 @@ import * as React from 'react'
 import type { UseToastManagerReturnValue } from './types'
 
 export function useToastManager(): UseToastManagerReturnValue {
-  const baseToastManager = BaseToast.useToastManager()
+  const manager = BaseToast.useToastManager()
+  const managerRef = React.useRef(manager)
+  managerRef.current = manager
 
-  const closeAll = React.useCallback((): void => {
-    baseToastManager.toasts.forEach(({ id }) => baseToastManager.close(id))
-  }, [baseToastManager])
-
-  // Memoize the returned object so its reference is stable across renders,
-  // preventing infinite loops when used as a useEffect dependency.
   return React.useMemo(
-    () => ({ ...baseToastManager, closeAll }) as UseToastManagerReturnValue,
-    [baseToastManager, closeAll]
+    () => ({
+      get toasts() {
+        return managerRef.current.toasts
+      },
+      add: options => managerRef.current.add(options),
+      update: (id, options) => managerRef.current.update(id, options),
+      close: id => managerRef.current.close(id),
+      promise: (p, options) => managerRef.current.promise(p, options),
+      closeAll: () => managerRef.current.toasts.forEach(({ id }) => managerRef.current.close(id)),
+    }),
+    []
   )
 }


### PR DESCRIPTION
### Description, Motivation and Context
 `useToastManager` was returning a new object reference whenever the toast list changed, causing infinite loops when the return value was used as a `useEffect` dependency
- Fixed by wrapping all methods in stable `useCallback([], [])` wrappers that delegate to a ref, and using a getter for `toasts` so it reads live without being a memo dependency

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
