### PR TITLE
refactor(components): removed intent from switch and updated unchecke…

### DIFF
--- a/e2e/a11y/pages/Switch.tsx
+++ b/e2e/a11y/pages/Switch.tsx
@@ -4,11 +4,11 @@ import React from 'react'
 export const A11ySwitch = () => (
   <section>
     <div>
-      <Switch intent="main">Agreed</Switch>
+      <Switch>Agreed</Switch>
     </div>
 
     <div>
-      <Switch intent="main" aria-label="Agreed again" defaultChecked />
+      <Switch aria-label="Agreed again" defaultChecked />
     </div>
   </section>
 )

--- a/packages/components/src/switch/Switch.stories.tsx
+++ b/packages/components/src/switch/Switch.stories.tsx
@@ -6,6 +6,7 @@ import { type ComponentProps, useState } from 'react'
 
 import { Switch } from '.'
 import { FormField } from '../form-field'
+import { Table } from '../table'
 
 const meta: Meta<typeof Switch> = {
   title: 'Components/Switch',
@@ -37,15 +38,39 @@ export const Icons: StoryFn = _args => (
   </Switch>
 )
 
-export const Disabled: StoryFn = _args => (
-  <div className="gap-lg flex">
-    <Switch disabled>Agreed</Switch>
+export const Disabled: StoryFn = _args => {
+  const rows = [
+    { id: 'enabled', label: 'Enabled', disabled: false },
+    { id: 'disabled', label: 'Disabled', disabled: true },
+  ]
 
-    <Switch defaultChecked disabled>
-      Agreed
-    </Switch>
-  </div>
-)
+  return (
+    <Table>
+      <Table.Grid aria-label="Switch states">
+        <Table.Header>
+          <Table.Column id="state" label="State" isRowHeader />
+          <Table.Column id="unchecked" label="Unchecked" />
+          <Table.Column id="checked" label="Checked" />
+        </Table.Header>
+        <Table.Body>
+          {rows.map(row => (
+            <Table.Row key={row.id} id={row.id}>
+              <Table.Cell>{row.label}</Table.Cell>
+              <Table.Cell>
+                <Switch disabled={row.disabled}>Agreed</Switch>
+              </Table.Cell>
+              <Table.Cell>
+                <Switch defaultChecked disabled={row.disabled}>
+                  Agreed
+                </Switch>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Grid>
+    </Table>
+  )
+}
 
 const sizes: ComponentProps<typeof Switch>['size'][] = ['sm', 'md']
 

--- a/packages/components/src/switch/SwitchInput.styles.ts
+++ b/packages/components/src/switch/SwitchInput.styles.ts
@@ -4,15 +4,16 @@ import { cva, VariantProps } from 'class-variance-authority'
 export const styles = cva(
   tw([
     'relative shrink-0 self-baseline',
-    'cursor-pointer',
+    'cursor-pointer aria-disabled:cursor-not-allowed',
     'rounded-full border-transparent',
     'hover:ring-4',
     'transition-colors duration-200 ease-in-out',
-    'disabled:hover:ring-transparent disabled:cursor-not-allowed disabled:opacity-dim-3',
+    'aria-disabled:opacity-dim-3',
     'focus-visible:u-outline',
-    'data-unchecked:bg-on-surface/dim-3',
+    'text-support bg-support data-unchecked:bg-neutral/dim-3',
     'u-shadow-border-transition',
     'overflow-x-hidden',
+    'hover:ring-support-container aria-disabled:hover:ring-transparent ',
   ]),
   {
     variants: {
@@ -23,25 +24,8 @@ export const styles = cva(
         sm: tw(['h-sz-24', 'w-sz-40', 'border-md']),
         md: tw(['h-sz-32', 'w-sz-56', 'border-[4px]']),
       }),
-      /**
-       * Color scheme of the switch input.
-       */
-      intent: makeVariants<
-        'intent',
-        ['main', 'support', 'accent', 'success', 'alert', 'error', 'info', 'neutral']
-      >({
-        main: ['[&[data-checked]]:bg-main', 'hover:ring-main-container', 'text-main'],
-        support: ['[&[data-checked]]:bg-support', 'hover:ring-support-container', 'text-support'],
-        accent: ['[&[data-checked]]:bg-accent', 'hover:ring-accent-container', 'text-accent'],
-        success: ['[&[data-checked]]:bg-success', 'hover:ring-success-container', 'text-success'],
-        alert: ['[&[data-checked]]:bg-alert', 'hover:ring-alert-container', 'text-alert'],
-        error: ['[&[data-checked]]:bg-error', 'hover:ring-error-container', 'text-error'],
-        info: ['[&[data-checked]]:bg-info', 'hover:ring-info-container', 'text-info'],
-        neutral: ['[&[data-checked]]:bg-neutral', 'hover:ring-neutral-container', 'text-neutral'],
-      }),
     },
     defaultVariants: {
-      intent: 'support',
       size: 'sm',
     },
   }

--- a/packages/components/src/switch/SwitchInput.tsx
+++ b/packages/components/src/switch/SwitchInput.tsx
@@ -69,7 +69,6 @@ export const SwitchInput = ({
   checked,
   checkedIcon = <Check />,
   defaultChecked,
-  intent: intentProp,
   uncheckedIcon = <Close />,
   size = 'md',
   onCheckedChange,
@@ -80,8 +79,7 @@ export const SwitchInput = ({
   ...rest
 }: SwitchInputProps) => {
   const [isChecked, setIsChecked] = useCombinedState(checked, defaultChecked)
-  const { name, description, state, isRequired, isInvalid } = useFormFieldControl()
-  const intent = state ?? intentProp
+  const { name, description, isRequired, isInvalid } = useFormFieldControl()
   const renderSlot = useRenderSlot(asChild, 'span')
   const isRequiredComputed = Boolean(required || isRequired)
 
@@ -95,7 +93,7 @@ export const SwitchInput = ({
       data-spark-component="switch-input"
       ref={ref}
       render={renderSlot}
-      className={styles({ intent, size, className })}
+      className={styles({ size, className })}
       checked={checked}
       defaultChecked={defaultChecked}
       onCheckedChange={nextChecked => handleCheckedChange(nextChecked)}


### PR DESCRIPTION
…d styles

BREAKING CHANGE: To consumers: please remove the intent prop from any instance of the Switch
component. Note: it still support error messages from the FormField

### Description, Motivation and Context

- `intent` prop deleted. The Switch now has a single design.
- `unchecked` state now uses `neutral` color instead of `support`, to reduce the visual hierarchy of unchecked switches.


### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [x] 🧠 Refactor
- [x] 💄 Styles


### Screenshots - Animations

<img width="779" height="234" alt="Capture d’écran 2026-07-22 à 11 08 23" src="https://github.com/user-attachments/assets/9966f68e-c50c-4a97-a67f-fd1940564c5d" />
