### PR TITLE
fix(components): allow dual icons on chips

### DIFF
--- a/packages/components/src/chip/Chip.doc.mdx
+++ b/packages/components/src/chip/Chip.doc.mdx
@@ -134,6 +134,16 @@ When the chip has a `pressed` status configured it becomes a toggle button.
 
 <Canvas of={stories.SelectionIntent} />
 
+### Icon
+
+Chips can display icons to provide additional visual context using `Chip.LeadingIcon` and `Chip.TrailingIcon`.
+
+<Callout kind="info">
+  When a `Chip.ClearButton` is present, the `Chip.TrailingIcon` will not be displayed as the clear button takes priority in the trailing position.
+</Callout>
+
+<Canvas of={stories.Icons} />
+
 ### Disabled
 
 When a chip is `disabled`, no action is fired when clicking on it.

--- a/packages/components/src/chip/Chip.stories.tsx
+++ b/packages/components/src/chip/Chip.stories.tsx
@@ -435,6 +435,58 @@ export const AssistEvent: StoryFn = _args => {
   )
 }
 
+export const Icons: StoryFn = () => (
+  <div className="gap-lg flex flex-col">
+    <div className="gap-md flex flex-row">
+      <Chip>
+        <Chip.LeadingIcon>
+          <Icon label="calendar">
+            <CalendarOutline />
+          </Icon>
+        </Chip.LeadingIcon>
+        <Chip.Content>Leading icon</Chip.Content>
+      </Chip>
+      <Chip>
+        <Chip.Content>Trailing icon</Chip.Content>
+        <Chip.TrailingIcon>
+          <Icon label="eye">
+            <EyeOutline />
+          </Icon>
+        </Chip.TrailingIcon>
+      </Chip>
+      <Chip>
+        <Chip.LeadingIcon>
+          <Icon label="mail">
+            <MailOutline />
+          </Icon>
+        </Chip.LeadingIcon>
+        <Chip.Content>Both icons</Chip.Content>
+        <Chip.TrailingIcon>
+          <Icon label="check">
+            <Check />
+          </Icon>
+        </Chip.TrailingIcon>
+      </Chip>
+    </div>
+    <div className="gap-md flex flex-row">
+      <Chip onClear={() => console.log('clear')}>
+        <Chip.LeadingIcon>
+          <Icon label="account">
+            <AccountFill />
+          </Icon>
+        </Chip.LeadingIcon>
+        <Chip.Content>With clear button</Chip.Content>
+        <Chip.TrailingIcon>
+          <Icon label="eye">
+            <EyeOutline />
+          </Icon>
+        </Chip.TrailingIcon>
+        <Chip.ClearButton label="clear" />
+      </Chip>
+    </div>
+  </div>
+)
+
 export const Suggestion: StoryFn = () => {
   const [isBlurred, setIsBlurred] = useState<boolean>(false)
   const [content, setContent] = useState<string>('')

--- a/packages/components/src/chip/useChipElement.tsx
+++ b/packages/components/src/chip/useChipElement.tsx
@@ -111,7 +111,7 @@ export const useChipElement = ({
     <>
       {leadingIcon}
       {content}
-      {leadingIcon === undefined ? trailingIcon : null}
+      {clearButton === undefined ? trailingIcon : null}
       {clearButton}
     </>
   )


### PR DESCRIPTION
### Description, Motivation and Context

- fix: TrailingIcon was not visible when LeadingIcon was also used on a Chip.
- now the TrailingIcon is hidden only when the clearButton is rendered (it takes its spot)

### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles


### Screenshots - Animations

<img width="994" height="313" alt="Capture d’écran 2026-06-23 à 15 57 00" src="https://github.com/user-attachments/assets/bcb6c81d-eeb8-46b8-b55e-2fcfb3618ce0" />
