### PR TITLE
ci: simplified dependabots updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    open-pull-requests-limit: 10
     schedule:
       interval: 'weekly'
     commit-message:
@@ -32,27 +33,3 @@ updates:
           - 'vite'
           - '@vitejs/*'
           - '*vite*'
-      dependencies:
-        patterns:
-          - '*'
-        exclude-patterns:
-          - '@zag-js/*'
-          - '@react-aria/*'
-          - '@react-stately/*'
-          - '@testing-library/*'
-          - '@testing-library'
-          - 'vitest'
-          - '@vitest/*'
-          - '@vitest'
-          - '@playwright/*'
-          - '@playwright'
-          - '@storybook/*'
-          - '*storybook*'
-          - 'vite'
-          - '@vitejs/*'
-          - '*vite*'
-        update-types: ['minor', 'patch']
-      major:
-        patterns:
-          - '*'
-        update-types: ['major']


### PR DESCRIPTION
### Description, Motivation and Context

- added 10 PRs limitation
- no longer group major updates in a single PR
- no longer group minor/patch updates of smaller dependencies in a single PR

### Types of changes
- [x] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
