### PR TITLE
feat(components): expose onBlur prop on Select

### DIFF
--- a/packages/components/src/select/Select.test.tsx
+++ b/packages/components/src/select/Select.test.tsx
@@ -348,4 +348,60 @@ describe('Select', () => {
       expect(onValueChangeSpy).not.toHaveBeenCalled()
     })
   })
+
+  describe('onBlur', () => {
+    beforeEach(vi.clearAllMocks)
+
+    const onBlurSpy = vi.fn()
+
+    const Implementation = () => (
+      <Select onBlur={onBlurSpy}>
+        <Select.Trigger aria-label="Book">
+          <Select.Value placeholder="Pick a book" />
+        </Select.Trigger>
+
+        <Select.Items>
+          <Select.Placeholder>--Pick a book--</Select.Placeholder>
+          <Select.Item value="book-1">War and Peace</Select.Item>
+          <Select.Item value="book-2">1984</Select.Item>
+        </Select.Items>
+      </Select>
+    )
+
+    it('should call the onBlur prop when the select loses focus', async () => {
+      const user = userEvent.setup()
+
+      render(<Implementation />)
+
+      await user.click(getSelect('Book'))
+      expect(onBlurSpy).not.toHaveBeenCalled()
+
+      await user.tab()
+      expect(onBlurSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should let Select.Items directly override the onBlur handler from Select', async () => {
+      const user = userEvent.setup()
+      const itemsOnBlurSpy = vi.fn()
+
+      render(
+        <Select onBlur={onBlurSpy}>
+          <Select.Trigger aria-label="Book">
+            <Select.Value placeholder="Pick a book" />
+          </Select.Trigger>
+
+          <Select.Items onBlur={itemsOnBlurSpy}>
+            <Select.Placeholder>--Pick a book--</Select.Placeholder>
+            <Select.Item value="book-1">War and Peace</Select.Item>
+          </Select.Items>
+        </Select>
+      )
+
+      await user.click(getSelect('Book'))
+      await user.tab()
+
+      expect(itemsOnBlurSpy).toHaveBeenCalledTimes(1)
+      expect(onBlurSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/components/src/select/SelectContext.tsx
+++ b/packages/components/src/select/SelectContext.tsx
@@ -3,6 +3,7 @@ import { useCombinedState } from '@spark-ui/hooks/use-combined-state'
 import {
   createContext,
   Dispatch,
+  FocusEventHandler,
   PropsWithChildren,
   ReactElement,
   SetStateAction,
@@ -25,6 +26,7 @@ export interface SelectContextState {
   setValue: (value: string) => void
   isControlled: boolean
   onValueChange?: (value: string) => void
+  onBlur?: FocusEventHandler<HTMLSelectElement>
   ariaLabel: string | undefined
   setAriaLabel: Dispatch<SetStateAction<string | undefined>>
   fieldId: string
@@ -60,6 +62,12 @@ export type SelectContextProps = PropsWithChildren<{
    * Event handler called when the value changes.
    */
   onValueChange?: (value: string) => void
+  /**
+   * Event handler called when the select loses focus. Useful for integrating with form
+   * libraries (e.g. React Hook Form, TanStack Form) that rely on `onBlur` to mark fields as
+   * touched and trigger validation.
+   */
+  onBlur?: FocusEventHandler<HTMLSelectElement>
 
   itemsComponent: ReactElement | undefined
   /**
@@ -82,6 +90,7 @@ export const SelectProvider = ({
   defaultValue,
   value: valueProp,
   onValueChange,
+  onBlur,
   disabled: disabledProp = false,
   readOnly: readOnlyProp = false,
   state: stateProp,
@@ -153,6 +162,7 @@ export const SelectProvider = ({
         setValue,
         isControlled,
         onValueChange,
+        onBlur,
         ariaLabel,
         setAriaLabel,
         fieldId,

--- a/packages/components/src/select/SelectItems.tsx
+++ b/packages/components/src/select/SelectItems.tsx
@@ -53,6 +53,7 @@ export const Items = ({
     fieldLabelId,
     isControlled,
     onValueChange,
+    onBlur,
     selectedItem,
     setValue,
     name,
@@ -81,6 +82,7 @@ export const Items = ({
       className={styles({ className, state, disabled, readOnly })}
       value={selectedItem?.value}
       onChange={handleChange}
+      onBlur={onBlur}
       id={fieldId}
       {...rest}
     >


### PR DESCRIPTION
Closes #2792

## Summary

`Select` exposes `onValueChange` but not `onBlur`. Form libraries (React Hook Form, TanStack Form, etc.) rely on `onBlur` at the field's boundary to mark it as touched and trigger validation. Today the only way to get it is by reaching into the subcomponent:

```tsx
<Select onValueChange={field.onChange}>
  ...
  <Select.Items onBlur={field.onBlur} />
</Select>
```

This PR adds `onBlur` to `Select` itself, threaded through `SelectContext` down to the native `<select>` rendered by `Select.Items`:

```tsx
<Select onValueChange={field.onChange} onBlur={field.onBlur}>
  ...
  <Select.Items />
</Select>
```

## Backward compatibility

Passing `onBlur` directly to `Select.Items` still works and takes precedence over the context value (mirrors how `disabled`/`name`/`required` already flow from context but stay overridable via `{...rest}`), so the existing workaround from the issue keeps working unchanged.

## Changes

- `SelectContext.tsx`: add `onBlur` to `SelectContextProps`/`SelectContextState`, pass it through the provider
- `SelectItems.tsx`: read `onBlur` from context and apply it to the native `<select>`, before the `{...rest}` spread
- `Select.test.tsx`: two new tests — `onBlur` fires once when the select loses focus, and a directly-passed `Select.Items` `onBlur` still overrides the root-level one

## Testing

- `npx vitest run packages/components/src/select/Select.test.tsx` — 13/13 passing
- `npm run typecheck` (tsgo) on `packages/components` — clean
- `npm run lint` / `npm run format:check` — no new warnings introduced (pre-existing `exhaustive-deps` warnings in this directory are unrelated to this change)

---

**Agent:** Claude Code