### PR TITLE
feat(components): button preset variants

### DIFF
--- a/packages/components/src/button/Button.appearance-styles.tsx
+++ b/packages/components/src/button/Button.appearance-styles.tsx
@@ -1,0 +1,130 @@
+import { makeVariants } from '@spark-ui/internal-utils'
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const buttonAppearanceStyles = cva(
+  [
+    'u-shadow-border-transition',
+    'box-border inline-flex items-center justify-center gap-md whitespace-nowrap',
+    'default:px-lg',
+    'rounded-button',
+    'text-body-1-highlight',
+    'focus-visible:u-outline',
+  ],
+  {
+    variants: {
+      /**
+       * Add underline to the button text.
+       */
+      underline: {
+        true: ['underline'],
+      },
+      /**
+       * Semantic appearance of the button that combines design and intent.
+       * When specified, this prop overrides both `design` and `intent`.
+       *
+       * - `primary`: Main action, filled background
+       * - `secondary`: Secondary action, filled support background
+       * - `tertiary`: Tertiary action, outlined with surface background
+       * - `contrast`: Contrast action, surface background
+       * - `ghost`: Link-style without background
+       * - `success`: Success action, outlined with transparent background
+       * - `danger`: Danger action, outlined with transparent background
+       * - `boost`: Accent action, filled accent background
+       * - `AI`: AI action, filled AI background
+       */
+      appearance: {
+        primary: [
+          'bg-main',
+          'text-on-main',
+          'rounded-button',
+          'enabled:hover:bg-main-hovered',
+          'enabled:active:bg-main-hovered',
+          'enabled:focus-visible:bg-main-hovered',
+        ],
+        secondary: [
+          'bg-support',
+          'text-on-support',
+          'rounded-button',
+          'enabled:hover:bg-support-hovered',
+          'enabled:active:bg-support-hovered',
+          'enabled:focus-visible:bg-support-hovered',
+        ],
+        tertiary: [
+          'border-outline',
+          'border-sm',
+          'bg-surface',
+          'text-on-surface',
+          'rounded-button',
+          'enabled:hover:bg-surface-hovered',
+          'enabled:active:bg-surface-hovered',
+          'enabled:focus-visible:bg-surface-hovered',
+        ],
+        contrast: [
+          'bg-surface',
+          'text-on-surface',
+          'rounded-button',
+          'enabled:hover:bg-surface-hovered',
+          'enabled:active:bg-surface-hovered',
+          'enabled:focus-visible:bg-surface-hovered',
+        ],
+        ghost: ['text-on-surface default:-mx-md px-md enabled:hover:bg-surface-hovered'],
+        success: [
+          'border-outline',
+          'border-sm',
+          'bg-transparent',
+          'text-success',
+          'rounded-button',
+          'enabled:hover:bg-success-container',
+          'enabled:active:bg-success-container',
+          'enabled:focus-visible:bg-success-container',
+        ],
+        danger: [
+          'border-outline',
+          'border-sm',
+          'bg-transparent',
+          'text-error',
+          'rounded-button',
+          'enabled:hover:bg-error-container',
+          'enabled:active:bg-error-container',
+          'enabled:focus-visible:bg-error-container',
+        ],
+        boost: [
+          'bg-accent',
+          'text-on-accent',
+          'rounded-button',
+          'enabled:hover:bg-accent-hovered',
+          'enabled:active:bg-accent-hovered',
+          'enabled:focus-visible:bg-accent-hovered',
+        ],
+        AI: [
+          'bg-ai',
+          'text-on-ai',
+          'rounded-button',
+          'enabled:hover:bg-ai-hovered',
+          'enabled:active:bg-ai-hovered',
+          'enabled:focus-visible:bg-ai-hovered',
+        ],
+      },
+      /**
+       * Size of the button.
+       */
+      size: makeVariants<'size', ['sm', 'md', 'lg']>({
+        sm: ['min-w-sz-32 h-sz-32'],
+        md: ['min-w-sz-44 h-sz-44'],
+        lg: ['min-w-sz-56 h-sz-56'],
+      }),
+      /**
+       * Disable the button, preventing user interaction and adding opacity.
+       */
+      disabled: {
+        true: ['cursor-not-allowed opacity-dim-3'],
+        false: ['cursor-pointer'],
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
+
+export type ButtonAppearanceStylesProps = VariantProps<typeof buttonAppearanceStyles>

--- a/packages/components/src/button/Button.doc.mdx
+++ b/packages/components/src/button/Button.doc.mdx
@@ -105,6 +105,34 @@ Use `aria-pressed` to transform the button into a toggle button.
 
 <Canvas of={ButtonStories.Toggle} />
 
+### Appearance (Experimental)
+
+<Callout kind="warning">
+  **Experimental API**: The `appearance` prop is currently in beta and should not be used in
+  production. The API may change in future versions. For production use, please use the `design` and
+  `intent` props instead.
+</Callout>
+
+Use the `appearance` prop to set semantic button styles that combine both design and intent.
+
+The appearance prop provides a simplified API for common button patterns:
+
+- `primary`: Main action with filled background
+- `secondary`: Secondary action with support color
+- `tertiary`: Tertiary action with outlined surface
+- `contrast`: Contrast action with surface background
+- `ghost`: Link-style without background
+- `success`: Success action with outlined style
+- `danger`: Danger action with outlined style
+- `boost`: Accent action with filled accent background
+- `AI`: AI action with filled AI background
+
+<Canvas of={ButtonStories.Appearance} />
+
+<Callout kind="info">
+  When using the `appearance` prop, both `design` and `intent` props are ignored.
+</Callout>
+
 ## Accessibility
 
 <A11yReport of="button" />

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -1,4 +1,5 @@
 import { Switch } from '@spark-ui/components/switch'
+import { Table } from '@spark-ui/components/table'
 import { Check } from '@spark-ui/icons/Check'
 import { FavoriteOutline } from '@spark-ui/icons/FavoriteOutline'
 import { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
@@ -34,6 +35,17 @@ const intents: ButtonProps['intent'][] = [
   'surfaceInverse',
 ]
 const designs: ButtonProps['design'][] = ['filled', 'outlined', 'tinted', 'contrast', 'ghost']
+const appearances: NonNullable<ButtonProps['appearance']>[] = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'contrast',
+  'ghost',
+  'success',
+  'danger',
+  'boost',
+  'AI',
+]
 
 export const Default: StoryObj = {
   render: _args => {
@@ -186,5 +198,59 @@ export const Toggle: StoryFn = () => {
         </Icon>
       )}
     </Button>
+  )
+}
+
+export const Appearance: StoryFn = _args => {
+  const [underline, setUnderline] = useState(false)
+
+  const appearanceRows = appearances.map((appearance, index) => ({
+    id: `appearance-${index}`,
+    appearance,
+  }))
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <Switch checked={underline} onClick={() => setUnderline(!underline)}>
+        Show underline
+      </Switch>
+      <Table>
+        <Table.Grid aria-label="Button appearance by state">
+          <Table.Header>
+            <Table.Column id="appearance" label="Appearance" isRowHeader />
+            <Table.Column id="base" label="Base" />
+            <Table.Column id="disabled" label="Disabled" />
+            <Table.Column id="loading" label="Loading" />
+          </Table.Header>
+          <Table.Body>
+            {appearanceRows.map(row => (
+              <Table.Row key={row.id} id={row.id}>
+                <Table.Cell>{row.appearance}</Table.Cell>
+                <Table.Cell className="bg-neutral-container">
+                  <Button appearance={row.appearance} underline={underline}>
+                    Click me
+                  </Button>
+                </Table.Cell>
+                <Table.Cell>
+                  <Button appearance={row.appearance} underline={underline} disabled>
+                    Click me
+                  </Button>
+                </Table.Cell>
+                <Table.Cell>
+                  <Button
+                    appearance={row.appearance}
+                    underline={underline}
+                    isLoading
+                    loadingLabel="Loading..."
+                  >
+                    Click me
+                  </Button>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Grid>
+      </Table>
+    </div>
   )
 }

--- a/packages/components/src/button/Button.test.tsx
+++ b/packages/components/src/button/Button.test.tsx
@@ -160,4 +160,55 @@ describe('Button', () => {
       expect(screen.getByRole('button', { name: 'Next' })).toHaveFocus()
     })
   })
+
+  describe('Appearance prop', () => {
+    it('should render with appearance prop', () => {
+      const props = {
+        ...defaultProps,
+        appearance: 'primary' as const,
+      }
+
+      render(<Button {...props} />)
+
+      expect(screen.getByRole('button', { name: props.children })).toBeInTheDocument()
+    })
+
+    it('should ignore design and intent when appearance is specified', () => {
+      const props = {
+        ...defaultProps,
+        appearance: 'primary' as const,
+        design: 'outlined' as const,
+        intent: 'success' as const,
+      }
+
+      render(<Button {...props} />)
+
+      const button = screen.getByRole('button', { name: props.children })
+      expect(button).toBeInTheDocument()
+      // The button should have primary appearance styles (bg-main text-on-main)
+      expect(button.className).toContain('bg-main')
+      expect(button.className).toContain('text-on-main')
+    })
+
+    it.each([
+      'primary',
+      'secondary',
+      'tertiary',
+      'contrast',
+      'ghost',
+      'success',
+      'danger',
+      'boost',
+      'AI',
+    ] as const)('should render %s appearance', appearance => {
+      const props = {
+        ...defaultProps,
+        appearance,
+      }
+
+      render(<Button {...props} />)
+
+      expect(screen.getByRole('button', { name: props.children })).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -3,10 +3,30 @@ import { ComponentPropsWithoutRef, type DOMAttributes, Ref, useMemo } from 'reac
 
 import { Slot, wrapPolymorphicSlot } from '../slot'
 import { Spinner, type SpinnerProps } from '../spinner'
+import {
+  buttonAppearanceStyles,
+  type ButtonAppearanceStylesProps,
+} from './Button.appearance-styles'
 import { buttonStyles, type ButtonStylesProps } from './Button.styles'
 
 export interface ButtonProps
-  extends Omit<ComponentPropsWithoutRef<'button'>, 'disabled'>, ButtonStylesProps {
+  extends
+    Omit<ComponentPropsWithoutRef<'button'>, 'disabled'>,
+    Omit<ButtonStylesProps, 'design' | 'intent'>,
+    Pick<ButtonAppearanceStylesProps, 'appearance'> {
+  /**
+   * Main style of the button.
+   */
+  design?: ButtonStylesProps['design']
+  /**
+   * Color scheme of the button.
+   */
+  intent?: ButtonStylesProps['intent']
+  /**
+   * Combined appearance preset (replaces `design` and `intent`).
+   * @beta This API is in beta and may change in future versions.
+   */
+  appearance?: ButtonAppearanceStylesProps['appearance']
   /**
    * Change the component to the HTML tag or custom component of the only child.
    */
@@ -69,6 +89,7 @@ export const Button = ({
   asChild,
   className,
   underline = false,
+  appearance,
   ref,
   ...others
 }: ButtonProps) => {
@@ -103,12 +124,16 @@ export const Button = ({
     ...(loadingLabel && { 'aria-label': loadingLabel }),
   }
 
-  return (
-    <Component
-      data-spark-component="button"
-      {...(Component === 'button' && { type: 'button' })}
-      ref={ref}
-      className={buttonStyles({
+  // Use appearance styles when appearance is specified, otherwise use legacy styles
+  const buttonClassName = appearance
+    ? buttonAppearanceStyles({
+        className,
+        appearance,
+        disabled: shouldNotInteract,
+        size,
+        underline,
+      })
+    : buttonStyles({
         className,
         design,
         disabled: shouldNotInteract,
@@ -116,7 +141,14 @@ export const Button = ({
         shape,
         size,
         underline,
-      })}
+      })
+
+  return (
+    <Component
+      data-spark-component="button"
+      {...(Component === 'button' && { type: 'button' })}
+      ref={ref}
+      className={buttonClassName}
       disabled={useNativeDisabled}
       aria-disabled={shouldNotInteract ? true : undefined}
       aria-busy={isLoading}

--- a/packages/components/src/icon-button/IconButton.doc.mdx
+++ b/packages/components/src/icon-button/IconButton.doc.mdx
@@ -90,6 +90,34 @@ Use `aria-pressed` to transform the button into a toggle button.
 
 <Canvas of={stories.Toggle} />
 
+### Appearance (Experimental)
+
+<Callout kind="warning">
+  **Experimental API**: The `appearance` prop is currently in beta and should not be used in
+  production. The API may change in future versions. For production use, please use the `design` and
+  `intent` props instead.
+</Callout>
+
+Use the `appearance` prop to set semantic button styles that combine both design and intent.
+
+The appearance prop provides a simplified API for common button patterns:
+
+- `primary`: Main action with filled background
+- `secondary`: Secondary action with support color
+- `tertiary`: Tertiary action with outlined surface
+- `contrast`: Contrast action with surface background
+- `ghost`: Link-style without background
+- `success`: Success action with outlined style
+- `danger`: Danger action with outlined style
+- `boost`: Accent action with filled accent background
+- `AI`: AI action with filled AI background
+
+<Canvas of={stories.Appearance} />
+
+<Callout kind="info">
+  When using the `appearance` prop, both `design` and `intent` props are ignored.
+</Callout>
+
 ## Accessibility
 
 <A11yReport of="icon-button" />

--- a/packages/components/src/icon-button/IconButton.stories.tsx
+++ b/packages/components/src/icon-button/IconButton.stories.tsx
@@ -1,3 +1,5 @@
+import { Switch } from '@spark-ui/components/switch'
+import { Table } from '@spark-ui/components/table'
 import { Tag } from '@spark-ui/components/tag'
 import { LikeFill } from '@spark-ui/icons/LikeFill'
 import { LikeOutline } from '@spark-ui/icons/LikeOutline'
@@ -31,6 +33,17 @@ const intents: IconButtonProps['intent'][] = [
   'surface',
 ]
 const designs: IconButtonProps['design'][] = ['filled', 'outlined', 'tinted', 'contrast', 'ghost']
+const appearances: NonNullable<IconButtonProps['appearance']>[] = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'contrast',
+  'ghost',
+  'success',
+  'danger',
+  'boost',
+  'AI',
+]
 
 const icon = (
   <Icon>
@@ -144,5 +157,69 @@ export const Toggle: StoryFn = () => {
     >
       <Icon>{pressed ? <LikeFill /> : <LikeOutline />}</Icon>
     </IconButton>
+  )
+}
+
+export const Appearance: StoryFn = _args => {
+  const [underline, setUnderline] = useState(false)
+
+  const appearanceRows = appearances.map((appearance, index) => ({
+    id: `appearance-${index}`,
+    appearance,
+  }))
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <Switch checked={underline} onClick={() => setUnderline(!underline)}>
+        Show underline
+      </Switch>
+      <Table>
+        <Table.Grid aria-label="IconButton appearance by state">
+          <Table.Header>
+            <Table.Column id="appearance" label="Appearance" isRowHeader />
+            <Table.Column id="base" label="Base" />
+            <Table.Column id="disabled" label="Disabled" />
+            <Table.Column id="loading" label="Loading" />
+          </Table.Header>
+          <Table.Body>
+            {appearanceRows.map(row => (
+              <Table.Row key={row.id} id={row.id}>
+                <Table.Cell>{row.appearance}</Table.Cell>
+                <Table.Cell className="bg-neutral-container">
+                  <IconButton
+                    appearance={row.appearance}
+                    underline={underline}
+                    aria-label={`${row.appearance} button`}
+                  >
+                    {icon}
+                  </IconButton>
+                </Table.Cell>
+                <Table.Cell>
+                  <IconButton
+                    appearance={row.appearance}
+                    underline={underline}
+                    disabled
+                    aria-label={`${row.appearance} disabled button`}
+                  >
+                    {icon}
+                  </IconButton>
+                </Table.Cell>
+                <Table.Cell>
+                  <IconButton
+                    appearance={row.appearance}
+                    underline={underline}
+                    isLoading
+                    loadingLabel="Loading..."
+                    aria-label={`${row.appearance} loading button`}
+                  >
+                    {icon}
+                  </IconButton>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Grid>
+      </Table>
+    </div>
   )
 }

--- a/packages/components/src/icon-button/IconButton.tsx
+++ b/packages/components/src/icon-button/IconButton.tsx
@@ -12,6 +12,7 @@ export interface IconButtonProps extends Omit<ButtonProps, 'loadingText'> {
  * A button component that contains only an icon without text label.
  */
 export const IconButton = ({
+  appearance,
   design = 'filled',
   disabled = false,
   intent = 'main',
@@ -26,6 +27,7 @@ export const IconButton = ({
       data-spark-component="icon-button"
       ref={ref}
       className={iconButtonStyles({ size, className })}
+      appearance={appearance}
       design={design}
       disabled={disabled}
       intent={intent}

--- a/packages/components/src/table/internal/TableBodyCellRenderer.tsx
+++ b/packages/components/src/table/internal/TableBodyCellRenderer.tsx
@@ -2,6 +2,7 @@ import { useTableSelectionCheckbox } from '@react-aria/table'
 import type { TableState } from '@react-stately/table'
 import type { GridNode } from '@react-types/grid'
 import type { Key } from '@react-types/shared'
+import { cx } from 'class-variance-authority'
 import { useCallback, useContext, useRef, type KeyboardEvent } from 'react'
 import { mergeProps, useFocusRing, useTableCell } from 'react-aria'
 
@@ -20,7 +21,7 @@ export function TableBodyCellRenderer({
 }) {
   const ref = useRef<HTMLTableCellElement>(null)
   const { gridCellProps } = useTableCell({ node: cell }, state, ref)
-  const { isFocusVisible, focusProps } = useFocusRing()
+  const { isFocusVisible, focusProps } = useFocusRing({ within: true })
   const keyboardMode = useContext(TableKeyboardModeContext)
 
   const stopRowKeyboardSelectionInInteractionMode = useCallback(
@@ -53,6 +54,7 @@ export function TableBodyCellRenderer({
   const selectionCheckbox = useTableSelectionCheckbox({ key: rowKey }, state)
   const columnKey = (state.collection.columns[cell.index ?? 0]?.key ?? null) as Key | null
   const columnWidth = columnKey ? resizeState?.columnWidths?.get?.(columnKey) : undefined
+  const customClassName = (cell.props as any)?.className
 
   if ((cell.props as any)?.isSelectionCell) {
     return (
@@ -87,7 +89,7 @@ export function TableBodyCellRenderer({
       )}
       ref={ref}
       data-spark-component="table-cell"
-      className={cellStyles()}
+      className={cx(cellStyles(), customClassName)}
       data-focus-visible={isFocusVisible || undefined}
       style={columnWidth ? { width: columnWidth } : undefined}
     >


### PR DESCRIPTION
### Description, Motivation and Context

Introducing `variant` prop on `Button` to replace complex combinations of `design + intent` props.

The goal is to reduce and simply using buttons in the future.

WARNING: the prop is still experimental, it will properly replace design/intent in a futur breaking change months away from now.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

<img width="1499" height="819" alt="Capture d’écran 2026-07-08 à 11 28 52" src="https://github.com/user-attachments/assets/6ee0667d-083a-4409-a0a7-621480485411" />

