### PR TITLE
fix(cli-utils): sync chromatic version with gha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "babel-loader": "10.0.0",
         "browserslist-to-esbuild": "2.1.1",
         "chalk": "5.6.2",
-        "chromatic": "^16.2.0",
+        "chromatic": "^18.0.1",
         "class-variance-authority": "0.7.1",
         "commitizen": "4.3.1",
         "concurrently": "10.0.3",
@@ -12425,19 +12425,26 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.2.0.tgz",
-      "integrity": "sha512-yFUC0iCumsw5JDQPmrNAgYuln25HRh79iGdJgm+dj87lv7kFatlRBgRcw8Kmzdw1si3qzGlzu36aCABS7Wg5aQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-18.0.1.tgz",
+      "integrity": "sha512-GlTYrZ4ui5ZW8Jzut6SAo5bMH3sIugYZ37Nq2DyVHBfPINeEzGA8eG5xNo4N/I2aRdM9Xnqw0SCls7wgf2llvA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
+        "chroma": "dist/bin.cjs",
+        "chromatic": "dist/bin.cjs",
+        "chromatic-cli": "dist/bin.cjs"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
       },
       "peerDependenciesMeta": {
         "@chromatic-com/cypress": {
@@ -12445,7 +12452,23 @@
         },
         "@chromatic-com/playwright": {
           "optional": true
+        },
+        "@chromatic-com/vitest": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/chromatic/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/class-variance-authority": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "babel-loader": "10.0.0",
     "browserslist-to-esbuild": "2.1.1",
     "chalk": "5.6.2",
-    "chromatic": "^16.2.0",
+    "chromatic": "^18.0.1",
     "class-variance-authority": "0.7.1",
     "commitizen": "4.3.1",
     "concurrently": "10.0.3",


### PR DESCRIPTION
### Description, Motivation and Context

Local version of Chromatic (16) was conflicting with GHA version (latest = 18) breaking some GraphQL request and prevent Chromatic from deploying the Storybook instance.

### Types of changes
- [x] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

