### PR TITLE
feat(components): add fullscreenBelow prop to Dialog for CSS-driven responsive fullscreen

### DIFF
--- a/packages/components/src/dialog/Dialog.doc.mdx
+++ b/packages/components/src/dialog/Dialog.doc.mdx
@@ -156,6 +156,19 @@ Pick a size among `sm`, `md`, `lg` and `fullscreen`.
 
 <Canvas of={stories.Sizes} />
 
+### Responsive fullscreen
+
+Use `fullscreenBelow` on `Dialog.Content` to make the dialog go fullscreen below a given breakpoint. Accepted values are `sm`, `md`, `lg`, `xl`, and `always`.
+
+```tsx
+// Fullscreen until md breakpoint, then size will be lg
+<Dialog.Content size="lg" fullscreenBelow="md">
+```
+
+This is the preferred alternative to `size="fullscreen"`, which is now deprecated. Using `fullscreenBelow="always"` is equivalent to `size="fullscreen"` and does not require a breakpoint.
+
+<Canvas of={stories.Responsive} />
+
 ## Advanced Examples
 
 ### Form inside a dialog

--- a/packages/components/src/dialog/Dialog.stories.tsx
+++ b/packages/components/src/dialog/Dialog.stories.tsx
@@ -69,7 +69,7 @@ export const Default: StoryFn = () => {
       <Dialog.Portal>
         <Dialog.Overlay />
 
-        <Dialog.Content size="lg">
+        <Dialog.Content size="lg" fullscreenBelow="md">
           <Dialog.Header>
             <Dialog.Title>Accessibilité</Dialog.Title>
           </Dialog.Header>
@@ -236,6 +236,59 @@ export const Sizes = () => {
           </Dialog.Footer>
 
           <Dialog.CloseButton aria-label="Close edit size" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}
+
+export const Responsive: StoryFn = () => {
+  const [fullscreenBelow, setFullscreenBelow] =
+    useState<ExcludeNull<DialogContentProps>['fullscreenBelow']>('md')
+
+  return (
+    <Dialog>
+      <div className="gap-md flex">
+        <Dialog.Trigger asChild>
+          <Button>Open</Button>
+        </Dialog.Trigger>
+      </div>
+
+      <Dialog.Portal>
+        <Dialog.Overlay />
+
+        <Dialog.Content fullscreenBelow={fullscreenBelow}>
+          <Dialog.Header>
+            <Dialog.Title>Responsive fullscreen</Dialog.Title>
+          </Dialog.Header>
+
+          <Dialog.Body className="gap-lg flex flex-col">
+            <Dialog.Description>
+              Resize the window to see the dialog go fullscreen below the selected breakpoint.
+            </Dialog.Description>
+
+            <RadioGroup
+              className="gap-md flex flex-wrap"
+              value={fullscreenBelow}
+              onValueChange={value =>
+                setFullscreenBelow(value as ExcludeNull<DialogContentProps>['fullscreenBelow'])
+              }
+            >
+              <RadioGroup.Radio value="sm">sm</RadioGroup.Radio>
+              <RadioGroup.Radio value="md">md</RadioGroup.Radio>
+              <RadioGroup.Radio value="lg">lg</RadioGroup.Radio>
+              <RadioGroup.Radio value="xl">xl</RadioGroup.Radio>
+              <RadioGroup.Radio value="always">always</RadioGroup.Radio>
+            </RadioGroup>
+          </Dialog.Body>
+
+          <Dialog.Footer className="gap-md flex justify-end">
+            <Dialog.Close asChild>
+              <Button>Close</Button>
+            </Dialog.Close>
+          </Dialog.Footer>
+
+          <Dialog.CloseButton aria-label="Close dialog" />
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog>

--- a/packages/components/src/dialog/Dialog.test.tsx
+++ b/packages/components/src/dialog/Dialog.test.tsx
@@ -215,4 +215,43 @@ describe('Dialog', () => {
 
     expect(screen.getByText(/Edit profile/i)).toHaveClass('group-has-data-[part=close]:pr-3xl')
   })
+
+  describe('responsive', () => {
+    it('should render a wrapper with the responsive fullscreen class', () => {
+      render(
+        <Dialog defaultOpen>
+          <Dialog.Portal>
+            <Dialog.Content fullscreenBelow="md">
+              <Dialog.Header>
+                <Dialog.Title>Fullscreen test</Dialog.Title>
+              </Dialog.Header>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog>
+      )
+
+      const wrapper = document.body.querySelector('[class*="max-md"]')
+
+      expect(wrapper).toBeInTheDocument()
+      expect(wrapper).toHaveClass('max-md:[--size:fullscreen]')
+    })
+
+    it('should render a wrapper with the always fullscreen class', () => {
+      render(
+        <Dialog defaultOpen>
+          <Dialog.Portal>
+            <Dialog.Content fullscreenBelow="always">
+              <Dialog.Header>
+                <Dialog.Title>Fullscreen test</Dialog.Title>
+              </Dialog.Header>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog>
+      )
+
+      const wrapper = document.body.querySelector('[class="[--size:fullscreen]"]')
+
+      expect(wrapper).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/components/src/dialog/DialogContent.styles.tsx
+++ b/packages/components/src/dialog/DialogContent.styles.tsx
@@ -6,6 +6,14 @@ export const dialogContentStyles = cva(
     'focus-visible:outline-hidden focus-visible:u-outline',
     '[&:not(:has(footer))]:pb-lg',
     '[&:not(:has(header))]:pt-lg',
+    '[@container_style(--size:fullscreen)]:fixed',
+    '[@container_style(--size:fullscreen)]:size-full',
+    '[@container_style(--size:fullscreen)]:top-0',
+    '[@container_style(--size:fullscreen)]:left-0',
+    '[@container_style(--size:fullscreen)]:max-w-none',
+    '[@container_style(--size:fullscreen)]:max-h-none',
+    '[@container_style(--size:fullscreen)]:translate-none!',
+    '[@container_style(--size:fullscreen)]:rounded-none',
     'data-open:animation-duration-400 data-closed:animation-duration-200',
     'data-starting-style:scale-90 data-starting-style:opacity-0',
     'data-ending-style:scale-90 data-ending-style:opacity-0',
@@ -22,6 +30,7 @@ export const dialogContentStyles = cva(
   {
     variants: {
       size: {
+        /** @deprecated Use `fullscreenBelow="always"` instead. */
         fullscreen: 'fixed size-full top-0 left-0',
         sm: 'max-w-[min(480px,calc(100vw-2rem))] data-nested-dialog-open:scale-90',
         md: 'max-w-[min(672px,calc(100vw-2rem))] data-nested-dialog-open:scale-90',

--- a/packages/components/src/dialog/DialogContent.tsx
+++ b/packages/components/src/dialog/DialogContent.tsx
@@ -5,6 +5,14 @@ import { ComponentProps, Ref, useEffect } from 'react'
 import { dialogContentStyles, type DialogContentStylesProps } from './DialogContent.styles'
 import { useDialog } from './DialogContext'
 
+const FULLSCREEN_BELOW_CLASS = {
+  sm: 'max-sm:[--size:fullscreen]',
+  md: 'max-md:[--size:fullscreen]',
+  lg: 'max-lg:[--size:fullscreen]',
+  xl: 'max-xl:[--size:fullscreen]',
+  always: '[--size:fullscreen]',
+} as const
+
 export interface ContentProps
   extends Omit<ComponentProps<typeof BaseDialog.Popup>, 'render'>, DialogContentStylesProps {
   /**
@@ -12,6 +20,11 @@ export interface ContentProps
    */
   isNarrow?: boolean
   ref?: Ref<HTMLDivElement>
+  /**
+   * Makes the dialog fullscreen at or below the given breakpoint, or always fullscreen when set to "always".
+   * Prefer this over `size="fullscreen"`, which is deprecated.
+   */
+  fullscreenBelow?: keyof typeof FULLSCREEN_BELOW_CLASS
 }
 
 /**
@@ -21,6 +34,7 @@ export const Content = ({
   className,
   isNarrow = false,
   size = 'md',
+  fullscreenBelow,
   ref,
   ...rest
 }: ContentProps) => {
@@ -32,7 +46,7 @@ export const Content = ({
     return () => setIsFullScreen(false)
   }, [setIsFullScreen, size])
 
-  return (
+  const popup = (
     <BaseDialog.Popup
       ref={ref}
       data-spark-component="dialog-content"
@@ -49,6 +63,12 @@ export const Content = ({
       {...rest}
     />
   )
+
+  if (fullscreenBelow) {
+    return <div className={FULLSCREEN_BELOW_CLASS[fullscreenBelow]}>{popup}</div>
+  }
+
+  return popup
 }
 
 Content.displayName = 'Dialog.Content'


### PR DESCRIPTION
### Description, Motivation and Context
Previously, making a dialog go fullscreen on small screens required detecting the window width in JS (e.g. through custom hooks, e.g. `useDialogSize`) and toggling `size="fullscreen"` accordingly. 

This PR introduces a `fullscreenBelow` prop on `Dialog.Content` that leverages [CSS container style queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_size_and_style_queries) to trigger the fullscreen layout purely in CSS.
Setting a CSS custom property (`--size: fullscreen`) on any ancestor is enough, no JS needed.

**Browser support:** CSS container style queries are [supported](https://caniuse.com/css-container-queries-style) in Chrome 111+, Safari 18+, and Firefox 151+.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles
