### PR TITLE
style(components): outlined cards with a Card.Type banner now has thi…

### DIFF
--- a/packages/components/src/card/Card.styles.tsx
+++ b/packages/components/src/card/Card.styles.tsx
@@ -9,7 +9,7 @@ export const cardStyles = cva(
   {
     variants: {
       design: {
-        outlined: ['border-sm'],
+        outlined: [],
         tinted: [],
       },
       /**
@@ -29,6 +29,10 @@ export const cardStyles = cva(
         neutral: [],
         surface: [],
       }),
+      hasType: {
+        true: [],
+        false: [],
+      },
     },
     compoundVariants: [
       // OUTLINED
@@ -41,6 +45,10 @@ export const cardStyles = cva(
       { intent: 'info', design: 'outlined', class: tw(['border-info']) },
       { intent: 'neutral', design: 'outlined', class: tw(['border-neutral']) },
       { intent: 'surface', design: 'outlined', class: tw(['border-outline']) },
+      // OUTLINED + TYPE
+      { design: 'outlined', hasType: true, class: tw(['border-md']) },
+      // OUTLINED + NO TYPE
+      { design: 'outlined', hasType: false, class: tw(['border-sm']) },
     ],
     defaultVariants: {
       design: 'outlined',

--- a/packages/components/src/card/Card.tsx
+++ b/packages/components/src/card/Card.tsx
@@ -48,6 +48,7 @@ export const Card = ({
           className,
           design,
           intent,
+          hasType: typeDetected,
         })}
         {...props}
       >

--- a/packages/components/src/card/Type.tsx
+++ b/packages/components/src/card/Type.tsx
@@ -32,13 +32,26 @@ export const typeStyles = cva(
         surface: ['bg-surface-inverse text-on-surface-inverse'],
       },
       design: {
-        outlined: ['-mx-px -mt-px'], // Fix border-radius visual gap by overlapping parent border
+        outlined: [], // Margins handled via compoundVariants to account for border width
         tinted: [],
       },
+      hasMediumBorder: {
+        true: [],
+        false: [],
+      },
     },
+    compoundVariants: [
+      { design: 'outlined', hasMediumBorder: false, class: '-mx-px -mt-px' },
+      {
+        design: 'outlined',
+        hasMediumBorder: true,
+        class: '-mx-(--border-width-md) -mt-(--border-width-md)',
+      },
+    ],
     defaultVariants: {
       intent: 'main',
       design: 'outlined',
+      hasMediumBorder: false,
     },
   }
 )
@@ -58,6 +71,9 @@ export const Type = ({ intent, children, ...props }: TypeProps) => {
   // Use intent from props if provided, otherwise inherit from parent Card context
   const resolvedIntent = intent ?? cardContext.intent ?? 'main'
 
+  // Card with outlined design and hasType=true uses border-md (2px), so Type needs -2px margins
+  const hasMediumBorder = cardContext.design === 'outlined' && cardContext.hasType
+
   // Don't render if no children provided (for backward compatibility with Backdrop)
   if (!children) {
     return null
@@ -65,7 +81,11 @@ export const Type = ({ intent, children, ...props }: TypeProps) => {
 
   return (
     <header
-      className={typeStyles({ intent: resolvedIntent, design: cardContext.design })}
+      className={typeStyles({
+        intent: resolvedIntent,
+        design: cardContext.design,
+        hasMediumBorder,
+      })}
       {...props}
     >
       {children}


### PR DESCRIPTION
…cker border-width

### Description, Motivation and Context

- `Card` with `design="outlined"` now has a stronger border when using `Card.Type` (header-like item inside the card)

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations

<img width="577" height="486" alt="Capture d’écran 2026-07-23 à 15 07 43" src="https://github.com/user-attachments/assets/643ba1d8-08b6-4aaf-9a40-e19d022f9382" />
