### PR TITLE
style(components): fixed chip padding to match new rounded shape

### DIFF
--- a/packages/components/src/chip/ChipClearButton.styles.tsx
+++ b/packages/components/src/chip/ChipClearButton.styles.tsx
@@ -10,8 +10,8 @@ export const chipClearButtonWrapperStyles = cva(
         true: ['cursor-not-allowed'],
       },
       isBordered: {
-        false: ['pr-md'],
-        true: ['pr-[7px]'],
+        false: ['pr-lg'],
+        true: ['pr-[calc(var(--spacing-lg)-var(--border-width-sm))]'],
       },
       design: {
         outlined: [],

--- a/packages/components/src/chip/variants/dashed.ts
+++ b/packages/components/src/chip/variants/dashed.ts
@@ -105,11 +105,11 @@ export const dashedVariants = [
   {
     design: 'dashed',
     hasClearButton: false,
-    class: tw(['px-[calc(var(--spacing-md)-var(--border-width-sm))]']),
+    class: tw(['px-[calc(var(--spacing-lg)-var(--border-width-sm))]']),
   },
   {
     design: 'dashed',
     hasClearButton: true,
-    class: tw(['pl-[calc(var(--spacing-md)-var(--border-width-sm))]']),
+    class: tw(['pl-[calc(var(--spacing-lg)-var(--border-width-sm))]']),
   },
 ] as const

--- a/packages/components/src/chip/variants/outlined.ts
+++ b/packages/components/src/chip/variants/outlined.ts
@@ -106,11 +106,11 @@ export const outlinedVariants = [
   {
     design: 'outlined',
     hasClearButton: false,
-    class: tw(['px-[calc(var(--spacing-md)-var(--border-width-sm))]']),
+    class: tw(['px-[calc(var(--spacing-lg)-var(--border-width-sm))]']),
   },
   {
     design: 'outlined',
     hasClearButton: true,
-    class: tw(['pl-[calc(var(--spacing-md)-var(--border-width-sm))]']),
+    class: tw(['pl-[calc(var(--spacing-lg)-var(--border-width-sm))]']),
   },
 ] as const

--- a/packages/components/src/chip/variants/tinted.ts
+++ b/packages/components/src/chip/variants/tinted.ts
@@ -114,11 +114,11 @@ export const tintedVariants = [
   {
     design: 'tinted',
     hasClearButton: false,
-    class: tw(['px-md']),
+    class: tw(['px-lg']),
   },
   {
     design: 'tinted',
     hasClearButton: true,
-    class: tw(['pl-md']),
+    class: tw(['pl-lg']),
   },
 ] as const


### PR DESCRIPTION
### Description, Motivation and Context

- Recent update of the `Chip` made it fully rounded. In consequence, the horizontal padding look a bit too small.
- Updating the horizontal padding from `md` to `lg`.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

BEFORE:
<img width="1024" height="212" alt="Capture d’écran 2026-07-16 à 10 28 11" src="https://github.com/user-attachments/assets/83104fc3-e1af-4483-a951-7d30db433d56" />



AFTER:
<img width="1017" height="202" alt="Capture d’écran 2026-07-16 à 10 28 22" src="https://github.com/user-attachments/assets/66845363-c73d-49aa-be8a-46bc2d78ed52" />
