### PR TITLE
fix(components): replace external image URL in LinkBox a11y test to prevent networkidle timeout

### DIFF
--- a/e2e/a11y/pages/LinkBox.tsx
+++ b/e2e/a11y/pages/LinkBox.tsx
@@ -11,7 +11,7 @@ export const A11yLinkBox = () => (
       <LinkBox asChild>
         <article className="space-y-md">
           <div className="bg-neutral relative aspect-square w-full overflow-hidden rounded-md shadow-md">
-            <img className="size-full" src="https://picsum.photos/200/200" alt="Card image" />
+            <img className="size-full" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Crect width='200' height='200' fill='%23ccc'/%3E%3C/svg%3E" alt="Card image" />
 
             <LinkBox.Raised>
               <IconButton shape="pill" aria-label="Like" className="bottom-md right-md !absolute">


### PR DESCRIPTION
### Description, Motivation and Context
The **link-box** accessibility test was timing out because `page.waitForLoadState('networkidle')` waits for all network activity to cease, but the test page was loading an image from `https://picsum.photos/200/200`.
This external request is slow, rate-limited, or blocked in CI environments (🤷) causing the test to consistently exceed the 30s timeout.

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [x] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
